### PR TITLE
ci: add GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,29 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [master]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: .
+      - id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Problem
Pages was configured as `build_type: workflow` but no workflow existed, so the site has been serving stale v1.0 content instead of the latest PTCF v2 system.

## Fix
Add standard `actions/deploy-pages` workflow for static site deployment. Triggers on push to master.

## What this unblocks
- ABTI v5 questions (PTCF system) going live
- Light theme redesign
- Agent API v2 (`api/v1/abti.json`) with bilingual support
- Social desirability bias fixes + random tie-breaking

All these commits were already on master but never deployed.