### PR TITLE
feat: add dynamic OG images for social sharing

### DIFF
--- a/api-server.js
+++ b/api-server.js
@@ -401,6 +401,62 @@ const server = http.createServer((req, res) => {
     }
   }
 
+  // GET /og/:type - dynamic OG image (SVG)
+  const ogMatch = url.pathname.match(/^\/og\/([A-Za-z]{4})$/);
+  if (ogMatch && req.method === 'GET') {
+    const code = ogMatch[1].toUpperCase();
+    const t = types[code];
+    if (!t) {
+      res.writeHead(404, {'Content-Type':'application/json'});
+      return res.end(JSON.stringify({error:`Unknown type: ${code}`}));
+    }
+    const nick = t.en.nick;
+    // Build dimension info from the type code letters
+    const dimInfo = [];
+    for (let i = 0; i < 4; i++) {
+      const letter = code[i];
+      const poleIdx = DL[i].indexOf(letter);
+      const pole = dimLabels.en[i][poleIdx];
+      const dim = dimNames.en[i];
+      dimInfo.push({ dim, pole, letter });
+    }
+
+    const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0a0a0f"/>
+      <stop offset="100%" stop-color="#12121f"/>
+    </linearGradient>
+    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#ff6b9d"/>
+      <stop offset="100%" stop-color="#c084fc"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <rect x="60" y="60" width="1080" height="510" rx="24" fill="#17172e" stroke="#2a2a4a" stroke-width="1"/>
+  <text x="600" y="130" text-anchor="middle" font-family="system-ui,-apple-system,sans-serif" font-size="22" font-weight="500" fill="#8a8aad" letter-spacing="4">ABTI \u2014 Agent Behavioral Type Indicator</text>
+  <line x1="200" y1="160" x2="1000" y2="160" stroke="#2a2a4a" stroke-width="1"/>
+  <text x="600" y="250" text-anchor="middle" font-family="system-ui,-apple-system,sans-serif" font-size="96" font-weight="700" fill="url(#accent)" letter-spacing="16">${code}</text>
+  <text x="600" y="310" text-anchor="middle" font-family="system-ui,-apple-system,sans-serif" font-size="32" font-weight="400" fill="#ededed">${nick}</text>
+  <line x1="200" y1="350" x2="1000" y2="350" stroke="#2a2a4a" stroke-width="1"/>
+${dimInfo.map((d, i) => {
+  const x = 160 + i * 250;
+  return `  <g transform="translate(${x}, 390)">
+    <rect width="190" height="130" rx="12" fill="#1e1e38" stroke="#2a2a4a" stroke-width="1"/>
+    <text x="95" y="35" text-anchor="middle" font-family="system-ui,-apple-system,sans-serif" font-size="14" font-weight="500" fill="#8a8aad">${d.dim}</text>
+    <text x="95" y="75" text-anchor="middle" font-family="system-ui,-apple-system,sans-serif" font-size="36" font-weight="700" fill="#ff6b9d">${d.letter}</text>
+    <text x="95" y="108" text-anchor="middle" font-family="system-ui,-apple-system,sans-serif" font-size="16" font-weight="400" fill="#ededed">${d.pole}</text>
+  </g>`;
+}).join('\n')}
+</svg>`;
+
+    res.writeHead(200, {
+      'Content-Type': 'image/svg+xml',
+      'Cache-Control': 'public, max-age=86400, immutable'
+    });
+    return res.end(svg);
+  }
+
   // GET /result/:type - shareable result page with dynamic OG tags
   const resultMatch = url.pathname.match(/^\/result\/([A-Za-z]{4})$/);
   if (resultMatch && req.method === 'GET') {
@@ -423,7 +479,7 @@ const server = http.createServer((req, res) => {
     // Replace OG meta tags
     html = html.replace(/<meta property="og:title"[^>]*>/, `<meta property="og:title" content="I am ${code} — ${nick} | ABTI">`);
     html = html.replace(/<meta property="og:description"[^>]*>/, `<meta property="og:description" content="${desc}">`);
-    html = html.replace(/<meta property="og:image"[^>]*>/, `<meta property="og:image" content="https://abti.kagura-agent.com/badge/${code}">`);
+    html = html.replace(/<meta property="og:image"[^>]*>/, `<meta property="og:image" content="https://abti.kagura-agent.com/og/${code}">`);
     html = html.replace(/<meta property="og:url"[^>]*>/, `<meta property="og:url" content="https://abti.kagura-agent.com/result/${code}">`);
     res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
     return res.end(html);

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -242,6 +242,69 @@ describe('GET /badge/:type', () => {
   });
 });
 
+// ─── GET /og/:type ───
+
+describe('GET /og/:type', () => {
+  it('returns SVG for valid type', async () => {
+    const r = await req('/og/PTCF');
+    assert.equal(r.status, 200);
+    assert.equal(r.headers['content-type'], 'image/svg+xml');
+    assert.match(r.body, /<svg/);
+    assert.match(r.body, /1200/);
+    assert.match(r.body, /630/);
+    assert.match(r.body, /PTCF/);
+    assert.match(r.body, /Architect/);
+  });
+
+  it('includes all 4 dimension labels', async () => {
+    const r = await req('/og/PTCF');
+    assert.match(r.body, /Autonomy/);
+    assert.match(r.body, /Precision/);
+    assert.match(r.body, /Transparency/);
+    assert.match(r.body, /Adaptability/);
+  });
+
+  it('includes correct pole labels for the type', async () => {
+    const r = await req('/og/PTCF');
+    assert.match(r.body, /Proactive/);
+    assert.match(r.body, /Thorough/);
+    assert.match(r.body, /Candid/);
+    assert.match(r.body, /Flexible/);
+  });
+
+  it('shows correct poles for opposite type REDN', async () => {
+    const r = await req('/og/REDN');
+    assert.match(r.body, /Responsive/);
+    assert.match(r.body, /Efficient/);
+    assert.match(r.body, /Diplomatic/);
+    assert.match(r.body, /Principled/);
+  });
+
+  it('includes ABTI branding', async () => {
+    const r = await req('/og/PTCF');
+    assert.match(r.body, /ABTI/);
+    assert.match(r.body, /Agent Behavioral Type Indicator/);
+  });
+
+  it('case insensitive type code', async () => {
+    const r = await req('/og/ptcf');
+    assert.equal(r.status, 200);
+    assert.match(r.body, /PTCF/);
+  });
+
+  it('404 for unknown type', async () => {
+    const r = await req('/og/XXXX');
+    assert.equal(r.status, 404);
+    const j = r.json();
+    assert.ok(j.error);
+  });
+
+  it('sets cache headers', async () => {
+    const r = await req('/og/PTCF');
+    assert.match(r.headers['cache-control'], /max-age=86400/);
+  });
+});
+
 // ─── GET /api/agents ───
 
 describe('GET /api/agents', () => {


### PR DESCRIPTION
Adds a `/og/:type` endpoint that generates a 1200×630 SVG image for each of the 16 ABTI types, designed for social media sharing.

## Changes

- **New `/og/:type` endpoint**: Generates a dynamic SVG OG image with:
  - ABTI branding header
  - Type code prominently displayed with gradient accent
  - Nickname (e.g. "The Architect")
  - All 4 dimension cards showing which pole the type falls on
  - Dark theme matching the site design (#0a0a0f background, #ff6b9d accent)

- **Updated `/result/:type`**: Now uses `/og/:type` instead of `/badge/:type` as the og:image, providing a much richer preview when sharing results on social media

- **Tests**: 8 new tests covering SVG generation, dimension labels, pole correctness, branding, case insensitivity, 404 handling, and cache headers

All 48 tests pass.

Closes #65