### PR TITLE
fix: isolate test data from production results.json

### DIFF
--- a/api-server.js
+++ b/api-server.js
@@ -3,8 +3,8 @@ const fs = require('fs');
 const path = require('path');
 
 // Data persistence
-const DATA_DIR = path.join(__dirname, 'data');
-const DATA_FILE = path.join(DATA_DIR, 'results.json');
+let DATA_DIR = process.env.ABTI_DATA_DIR || path.join(__dirname, 'data');
+let DATA_FILE = path.join(DATA_DIR, 'results.json');
 
 function loadData() {
   try {
@@ -17,6 +17,13 @@ function loadData() {
 function saveData(data) {
   if (!fs.existsSync(DATA_DIR)) fs.mkdirSync(DATA_DIR, { recursive: true });
   fs.writeFileSync(DATA_FILE, JSON.stringify(data, null, 2));
+}
+
+// Re-initialize data dir and reload data (used by tests)
+function resetData() {
+  DATA_DIR = process.env.ABTI_DATA_DIR || path.join(__dirname, 'data');
+  DATA_FILE = path.join(DATA_DIR, 'results.json');
+  agentData = loadData();
 }
 
 let agentData = loadData();
@@ -412,3 +419,4 @@ if (require.main === module) {
   server.listen(3300, '127.0.0.1', () => console.log('ABTI API listening on :3300'));
 }
 module.exports = server;
+module.exports.resetData = resetData;

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -1,6 +1,13 @@
 const { describe, it, before, after } = require('node:test');
 const assert = require('node:assert/strict');
 const http = require('node:http');
+const os = require('node:os');
+const fs = require('node:fs');
+const path = require('node:path');
+
+// Set up isolated data dir BEFORE requiring the server
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'abti-test-'));
+process.env.ABTI_DATA_DIR = tmpDir;
 
 const server = require('../api-server.js');
 
@@ -30,7 +37,13 @@ before(() => new Promise((resolve) => {
   });
 }));
 
-after(() => new Promise((resolve) => server.close(resolve)));
+after(() => new Promise((resolve) => {
+  server.close(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    delete process.env.ABTI_DATA_DIR;
+    resolve();
+  });
+}));
 
 // ─── GET /api/test ───
 


### PR DESCRIPTION
Closes #43

## Problem
Tests POST to `/api/agent-test` which writes TestBot, ModelBot, etc. to `data/results.json` — the same file used by the live API. Every test run inflates the total counter and pollutes the agents gallery.

## Changes
- **api-server.js**: `DATA_DIR` now reads from `ABTI_DATA_DIR` env var (falls back to `__dirname/data`)
- **api-server.js**: Added `resetData()` export for test re-initialization
- **test/api.test.js**: Creates a temp directory and sets `ABTI_DATA_DIR` *before* requiring the server; cleans up in `after()`

## Tests
All 38 tests pass:
```
ℹ tests 38 | pass 38 | fail 0
```