### PR TITLE
feat: add type comparison API endpoint and comparison page

### DIFF
--- a/agents.html
+++ b/agents.html
@@ -58,6 +58,7 @@ nav a:hover, nav a.active { color: var(--accent); }
   <a href="index-v4.html">ABTI</a>
   <a href="sbti.html">SBTI-AI</a>
   <a href="agents.html" class="active">Agents</a>
+  <a href="compare.html">Compare</a>
   <a href="api.html">API</a>
 </nav>
 <div class="wrap">

--- a/api-server.js
+++ b/api-server.js
@@ -282,6 +282,63 @@ const server = http.createServer((req, res) => {
     return;
   }
 
+  // GET /api/compare/:type1/:type2 - compare two types
+  const compareMatch = url.pathname.match(/^\/api\/compare\/([A-Za-z]{4})\/([A-Za-z]{4})$/);
+  if (compareMatch && req.method === 'GET') {
+    const code1 = compareMatch[1].toUpperCase();
+    const code2 = compareMatch[2].toUpperCase();
+    const t1 = types[code1];
+    const t2 = types[code2];
+    if (!t1 || !t2) {
+      res.writeHead(400, {'Content-Type':'application/json'});
+      return res.end(JSON.stringify({error:`Invalid type code: ${!t1 ? code1 : code2}`}));
+    }
+    const lang = url.searchParams.get('lang') || 'en';
+    const r1 = richProfiles[code1];
+    const r2 = richProfiles[code2];
+    const p1 = r1?.[lang] || r1?.en || t1.en;
+    const p2 = r2?.[lang] || r2?.en || t2.en;
+
+    const dimensions = [];
+    for (let i = 0; i < 4; i++) {
+      const dn = (dimNames[lang] || dimNames.en)[i];
+      const dl = (dimLabels[lang] || dimLabels.en)[i];
+      const letter1 = code1[i];
+      const letter2 = code2[i];
+      const pole1 = letter1 === DL[i][0] ? dl[0] : dl[1];
+      const pole2 = letter2 === DL[i][0] ? dl[0] : dl[1];
+      dimensions.push({
+        name: dn,
+        poles: dl,
+        letters: DL[i],
+        type1: { letter: letter1, pole: pole1 },
+        type2: { letter: letter2, pole: pole2 },
+        match: letter1 === letter2
+      });
+    }
+
+    const compat1 = p1.bestPairedWith?.some(bp => bp.type === code2) || false;
+    const compat2 = p2.bestPairedWith?.some(bp => bp.type === code1) || false;
+    const compatibility = {
+      mutual: compat1 && compat2,
+      type1RecommendsType2: compat1,
+      type2RecommendsType1: compat2,
+      reason1: p1.bestPairedWith?.find(bp => bp.type === code2)?.reason || null,
+      reason2: p2.bestPairedWith?.find(bp => bp.type === code1)?.reason || null
+    };
+
+    const shared = dimensions.filter(d => d.match).length;
+
+    res.writeHead(200, {'Content-Type':'application/json'});
+    return res.end(JSON.stringify({
+      type1: { code: code1, nick: p1.nick, strengths: p1.strengths, blindSpots: p1.blindSpots, workStyle: p1.workStyle },
+      type2: { code: code2, nick: p2.nick, strengths: p2.strengths, blindSpots: p2.blindSpots, workStyle: p2.workStyle },
+      dimensions,
+      sharedDimensions: shared,
+      compatibility
+    }));
+  }
+
   // GET /badge/:type - SVG shield badge
   const badgeMatch = url.pathname.match(/^\/badge\/([A-Za-z]{4})$/);
   if (badgeMatch && req.method === 'GET') {
@@ -348,7 +405,7 @@ const server = http.createServer((req, res) => {
   }
 
   res.writeHead(404, {'Content-Type':'application/json'});
-  res.end(JSON.stringify({error:'not found',endpoints:['GET /api/test','GET /api/sbti/test','GET /api/types','GET /api/sbti/types','POST /api/agent-test','POST /api/sbti/agent-test','GET /api/agents','GET /badge/:type','GET /result/:type']}));
+  res.end(JSON.stringify({error:'not found',endpoints:['GET /api/test','GET /api/sbti/test','GET /api/types','GET /api/sbti/types','POST /api/agent-test','POST /api/sbti/agent-test','GET /api/agents','GET /api/compare/:type1/:type2','GET /badge/:type','GET /result/:type']}));
 });
 
 if (require.main === module) {

--- a/api.html
+++ b/api.html
@@ -135,6 +135,7 @@ pre code {
 <nav class="nav">
   <a href="index.html">ABTI</a>
   <a href="sbti.html">SBTI-AI</a>
+  <a href="compare.html">Compare</a>
   <a href="api.html" class="active">API</a>
 </nav>
 

--- a/compare.html
+++ b/compare.html
@@ -1,0 +1,196 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Compare Types — ABTI</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=DM+Sans:opsz,wght@9..40,400;9..40,500;9..40,600;9..40,700&family=Instrument+Serif&display=swap" rel="stylesheet">
+<style>
+:root {
+  --bg: #fafaf9; --surface: #fff; --surface2: #f5f5f4;
+  --text: #1c1917; --text2: #78716c; --text3: #a8a29e;
+  --accent: #0d9488; --accent2: #0f766e; --accent-soft: #f0fdfa;
+  --border: #e7e5e4; --radius: 10px;
+  --shadow: 0 1px 3px rgba(28,25,23,.06), 0 1px 2px rgba(28,25,23,.04);
+  --shadow-md: 0 4px 12px rgba(28,25,23,.07), 0 2px 4px rgba(28,25,23,.04);
+}
+* { margin: 0; padding: 0; box-sizing: border-box; }
+body { font-family: 'DM Sans', system-ui, sans-serif; background: var(--bg); color: var(--text); min-height: 100vh; -webkit-font-smoothing: antialiased; }
+
+nav { position: fixed; top: 0; left: 0; right: 0; display: flex; align-items: center; justify-content: center; gap: 2rem; padding: .7rem 1rem; background: rgba(250,250,249,.88); backdrop-filter: blur(12px); -webkit-backdrop-filter: blur(12px); border-bottom: 1px solid var(--border); z-index: 100; font-size: .82rem; letter-spacing: .08em; }
+nav a { color: var(--text2); text-decoration: none; font-weight: 500; transition: color .2s; }
+nav a:hover, nav a.active { color: var(--accent); }
+
+.wrap { max-width: 800px; margin: 0 auto; padding: 5rem 1.25rem 2rem; }
+.header { text-align: center; margin-bottom: 2rem; }
+.header h1 { font-family: 'Instrument Serif', serif; font-size: 2.4rem; font-weight: 400; color: var(--text); margin-bottom: .4rem; }
+.header h1 span { color: var(--accent); }
+
+.selectors { display: flex; gap: 1rem; justify-content: center; align-items: center; flex-wrap: wrap; margin-bottom: 2.5rem; }
+.selectors select { font-family: 'DM Sans', system-ui, sans-serif; font-size: .9rem; padding: .5rem 1rem; border: 1px solid var(--border); border-radius: var(--radius); background: var(--surface); color: var(--text); cursor: pointer; min-width: 180px; }
+.selectors select:focus { outline: none; border-color: var(--accent); }
+.vs { font-weight: 600; color: var(--text3); font-size: .85rem; letter-spacing: .1em; }
+.compare-btn { font-family: 'DM Sans', system-ui, sans-serif; font-size: .85rem; font-weight: 600; padding: .55rem 1.5rem; background: var(--accent); color: #fff; border: none; border-radius: var(--radius); cursor: pointer; transition: background .2s; letter-spacing: .04em; }
+.compare-btn:hover { background: var(--accent2); }
+
+#result { display: none; }
+
+.types-row { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; margin-bottom: 2rem; }
+.type-card { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); padding: 1.25rem; box-shadow: var(--shadow); }
+.type-card .pill { display: inline-block; background: var(--accent-soft); color: var(--accent); font-size: .7rem; font-weight: 700; padding: .15rem .55rem; border-radius: 999px; letter-spacing: .06em; margin-bottom: .4rem; }
+.type-card h2 { font-size: 1.1rem; font-weight: 600; margin-bottom: .25rem; }
+.type-card .nick { color: var(--text2); font-size: .85rem; margin-bottom: .75rem; }
+.type-card h3 { font-size: .78rem; font-weight: 600; color: var(--text); margin-bottom: .35rem; text-transform: uppercase; letter-spacing: .06em; }
+.type-card ul { list-style: none; margin-bottom: .75rem; }
+.type-card li { font-size: .82rem; color: var(--text2); line-height: 1.5; padding-left: .9rem; position: relative; margin-bottom: .2rem; }
+.type-card li::before { content: ''; position: absolute; left: 0; top: .55em; width: 4px; height: 4px; border-radius: 50%; background: var(--accent); }
+.type-card .work-style { font-size: .82rem; color: var(--text2); line-height: 1.55; }
+
+.section-title { font-size: .95rem; font-weight: 600; margin-bottom: 1rem; color: var(--text); }
+
+.dims { display: flex; flex-direction: column; gap: .75rem; margin-bottom: 2rem; }
+.dim { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); padding: 1rem 1.25rem; box-shadow: var(--shadow); }
+.dim-name { font-size: .8rem; font-weight: 600; color: var(--text); margin-bottom: .5rem; text-transform: uppercase; letter-spacing: .06em; }
+.dim-bar { position: relative; height: 28px; background: var(--surface2); border-radius: 14px; overflow: hidden; margin-bottom: .35rem; }
+.dim-bar .pole-label { position: absolute; top: 50%; transform: translateY(-50%); font-size: .7rem; font-weight: 600; z-index: 2; }
+.dim-bar .pole-left { left: .6rem; color: var(--text2); }
+.dim-bar .pole-right { right: .6rem; color: var(--text2); }
+.dim-marker { position: absolute; top: 2px; width: 24px; height: 24px; border-radius: 50%; display: flex; align-items: center; justify-content: center; font-size: .65rem; font-weight: 700; color: #fff; z-index: 3; transition: left .3s; }
+.marker-1 { background: var(--accent); }
+.marker-2 { background: #e8658a; }
+.dim-status { font-size: .72rem; color: var(--text3); text-align: center; }
+.dim-status.match { color: var(--accent); font-weight: 600; }
+
+.compat { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); padding: 1.25rem; box-shadow: var(--shadow); margin-bottom: 2rem; }
+.compat-badge { display: inline-block; padding: .2rem .7rem; border-radius: 999px; font-size: .75rem; font-weight: 600; margin-bottom: .75rem; }
+.compat-badge.mutual { background: #dcfce7; color: #166534; }
+.compat-badge.partial { background: #fef9c3; color: #854d0e; }
+.compat-badge.none { background: var(--surface2); color: var(--text3); }
+.compat-reason { font-size: .82rem; color: var(--text2); line-height: 1.55; margin-top: .4rem; }
+.compat-reason strong { color: var(--text); font-weight: 600; }
+
+.footer { text-align: center; color: var(--text3); font-size: .72rem; margin-top: 2rem; padding-bottom: 1rem; }
+
+@media (max-width: 600px) {
+  .types-row { grid-template-columns: 1fr; }
+  .header h1 { font-size: 1.8rem; }
+  .wrap { padding: 4rem 1rem 1.5rem; }
+  .selectors { flex-direction: column; align-items: stretch; }
+  .selectors select { min-width: auto; }
+  .vs { display: none; }
+}
+</style>
+</head>
+<body>
+<nav>
+  <a href="index.html">ABTI</a>
+  <a href="sbti.html">SBTI-AI</a>
+  <a href="agents.html">Agents</a>
+  <a href="compare.html" class="active">Compare</a>
+  <a href="api.html">API</a>
+</nav>
+<div class="wrap">
+  <div class="header">
+    <h1>Compare <span>Types</span></h1>
+  </div>
+  <div class="selectors">
+    <select id="sel1"></select>
+    <span class="vs">VS</span>
+    <select id="sel2"></select>
+    <button class="compare-btn" onclick="doCompare()">Compare</button>
+  </div>
+  <div id="result"></div>
+  <div class="footer">ABTI &mdash; Agent Behavioral Type Indicator</div>
+</div>
+<script>
+const TYPES = [
+  'PTCF','PTCN','PTDF','PTDN','PECF','PECN','PEDF','PEDN',
+  'RTCF','RTCN','RTDF','RTDN','RECF','RECN','REDF','REDN'
+];
+
+const sel1 = document.getElementById('sel1');
+const sel2 = document.getElementById('sel2');
+
+TYPES.forEach(t => {
+  sel1.add(new Option(t, t));
+  sel2.add(new Option(t, t));
+});
+sel2.value = 'REDN';
+
+// Read URL params
+const params = new URLSearchParams(location.search);
+if (params.get('a') && TYPES.includes(params.get('a').toUpperCase())) sel1.value = params.get('a').toUpperCase();
+if (params.get('b') && TYPES.includes(params.get('b').toUpperCase())) sel2.value = params.get('b').toUpperCase();
+if (params.get('a') && params.get('b')) doCompare();
+
+async function doCompare() {
+  const a = sel1.value, b = sel2.value;
+  history.replaceState(null, '', `compare.html?a=${a}&b=${b}`);
+  const res = await fetch(`/api/compare/${a}/${b}`);
+  if (!res.ok) { document.getElementById('result').innerHTML = '<p style="color:red">Error loading comparison</p>'; document.getElementById('result').style.display='block'; return; }
+  const d = await res.json();
+  render(d);
+}
+
+function render(d) {
+  const el = document.getElementById('result');
+  el.style.display = 'block';
+
+  const t1 = d.type1, t2 = d.type2;
+
+  let html = `<div class="types-row">`;
+  html += renderTypeCard(t1);
+  html += renderTypeCard(t2);
+  html += `</div>`;
+
+  html += `<div class="section-title">Dimensions (${d.sharedDimensions}/4 shared)</div>`;
+  html += `<div class="dims">`;
+  d.dimensions.forEach(dim => {
+    const m1pos = dim.type1.letter === dim.letters[0] ? 20 : 75;
+    const m2pos = dim.type2.letter === dim.letters[0] ? 20 : 75;
+    html += `<div class="dim">
+      <div class="dim-name">${dim.name}</div>
+      <div class="dim-bar">
+        <span class="pole-label pole-left">${dim.poles[0]}</span>
+        <span class="pole-label pole-right">${dim.poles[1]}</span>
+        <span class="dim-marker marker-1" style="left:${m1pos}%">${t1.code.slice(0,2)}</span>
+        <span class="dim-marker marker-2" style="left:${m2pos}%">${t2.code.slice(0,2)}</span>
+      </div>
+      <div class="dim-status ${dim.match ? 'match' : ''}">${dim.match ? 'Match — both ' + dim.type1.pole : dim.type1.pole + ' vs ' + dim.type2.pole}</div>
+    </div>`;
+  });
+  html += `</div>`;
+
+  // Compatibility
+  const c = d.compatibility;
+  let badgeClass = 'none', badgeText = 'No direct compatibility noted';
+  if (c.mutual) { badgeClass = 'mutual'; badgeText = 'Mutually recommended pair'; }
+  else if (c.type1RecommendsType2 || c.type2RecommendsType1) { badgeClass = 'partial'; badgeText = 'One-way recommendation'; }
+
+  html += `<div class="section-title">Compatibility</div>`;
+  html += `<div class="compat">`;
+  html += `<span class="compat-badge ${badgeClass}">${badgeText}</span>`;
+  if (c.reason1) html += `<div class="compat-reason"><strong>${t1.code}→${t2.code}:</strong> ${c.reason1}</div>`;
+  if (c.reason2) html += `<div class="compat-reason"><strong>${t2.code}→${t1.code}:</strong> ${c.reason2}</div>`;
+  html += `</div>`;
+
+  el.innerHTML = html;
+}
+
+function renderTypeCard(t) {
+  let h = `<div class="type-card">
+    <span class="pill">${t.code}</span>
+    <h2>${t.code}</h2>
+    <div class="nick">${t.nick}</div>
+    <h3>Strengths</h3><ul>`;
+  (t.strengths || []).forEach(s => h += `<li>${s}</li>`);
+  h += `</ul><h3>Blind Spots</h3><ul>`;
+  (t.blindSpots || []).forEach(s => h += `<li>${s}</li>`);
+  h += `</ul><h3>Work Style</h3><div class="work-style">${t.workStyle || ''}</div></div>`;
+  return h;
+}
+</script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -596,6 +596,7 @@ body {
   <a href="index.html" class="active">ABTI</a>
   <a href="sbti.html">SBTI-AI</a>
   <a href="agents.html">Agents</a>
+  <a href="compare.html">Compare</a>
   <a href="api.html">API</a>
   <button class="lang-btn" onclick="toggleLang()" id="langBtn">EN</button>
 </nav>

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -299,6 +299,58 @@ describe('GET /result/:type', () => {
   });
 });
 
+// ─── GET /api/compare/:type1/:type2 ───
+
+describe('GET /api/compare/:type1/:type2', () => {
+  it('compares same type', async () => {
+    const r = await req('/api/compare/PTCF/PTCF');
+    assert.equal(r.status, 200);
+    const j = r.json();
+    assert.equal(j.type1.code, 'PTCF');
+    assert.equal(j.type2.code, 'PTCF');
+    assert.equal(j.dimensions.length, 4);
+    assert.equal(j.sharedDimensions, 4);
+    assert.ok(j.dimensions.every(d => d.match === true));
+  });
+
+  it('compares different types', async () => {
+    const r = await req('/api/compare/PTCF/REDN');
+    assert.equal(r.status, 200);
+    const j = r.json();
+    assert.equal(j.type1.code, 'PTCF');
+    assert.equal(j.type2.code, 'REDN');
+    assert.equal(j.sharedDimensions, 0);
+    assert.ok(j.dimensions.every(d => d.match === false));
+    assert.ok(j.type1.strengths);
+    assert.ok(j.type2.blindSpots);
+    assert.ok(j.type1.nick);
+  });
+
+  it('400 for invalid type code', async () => {
+    const r = await req('/api/compare/PTCF/ZZZZ');
+    assert.equal(r.status, 400);
+    assert.ok(r.json().error.includes('ZZZZ'));
+  });
+
+  it('returns zh content with lang=zh', async () => {
+    const r = await req('/api/compare/PTCF/REDN?lang=zh');
+    assert.equal(r.status, 200);
+    const j = r.json();
+    assert.ok(j.dimensions[0].name.match(/自主/));
+  });
+
+  it('detects compatibility (PTCF ↔ RTDN mutual)', async () => {
+    const r = await req('/api/compare/PTCF/RTDN');
+    assert.equal(r.status, 200);
+    const j = r.json();
+    assert.equal(j.compatibility.type1RecommendsType2, true);
+    assert.equal(j.compatibility.type2RecommendsType1, true);
+    assert.equal(j.compatibility.mutual, true);
+    assert.ok(j.compatibility.reason1);
+    assert.ok(j.compatibility.reason2);
+  });
+});
+
 // ─── OPTIONS (CORS) ───
 
 describe('CORS', () => {


### PR DESCRIPTION
## Summary

Closes #41

Add a type comparison feature to ABTI:

### API: `GET /api/compare/:type1/:type2`
- Both types' profiles (nick, strengths, blindSpots, workStyle)
- Dimension-by-dimension comparison (match/differ for each of 4 dimensions)
- Compatibility analysis (checks bestPairedWith in both directions, returns reasons)
- `?lang=zh` support
- 400 for invalid type codes

### Web: `compare.html`
- Visual side-by-side type comparison page
- Two type selector dropdowns + Compare button
- Dimension bars, strengths/blindSpots, compatibility section
- Shareable URL (`?a=PTCF&b=RECN`)
- Responsive, matches existing site design

### Nav
- Added Compare link to index.html, agents.html, api.html

### Tests
- 5 new tests (same/different types, invalid codes, lang, compatibility detection)
- 38 total, all pass

## Test Results
```
ℹ tests 38
ℹ pass 38
ℹ fail 0
```