### PR TITLE
fix: send agentName from GitHub Action to populate registry (#57)

### DIFF
--- a/action/README.md
+++ b/action/README.md
@@ -13,6 +13,7 @@ The action sends each scenario question to an LLM (OpenAI, Anthropic, or Google 
 | `provider` | **Yes** | — | `openai`, `anthropic`, or `gemini` |
 | `model` | **Yes** | — | Model name (e.g. `gpt-4o`, `claude-sonnet-4-20250514`) |
 | `api-key` | **Yes** | — | API key for the LLM provider |
+| `agent-name` | No | `<model> (<provider>)` | Display name for the agent in the registry |
 | `post-comment` | No | `false` | Post a PR comment with results |
 | `api-base-url` | No | `https://abti.kagura-agent.com` | ABTI API base URL |
 | `lang` | No | `en` | Language for questions (`en` or `zh`) |

--- a/action/action.yml
+++ b/action/action.yml
@@ -26,6 +26,9 @@ inputs:
     description: 'ABTI API base URL'
     required: false
     default: 'https://abti.kagura-agent.com'
+  agent-name:
+    description: 'Display name for the agent in the registry (defaults to "<model> (<provider>)")'
+    required: false
   lang:
     description: 'Language for questions (en or zh)'
     required: false

--- a/action/index.js
+++ b/action/index.js
@@ -362,6 +362,7 @@ async function run() {
   const postCommentFlag = getInput('post-comment') === 'true';
   const apiBaseUrl = getInput('api-base-url') || 'https://abti.kagura-agent.com';
   const lang = getInput('lang') || 'en';
+  const agentName = getInput('agent-name') || `${model} (${provider})`;
 
   // Resolve agent system prompt
   let basePrompt = '';
@@ -408,7 +409,7 @@ async function run() {
 
   // 3. Submit answers
   info('Submitting answers...');
-  const result = await httpPostJSON(`${apiBaseUrl}/api/agent-test`, { answers, lang, model, provider });
+  const result = await httpPostJSON(`${apiBaseUrl}/api/agent-test`, { answers, lang, model, provider, agentName });
   info(`Result: ${result.type} — ${result.nick}`);
 
   // 4. Set outputs


### PR DESCRIPTION
## What

The GitHub Action wasn't sending `agentName` in the `POST /api/agent-test` payload. The API server only adds entries to the agent registry when `agentName` is present, so all CI-triggered test results were invisible on the agents page.

## Changes

- **action/action.yml**: Added optional `agent-name` input
- **action/index.js**: Reads `agent-name`, defaults to `${model} (${provider})`, sends it in the POST payload
- **action/README.md**: Documented the new input

## Testing

- All 39 existing tests pass
- Minimal 3-file change, no API server changes needed

Closes #57