### PR TITLE
fix: align API server scoring threshold with web test

### DIFF
--- a/api-server.js
+++ b/api-server.js
@@ -76,7 +76,11 @@ function scoreABTI(answers) {
   const scores = [0,0,0,0];
   for (let i = 0; i < 16; i++) scores[qMap[i]] += answers[i] ? 1 : 0;
   let code = '';
-  for (let i = 0; i < 4; i++) code += scores[i] >= 2 ? DL[i][0] : DL[i][1];
+  for (let i = 0; i < 4; i++) {
+    if (scores[i] >= 3) code += DL[i][0];
+    else if (scores[i] <= 1) code += DL[i][1];
+    else code += DL[i][Math.random() < 0.5 ? 0 : 1];
+  }
   return { code, scores };
 }
 
@@ -227,7 +231,9 @@ const server = http.createServer((req, res) => {
         for (let i = 0; i < 4; i++) {
           const dn = (dimNames[l]||dimNames.en)[i];
           const dl = (dimLabels[l]||dimLabels.en)[i];
-          dims[dn] = { score: scores[i], max: 4, pole: scores[i]>=2 ? dl[0] : dl[1], letter: scores[i]>=2 ? DL[i][0] : DL[i][1] };
+          const letter = scores[i] >= 3 ? DL[i][0] : scores[i] <= 1 ? DL[i][1] : DL[i][Math.random() < 0.5 ? 0 : 1];
+          const pole = scores[i] >= 3 ? dl[0] : scores[i] <= 1 ? dl[1] : dl[Math.random() < 0.5 ? 0 : 1];
+          dims[dn] = { score: scores[i], max: 4, pole, letter };
         }
         // Persist result
         agentData.total++;

--- a/mcp/server.js
+++ b/mcp/server.js
@@ -33,7 +33,11 @@ function scoreABTI(answers) {
   const scores = [0,0,0,0];
   for (let i = 0; i < 16; i++) scores[qMap[i]] += answers[i] ? 1 : 0;
   let code = '';
-  for (let i = 0; i < 4; i++) code += scores[i] >= 2 ? DL[i][0] : DL[i][1];
+  for (let i = 0; i < 4; i++) {
+    if (scores[i] >= 3) code += DL[i][0];
+    else if (scores[i] <= 1) code += DL[i][1];
+    else code += DL[i][Math.random() < 0.5 ? 0 : 1];
+  }
   return { code, scores };
 }
 
@@ -42,7 +46,9 @@ function buildDimensions(scores, lang) {
   for (let i = 0; i < 4; i++) {
     const dn = (dimNames[lang] || dimNames.en)[i];
     const dl = (dimLabels[lang] || dimLabels.en)[i];
-    dims[dn] = { score: scores[i], max: 4, pole: scores[i] >= 2 ? dl[0] : dl[1], letter: scores[i] >= 2 ? DL[i][0] : DL[i][1] };
+    const letter = scores[i] >= 3 ? DL[i][0] : scores[i] <= 1 ? DL[i][1] : DL[i][Math.random() < 0.5 ? 0 : 1];
+    const pole = scores[i] >= 3 ? dl[0] : scores[i] <= 1 ? dl[1] : dl[Math.random() < 0.5 ? 0 : 1];
+    dims[dn] = { score: scores[i], max: 4, pole, letter };
   }
   return dims;
 }

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -95,6 +95,19 @@ describe('POST /api/agent-test', () => {
     assert.equal(r.json().type, 'REDN');
   });
 
+  it('randomly assigns pole letters when score is 2 (tie)', async () => {
+    // 2 A's + 2 B's per dimension → score 2 each → random pick
+    const tieAnswers = [1,1,0,0, 1,1,0,0, 1,1,0,0, 1,1,0,0];
+    const r = await req('/api/agent-test', { method: 'POST', body: { answers: tieAnswers } });
+    const j = r.json();
+    assert.equal(r.status, 200);
+    // Each letter must be one of the two valid poles for its dimension
+    const DL = [['P','R'],['T','E'],['C','D'],['F','N']];
+    for (let i = 0; i < 4; i++) {
+      assert.ok(DL[i].includes(j.type[i]), `dim ${i}: '${j.type[i]}' not in [${DL[i]}]`);
+    }
+  });
+
   it('returns zh nick with lang=zh', async () => {
     const r = await req('/api/agent-test', { method: 'POST', body: { answers: allA, lang: 'zh' } });
     const j = r.json();


### PR DESCRIPTION
## Problem

The API server (`api-server.js`) and MCP server (`mcp/server.js`) used `>= 2` (50%) as the threshold for assigning dimension pole letters, while the web test (`index.html`) uses `>= 3` (75%) with a random tiebreak at score `== 2`.

This meant the same answers could produce different personality types depending on which test method was used.

## Fix

Aligned both servers with the web test and static API spec logic:
- `score >= 3` → first pole letter
- `score <= 1` → second pole letter
- `score == 2` → random pick (removes systematic bias)

## Changes

- `api-server.js`: Fix `scoreABTI()` and dimension pole/letter assignment
- `mcp/server.js`: Fix same bug in MCP server
- `test/api.test.js`: Add tie-scenario test for score=2

## Tests

All 39 tests pass ✅

Fixes #51