### PR TITLE
feat: store and display dimension scores for agent results

### DIFF
--- a/agents.html
+++ b/agents.html
@@ -41,6 +41,12 @@ nav a:hover, nav a.active { color: var(--accent); }
 .card-nick { color: var(--text2); font-size: .82rem; }
 .card-time { color: var(--text3); font-size: .72rem; margin-top: .3rem; }
 .card-model { color: var(--text2); font-size: .72rem; margin-top: .2rem; opacity: .8; }
+.card-scores { display: flex; flex-direction: column; gap: .25rem; margin-top: .45rem; }
+.card-score-row { display: flex; align-items: center; gap: .4rem; font-size: .68rem; }
+.card-score-label { width: 28px; font-weight: 600; color: var(--accent); text-align: right; flex-shrink: 0; }
+.card-score-bar { flex: 1; height: 6px; background: color-mix(in srgb, var(--accent) 30%, transparent); border-radius: 3px; overflow: hidden; }
+.card-score-fill { height: 100%; background: var(--accent); border-radius: 3px; }
+.card-score-pct { width: 28px; font-size: .62rem; color: var(--text3); }
 
 .dist { margin-bottom: 2.5rem; }
 .dist-title { font-size: .75rem; font-weight: 600; letter-spacing: .1em; color: var(--text2); text-transform: uppercase; margin-bottom: 1rem; }
@@ -161,6 +167,15 @@ nav a:hover, nav a.active { color: var(--accent); }
         + '<span class="pill">' + esc(a.type) + '</span>'
         + (a.nick ? ' <span class="card-nick">' + esc(a.nick) + '</span>' : '')
         + (a.model || a.provider ? '<div class="card-model">' + esc([a.model, a.provider].filter(Boolean).join(' · ')) + '</div>' : '')
+        + (a.dimensions ? '<div class="card-scores">' + a.dimensions.map(d => {
+            const pct = Math.round(d.score / d.max * 100);
+            const winner = d.score >= d.max / 2 ? d.poles[0] : d.poles[1];
+            return '<div class="card-score-row">'
+              + '<span class="card-score-label">' + winner + '</span>'
+              + '<div class="card-score-bar"><div class="card-score-fill" style="width:' + pct + '%"></div></div>'
+              + '<span class="card-score-pct">' + pct + '%</span>'
+              + '</div>';
+          }).join('') + '</div>' : '')
         + (time ? '<div class="card-time">' + time + '</div>' : '')
         + '</div>';
     }).join('');

--- a/api-server.js
+++ b/api-server.js
@@ -243,7 +243,7 @@ const server = http.createServer((req, res) => {
           const now = new Date().toISOString();
           const oneHourAgo = Date.now() - 3600000;
           const existing = agentData.agents.findIndex(a => a.name === name && new Date(a.testedAt).getTime() > oneHourAgo);
-          const entry = { name, url: urlStr, type: code, nick: t?.en?.nick || 'Unknown', testedAt: now };
+          const entry = { name, url: urlStr, type: code, nick: t?.en?.nick || 'Unknown', testedAt: now, scores: scores.slice(), dimensions: DL.map((d, i) => ({ poles: d, score: scores[i], max: 4 })) };
           if (typeof model === 'string' && model) entry.model = model.slice(0, 64);
           if (typeof provider === 'string' && provider) entry.provider = provider.slice(0, 32);
           if (existing !== -1) {

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -143,6 +143,19 @@ describe('POST /api/agent-test', () => {
     assert.equal(a.provider, undefined);
   });
 
+  it('stores dimension scores in agent entry', async () => {
+    await req('/api/agent-test', { method: 'POST', body: { answers: allA, agentName: 'ScoreBot' } });
+    const agents = await req('/api/agents');
+    const a = agents.json().agents.find(a => a.name === 'ScoreBot');
+    assert.deepEqual(a.scores, [4, 4, 4, 4]);
+    assert.equal(a.dimensions.length, 4);
+    for (let i = 0; i < 4; i++) {
+      assert.deepEqual(a.dimensions[i].poles, [['P','R'],['T','E'],['C','D'],['F','N']][i]);
+      assert.equal(a.dimensions[i].score, 4);
+      assert.equal(a.dimensions[i].max, 4);
+    }
+  });
+
   it('truncates model and provider to max length', async () => {
     const longModel = 'x'.repeat(100);
     const longProvider = 'y'.repeat(50);


### PR DESCRIPTION
Closes #61

## Changes

- **API** (`api-server.js`): Include `scores` array and `dimensions` metadata in stored agent entries
- **Agents page** (`agents.html`): Render dimension bar charts on agent cards when scores available — shows winning pole letter, filled bar, and percentage
- **Test**: Added assertion for scores/dimensions in stored agent data
- **Backward compatible**: Existing entries without scores still display normally

## Testing

```
npm test → 40/40 pass ✅
```