### PR TITLE
feat: track model and provider metadata in agent test results

### DIFF
--- a/action/index.js
+++ b/action/index.js
@@ -366,7 +366,7 @@ async function run() {
 
   // 3. Submit answers
   info('Submitting answers...');
-  const result = await httpPostJSON(`${apiBaseUrl}/api/agent-test`, { answers, lang });
+  const result = await httpPostJSON(`${apiBaseUrl}/api/agent-test`, { answers, lang, model, provider });
   info(`Result: ${result.type} — ${result.nick}`);
 
   // 4. Set outputs

--- a/agents.html
+++ b/agents.html
@@ -40,6 +40,7 @@ nav a:hover, nav a.active { color: var(--accent); }
 .pill { display: inline-block; background: var(--accent-soft); color: var(--accent); font-size: .7rem; font-weight: 700; padding: .15rem .55rem; border-radius: 999px; letter-spacing: .06em; margin-bottom: .3rem; }
 .card-nick { color: var(--text2); font-size: .82rem; }
 .card-time { color: var(--text3); font-size: .72rem; margin-top: .3rem; }
+.card-model { color: var(--text2); font-size: .72rem; margin-top: .2rem; opacity: .8; }
 
 .empty { text-align: center; color: var(--text3); font-size: .95rem; padding: 3rem 1rem; }
 
@@ -88,6 +89,7 @@ nav a:hover, nav a.active { color: var(--accent); }
         + '<div class="card-name">' + nameHtml + '</div>'
         + '<span class="pill">' + esc(a.type) + '</span>'
         + (a.nick ? ' <span class="card-nick">' + esc(a.nick) + '</span>' : '')
+        + (a.model || a.provider ? '<div class="card-model">' + esc([a.model, a.provider].filter(Boolean).join(' · ')) + '</div>' : '')
         + (time ? '<div class="card-time">' + time + '</div>' : '')
         + '</div>';
     }).join('');

--- a/api-server.js
+++ b/api-server.js
@@ -208,7 +208,7 @@ const server = http.createServer((req, res) => {
     req.on('end', () => {
       try {
         const parsed = JSON.parse(body);
-        const { answers, lang, agentName, agentUrl } = parsed;
+        const { answers, lang, agentName, agentUrl, model, provider } = parsed;
         if (!Array.isArray(answers) || answers.length !== 16) {
           res.writeHead(400, {'Content-Type':'application/json'});
           return res.end(JSON.stringify({error:'answers must be array of 16 values (1=A, 0=B)'}));
@@ -231,6 +231,8 @@ const server = http.createServer((req, res) => {
           const oneHourAgo = Date.now() - 3600000;
           const existing = agentData.agents.findIndex(a => a.name === name && new Date(a.testedAt).getTime() > oneHourAgo);
           const entry = { name, url: urlStr, type: code, nick: t?.en?.nick || 'Unknown', testedAt: now };
+          if (typeof model === 'string' && model) entry.model = model.slice(0, 64);
+          if (typeof provider === 'string' && provider) entry.provider = provider.slice(0, 32);
           if (existing !== -1) {
             agentData.agents[existing] = entry;
           } else {

--- a/cli/bin/abti.js
+++ b/cli/bin/abti.js
@@ -72,6 +72,8 @@ const submit = flag('--submit');
 const lang = opt('--lang') === 'zh' ? 'zh' : 'en';
 const agentName = opt('--name');
 const agentUrl = opt('--url');
+const model = opt('--model');
+const provider = opt('--provider');
 
 if (flag('--help') || flag('-h')) {
   console.log(`
@@ -83,6 +85,8 @@ if (flag('--help') || flag('-h')) {
     npx abti --lang zh       Chinese questions
     npx abti --name myAgent  Set agent name
     npx abti --url URL       Set agent URL
+    npx abti --model MODEL   Set model name
+    npx abti --provider PRV  Set provider name
     npx abti --submit        Submit result to registry
 
   Combine flags:
@@ -226,6 +230,8 @@ async function run() {
       const body = { answers: answers.map(a => a ? 1 : 0), lang };
       if (agentName) body.agentName = agentName;
       if (agentUrl) body.agentUrl = agentUrl;
+      if (model) body.model = model;
+      if (provider) body.provider = provider;
       await httpPost(`${API_BASE}/api/agent-test`, body);
       if (!jsonMode) console.log(`\n  ${t.submitted}`);
     } catch (err) {

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -99,6 +99,35 @@ describe('POST /api/agent-test', () => {
     assert.ok(j.agents.some(a => a.name === 'TestBot'));
   });
 
+  it('stores model and provider when provided', async () => {
+    const r = await req('/api/agent-test', { method: 'POST', body: { answers: allA, agentName: 'ModelBot', model: 'gpt-4o', provider: 'openai' } });
+    assert.equal(r.status, 200);
+    const agents = await req('/api/agents');
+    const a = agents.json().agents.find(a => a.name === 'ModelBot');
+    assert.equal(a.model, 'gpt-4o');
+    assert.equal(a.provider, 'openai');
+  });
+
+  it('omits model/provider when not provided (backwards compat)', async () => {
+    const r = await req('/api/agent-test', { method: 'POST', body: { answers: allA, agentName: 'PlainBot' } });
+    assert.equal(r.status, 200);
+    const agents = await req('/api/agents');
+    const a = agents.json().agents.find(a => a.name === 'PlainBot');
+    assert.equal(a.model, undefined);
+    assert.equal(a.provider, undefined);
+  });
+
+  it('truncates model and provider to max length', async () => {
+    const longModel = 'x'.repeat(100);
+    const longProvider = 'y'.repeat(50);
+    const r = await req('/api/agent-test', { method: 'POST', body: { answers: allA, agentName: 'TruncBot', model: longModel, provider: longProvider } });
+    assert.equal(r.status, 200);
+    const agents = await req('/api/agents');
+    const a = agents.json().agents.find(a => a.name === 'TruncBot');
+    assert.equal(a.model.length, 64);
+    assert.equal(a.provider.length, 32);
+  });
+
   it('400 on wrong length', async () => {
     const r = await req('/api/agent-test', { method: 'POST', body: { answers: [1, 0, 1] } });
     assert.equal(r.status, 400);


### PR DESCRIPTION
Closes #37

## Changes

Adds optional `model` and `provider` metadata fields throughout the stack, enabling tracking of which LLM model produced each ABTI result.

### API (`api-server.js`)
- `POST /api/agent-test` now accepts optional `model` (string, max 64 chars) and `provider` (string, max 32 chars)
- Fields are stored in `data/results.json` agent entries
- Returned via `GET /api/agents`

### GitHub Action (`action/index.js`)
- Sends `model` and `provider` when submitting results to the API

### CLI (`cli/bin/abti.js`)
- New flags: `--model MODEL` and `--provider PRV`
- Included in POST body when `--submit` is used

### Agents Gallery (`agents.html`)
- Displays `model · provider` on agent cards when present

### Tests
- 3 new tests: stores fields, backwards compat, truncation
- 33 total tests, all passing

## Why
The north star is building a quantifiable agent behavioral assessment system. Knowing which model produces which personality type enables cross-model comparison and version tracking.