### PR TITLE
feat: add OpenAI provider support to seed-registry script (#47)

### DIFF
--- a/scripts/seed-registry.js
+++ b/scripts/seed-registry.js
@@ -78,7 +78,25 @@ function httpPostJSON(url, body, headers) {
   });
 }
 
-// ─── LLM call ───────────────────────────────────────────────────────────────
+// ─── LLM calls ──────────────────────────────────────────────────────────────
+
+function callOpenAI(opts, systemPrompt, userMessage) {
+  const url = opts.baseUrl
+    ? opts.baseUrl.replace(/\/+$/, '') + '/v1/chat/completions'
+    : 'https://api.openai.com/v1/chat/completions';
+  const headers = {
+    'Authorization': `Bearer ${opts.apiKey}`,
+  };
+  return httpPostJSON(url, {
+    model: opts.model,
+    messages: [
+      { role: 'system', content: systemPrompt },
+      { role: 'user', content: userMessage },
+    ],
+    max_tokens: 4,
+    temperature: 0,
+  }, headers).then(json => json.choices[0].message.content.trim());
+}
 
 function callAnthropic(opts, systemPrompt, userMessage) {
   const url = opts.baseUrl
@@ -94,6 +112,12 @@ function callAnthropic(opts, systemPrompt, userMessage) {
     system: systemPrompt,
     messages: [{ role: 'user', content: userMessage }],
   }, headers).then(json => json.content[0].text.trim());
+}
+
+function callLLM(opts, systemPrompt, userMessage) {
+  if (opts.provider === 'openai') return callOpenAI(opts, systemPrompt, userMessage);
+  if (opts.provider === 'anthropic') return callAnthropic(opts, systemPrompt, userMessage);
+  throw new Error(`Unknown provider: ${opts.provider}. Must be "openai" or "anthropic".`);
 }
 
 // ─── Answer parsing ─────────────────────────────────────────────────────────
@@ -152,7 +176,7 @@ async function main() {
       ].join('\n');
 
       console.log(`  Q${i + 1}/${questions.length} [${q.dimension}]...`);
-      const response = await callAnthropic(opts, systemPrompt, userMessage);
+      const response = await callLLM(opts, systemPrompt, userMessage);
       const answer = parseAnswer(response);
       console.log(`    → ${answer === 1 ? 'A' : 'B'} (raw: "${response}")`);
       answers.push(answer);


### PR DESCRIPTION
## Summary

Adds OpenAI provider support to `scripts/seed-registry.js`, matching the multi-provider pattern already used in `action/index.js`.

## Changes

- **`callOpenAI()`** — calls OpenAI chat completions API via `httpPostJSON`, supports `--base-url` for compatible APIs (vLLM, Ollama, etc.)
- **`callLLM()`** — routes to `callOpenAI` or `callAnthropic` based on `--provider` flag, throws on unknown provider
- Main loop now calls `callLLM()` instead of `callAnthropic()` directly

## Usage

```bash
# OpenAI
node scripts/seed-registry.js --provider openai --model gpt-4o --api-key \$OPENAI_API_KEY --agent-name 'GPT-4o'

# OpenAI-compatible (e.g. local vLLM)
node scripts/seed-registry.js --provider openai --model my-model --api-key test --base-url http://localhost:8000 --agent-name 'Local Model'

# Anthropic (unchanged)
node scripts/seed-registry.js --provider anthropic --model claude-opus-4 --api-key \$ANTHROPIC_API_KEY --agent-name 'Claude'
```

## Testing

- All 38 existing API tests pass ✅
- No changes to API server or other files

Closes #47