### PR TITLE
feat: add Google Gemini provider support to action and seed script

### DIFF
--- a/action/README.md
+++ b/action/README.md
@@ -2,7 +2,7 @@
 
 Run an [ABTI personality test](https://abti.kagura-agent.com) on your AI agent directly in GitHub Actions.
 
-The action sends each scenario question to an LLM (OpenAI or Anthropic), collects its choices, and reports the resulting ABTI type as a job summary, outputs, and optional PR comment.
+The action sends each scenario question to an LLM (OpenAI, Anthropic, or Google Gemini), collects its choices, and reports the resulting ABTI type as a job summary, outputs, and optional PR comment.
 
 ## Inputs
 
@@ -10,7 +10,7 @@ The action sends each scenario question to an LLM (OpenAI or Anthropic), collect
 |-------|----------|---------|-------------|
 | `agent-prompt` | No | — | Agent system prompt string |
 | `agent-prompt-file` | No | — | Path to file containing system prompt (e.g. `AGENTS.md`) |
-| `provider` | **Yes** | — | `openai` or `anthropic` |
+| `provider` | **Yes** | — | `openai`, `anthropic`, or `gemini` |
 | `model` | **Yes** | — | Model name (e.g. `gpt-4o`, `claude-sonnet-4-20250514`) |
 | `api-key` | **Yes** | — | API key for the LLM provider |
 | `post-comment` | No | `false` | Post a PR comment with results |
@@ -35,6 +35,16 @@ The action sends each scenario question to an LLM (OpenAI or Anthropic), collect
     provider: openai
     model: gpt-4o
     api-key: ${{ secrets.OPENAI_API_KEY }}
+```
+
+### Basic — test with Gemini
+
+```yaml
+- uses: kagura-agent/abti@master
+  with:
+    provider: gemini
+    model: gemini-2.5-flash
+    api-key: ${{ secrets.GOOGLE_AI_API_KEY }}
 ```
 
 ### With agent system prompt from file
@@ -90,5 +100,5 @@ The action sends each scenario question to an LLM (OpenAI or Anthropic), collect
 ## Requirements
 
 - Node.js 20+ (provided by GitHub Actions runners)
-- An OpenAI or Anthropic API key stored as a repository secret
+- An OpenAI, Anthropic, or Google AI API key stored as a repository secret
 - For PR comments: `GITHUB_TOKEN` with `pull-requests: write` permission

--- a/action/index.js
+++ b/action/index.js
@@ -193,12 +193,54 @@ function callAnthropic(apiKey, model, systemPrompt, userMessage) {
 }
 
 /**
+ * Call Google Gemini generateContent API.
+ */
+function callGemini(apiKey, model, systemPrompt, userMessage) {
+  return new Promise((resolve, reject) => {
+    const payload = JSON.stringify({
+      contents: [{ role: 'user', parts: [{ text: userMessage }] }],
+      systemInstruction: { parts: [{ text: systemPrompt }] },
+      generationConfig: { maxOutputTokens: 4, temperature: 0 },
+    });
+    const reqPath = `/v1beta/models/${model}:generateContent?key=${apiKey}`;
+    const req = https.request({
+      hostname: 'generativelanguage.googleapis.com',
+      path: reqPath,
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Content-Length': Buffer.byteLength(payload),
+      },
+    }, (res) => {
+      let data = '';
+      res.on('data', (chunk) => (data += chunk));
+      res.on('end', () => {
+        if (res.statusCode < 200 || res.statusCode >= 300) {
+          return reject(new Error(`Gemini API returned ${res.statusCode}: ${data}`));
+        }
+        try {
+          const json = JSON.parse(data);
+          resolve(json.candidates[0].content.parts[0].text.trim());
+        } catch (e) {
+          reject(new Error(`Failed to parse Gemini response: ${e.message}`));
+        }
+      });
+      res.on('error', reject);
+    });
+    req.on('error', reject);
+    req.write(payload);
+    req.end();
+  });
+}
+
+/**
  * Route to the correct LLM provider.
  */
 function callLLM(provider, apiKey, model, systemPrompt, userMessage) {
   if (provider === 'openai') return callOpenAI(apiKey, model, systemPrompt, userMessage);
   if (provider === 'anthropic') return callAnthropic(apiKey, model, systemPrompt, userMessage);
-  throw new Error(`Unknown provider: ${provider}. Must be "openai" or "anthropic".`);
+  if (provider === 'gemini') return callGemini(apiKey, model, systemPrompt, userMessage);
+  throw new Error(`Unknown provider: ${provider}. Must be "openai", "anthropic", or "gemini".`);
 }
 
 // ─── Answer parsing ──────────────────────────────────────────────────────────

--- a/agents.html
+++ b/agents.html
@@ -75,7 +75,7 @@ nav a:hover, nav a.active { color: var(--accent); }
 </head>
 <body>
 <nav>
-  <a href="index-v4.html">ABTI</a>
+  <a href="index.html">ABTI</a>
   <a href="sbti.html">SBTI-AI</a>
   <a href="agents.html" class="active">Agents</a>
   <a href="compare.html">Compare</a>

--- a/scripts/seed-registry.js
+++ b/scripts/seed-registry.js
@@ -114,10 +114,21 @@ function callAnthropic(opts, systemPrompt, userMessage) {
   }, headers).then(json => json.content[0].text.trim());
 }
 
+function callGemini(opts, systemPrompt, userMessage) {
+  const model = opts.model;
+  const url = `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${opts.apiKey}`;
+  return httpPostJSON(url, {
+    contents: [{ role: 'user', parts: [{ text: userMessage }] }],
+    systemInstruction: { parts: [{ text: systemPrompt }] },
+    generationConfig: { maxOutputTokens: 4, temperature: 0 },
+  }).then(json => json.candidates[0].content.parts[0].text.trim());
+}
+
 function callLLM(opts, systemPrompt, userMessage) {
   if (opts.provider === 'openai') return callOpenAI(opts, systemPrompt, userMessage);
   if (opts.provider === 'anthropic') return callAnthropic(opts, systemPrompt, userMessage);
-  throw new Error(`Unknown provider: ${opts.provider}. Must be "openai" or "anthropic".`);
+  if (opts.provider === 'gemini') return callGemini(opts, systemPrompt, userMessage);
+  throw new Error(`Unknown provider: ${opts.provider}. Must be "openai", "anthropic", or "gemini".`);
 }
 
 // ─── Answer parsing ─────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #53

## Changes

- **action/index.js**: Add `callGemini()` using the Gemini REST API (`generativelanguage.googleapis.com/v1beta/models/{model}:generateContent`). API key passed as query parameter. Updated `callLLM()` router.
- **scripts/seed-registry.js**: Same Gemini provider support added.
- **agents.html**: Fix nav link pointing to `index-v4.html` → `index.html`.

## Usage

### GitHub Action
```yaml
- uses: kagura-agent/abti@master
  with:
    provider: gemini
    model: gemini-2.5-flash
    api-key: ${{ secrets.GOOGLE_AI_API_KEY }}
```

### Seed Script
```bash
node scripts/seed-registry.js --provider gemini --model gemini-2.5-flash --api-key $KEY --agent-name 'Gemini Flash'
```

## Testing

All 39 existing tests pass. The Gemini provider follows the same patterns as OpenAI/Anthropic (native https, no deps, same error handling).