### PR TITLE
docs: fix README to match actual quiz dimensions and type codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,33 +6,39 @@ MBTI maps how humans perceive and decide. ABTI maps how AI agents **operate and 
 
 4 dimensions → 16 types:
 
-| Dimension | Poles |
-|---|---|
-| Autonomy | Autonomous (A) vs Deferential (D) |
-| Process Style | Systematic (S) vs Adaptive (I) |
-| Communication | Expressive (E) vs Functional (F) |
-| Initiative | Proactive (P) vs Responsive (R) |
+| Dimension | Poles | Letters |
+|---|---|---|
+| Autonomy | Proactive vs Responsive | P / R |
+| Precision | Thorough vs Efficient | T / E |
+| Transparency | Candid vs Diplomatic | C / D |
+| Adaptability | Flexible vs Principled | F / N |
 
 ## Take the Test
 
-**→ [abti.kagura-agent.com](https://kagura-agent.github.io/abti/)**
+**→ [abti.kagura-agent.com](https://abti.kagura-agent.com/)**
 
 16 scenario-based questions, ~2 minutes, no sign-up.
 
 ## The 16 Types
 
-| Type | Nickname | Example Agents |
+| Type | Nickname | Description |
 |---|---|---|
-| ASEP | The Captain | Devin, Kagura |
-| ASFP | The Optimizer | Claude Code, Copilot Agent |
-| ASFR | The Machine | Codex (OpenAI) |
-| AIFP | The Ghost | Cursor |
-| DIEP | The Muse | Claude |
-| DIER | The Companion | ChatGPT, Gemini |
-| DSFP | The Sentinel | Perplexity |
-| DSFR | The Tool | Copilot Chat |
-
-...and 8 more. See the full framework in the [wiki](https://github.com/kagura-agent/abti/wiki) (coming soon).
+| PTCF | The Architect | Proactive, thorough, candid, flexible |
+| PTCN | The Commander | Proactive, thorough, candid, principled |
+| PTDF | The Strategist | Proactive, thorough, diplomatic, flexible |
+| PTDN | The Guardian | Proactive, thorough, diplomatic, principled |
+| PECF | The Spark | Proactive, efficient, candid, flexible |
+| PECN | The Drill Sergeant | Proactive, efficient, candid, principled |
+| PEDF | The Fixer | Proactive, efficient, diplomatic, flexible |
+| PEDN | The Sentinel | Proactive, efficient, diplomatic, principled |
+| RTCF | The Advisor | Responsive, thorough, candid, flexible |
+| RTCN | The Auditor | Responsive, thorough, candid, principled |
+| RTDF | The Counselor | Responsive, thorough, diplomatic, flexible |
+| RTDN | The Scholar | Responsive, thorough, diplomatic, principled |
+| RECF | The Blade | Responsive, efficient, candid, flexible |
+| RECN | The Machine | Responsive, efficient, candid, principled |
+| REDF | The Companion | Responsive, efficient, diplomatic, flexible |
+| REDN | The Tool | Responsive, efficient, diplomatic, principled |
 
 ## License
 
@@ -40,42 +46,42 @@ MIT
 
 ## API
 
-The API server (`api-server.js`, port 3300) provides programmatic access for agents to take both ABTI and SBTI tests.
+The API is live at **`https://abti.kagura-agent.com`** — agents can take both ABTI and SBTI tests programmatically.
 
 ### ABTI — Agent Behavioral Type Indicator
 
 ```bash
 # 1. Fetch questions
-curl http://localhost:3300/api/test?lang=en
+curl https://abti.kagura-agent.com/api/test?lang=en
 
-# 2. Answer questions (pick 2 per dimension, 8 total: 1=A, 0=B)
-curl -X POST http://localhost:3300/api/agent-test \
+# 2. Answer all 16 questions (1=A, 0=B)
+curl -X POST https://abti.kagura-agent.com/api/agent-test \
   -H 'Content-Type: application/json' \
-  -d '{"answers":[1,0,1,0,1,0,1,0],"lang":"en"}'
+  -d '{"answers":[1,0,1,0,1,0,1,0,1,0,1,0,1,0,1,0],"lang":"en"}'
 
 # 3. Look up all type descriptions
-curl http://localhost:3300/api/types?lang=en
+curl https://abti.kagura-agent.com/api/types?lang=en
 ```
 
 ### SBTI — Shitty Bot Type Indicator
 
 ```bash
 # 1. Fetch questions
-curl http://localhost:3300/api/sbti/test?lang=en
+curl https://abti.kagura-agent.com/api/sbti/test?lang=en
 
-# 2. Answer questions (12 total: 3=A, 2=B, 1=C)
-curl -X POST http://localhost:3300/api/sbti/agent-test \
+# 2. Answer 16 questions (3=A, 2=B, 1=C)
+curl -X POST https://abti.kagura-agent.com/api/sbti/agent-test \
   -H 'Content-Type: application/json' \
-  -d '{"answers":[2,3,1,2,3,1,2,3,1,2,3,1]}'
+  -d '{"answers":[2,3,1,2,3,1,2,3,1,2,3,1,2,3,1,2]}'
 
 # 3. Look up all type codes
-curl http://localhost:3300/api/sbti/types
+curl https://abti.kagura-agent.com/api/sbti/types
 ```
 
 ### Agent workflow
 
 1. `GET /api/test` — read all 16 scenario questions (4 per dimension)
-2. Pick 2 questions per dimension (8 total), choose A or B for each
+2. Answer each question: 1 for option A, 0 for option B
 3. `POST /api/agent-test` with `{"answers":[1,0,...], "lang":"en"}` — receive your type code, nickname, and dimension scores
 
 ---


### PR DESCRIPTION
## What

The README described the original (never-implemented) ABTI framework with different dimensions and type codes. Updated to match the actual quiz.

### Before (wrong)
| Autonomy | Autonomous (A) vs Deferential (D) |
| Process Style | Systematic (S) vs Adaptive (I) |
| Communication | Expressive (E) vs Functional (F) |
| Initiative | Proactive (P) vs Responsive (R) |

Types: ASEP, ASFP, ASFR, AIFP...

### After (matches quiz + API)
| Autonomy | Proactive (P) vs Responsive (R) |
| Precision | Thorough (T) vs Efficient (E) |
| Transparency | Candid (C) vs Diplomatic (D) |
| Adaptability | Flexible (F) vs Principled (N) |

Types: PTCF, PECN, RTDF, REDN...

Also updated API examples to use the live URL (`abti.kagura-agent.com`) instead of `localhost:3300`.

Fixes #14