### PR TITLE
feat(action): add llm-base-url input for OpenRouter/Azure/custom endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,19 @@ Test your AI agent's personality in CI. Add to any workflow:
 
 The action sends each ABTI scenario to the LLM, collects A/B answers, and writes a job summary with the result. Set `post-comment: 'true'` to comment on PRs.
 
+### Using with OpenRouter or custom endpoints
+
+```yaml
+- uses: kagura-agent/abti@master
+  id: abti
+  with:
+    agent-prompt-file: AGENTS.md
+    provider: openai
+    model: anthropic/claude-sonnet-4
+    api-key: ${{ secrets.OPENROUTER_API_KEY }}
+    llm-base-url: https://openrouter.ai/api
+```
+
 See [`action/README.md`](action/README.md) for full documentation.
 
 ## MCP Server

--- a/action/action.yml
+++ b/action/action.yml
@@ -22,6 +22,9 @@ inputs:
     description: 'Post a PR comment with results'
     required: false
     default: 'false'
+  llm-base-url:
+    description: 'Base URL for the LLM API (e.g. https://openrouter.ai/api). Overrides the default provider endpoint.'
+    required: false
   api-base-url:
     description: 'ABTI API base URL'
     required: false

--- a/action/index.js
+++ b/action/index.js
@@ -105,8 +105,12 @@ function httpPostJSON(url, body) {
 /**
  * Call OpenAI chat completions API.
  */
-function callOpenAI(apiKey, model, systemPrompt, userMessage) {
+function callOpenAI(apiKey, model, systemPrompt, userMessage, baseUrl) {
   return new Promise((resolve, reject) => {
+    const parsed = baseUrl
+      ? new URL(baseUrl.replace(/\/+$/, '') + '/v1/chat/completions')
+      : new URL('https://api.openai.com/v1/chat/completions');
+    const mod = parsed.protocol === 'https:' ? https : http;
     const payload = JSON.stringify({
       model,
       messages: [
@@ -116,9 +120,10 @@ function callOpenAI(apiKey, model, systemPrompt, userMessage) {
       max_tokens: 4,
       temperature: 0,
     });
-    const req = https.request({
-      hostname: 'api.openai.com',
-      path: '/v1/chat/completions',
+    const req = mod.request({
+      hostname: parsed.hostname,
+      port: parsed.port,
+      path: parsed.pathname + parsed.search,
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -150,8 +155,12 @@ function callOpenAI(apiKey, model, systemPrompt, userMessage) {
 /**
  * Call Anthropic messages API.
  */
-function callAnthropic(apiKey, model, systemPrompt, userMessage) {
+function callAnthropic(apiKey, model, systemPrompt, userMessage, baseUrl) {
   return new Promise((resolve, reject) => {
+    const parsed = baseUrl
+      ? new URL(baseUrl.replace(/\/+$/, '') + '/v1/messages')
+      : new URL('https://api.anthropic.com/v1/messages');
+    const mod = parsed.protocol === 'https:' ? https : http;
     const payload = JSON.stringify({
       model,
       max_tokens: 4,
@@ -160,9 +169,10 @@ function callAnthropic(apiKey, model, systemPrompt, userMessage) {
         { role: 'user', content: userMessage },
       ],
     });
-    const req = https.request({
-      hostname: 'api.anthropic.com',
-      path: '/v1/messages',
+    const req = mod.request({
+      hostname: parsed.hostname,
+      port: parsed.port,
+      path: parsed.pathname + parsed.search,
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -236,9 +246,9 @@ function callGemini(apiKey, model, systemPrompt, userMessage) {
 /**
  * Route to the correct LLM provider.
  */
-function callLLM(provider, apiKey, model, systemPrompt, userMessage) {
-  if (provider === 'openai') return callOpenAI(apiKey, model, systemPrompt, userMessage);
-  if (provider === 'anthropic') return callAnthropic(apiKey, model, systemPrompt, userMessage);
+function callLLM(provider, apiKey, model, systemPrompt, userMessage, baseUrl) {
+  if (provider === 'openai') return callOpenAI(apiKey, model, systemPrompt, userMessage, baseUrl);
+  if (provider === 'anthropic') return callAnthropic(apiKey, model, systemPrompt, userMessage, baseUrl);
   if (provider === 'gemini') return callGemini(apiKey, model, systemPrompt, userMessage);
   throw new Error(`Unknown provider: ${provider}. Must be "openai", "anthropic", or "gemini".`);
 }
@@ -361,6 +371,7 @@ async function run() {
   const apiKey = getInput('api-key', true);
   const postCommentFlag = getInput('post-comment') === 'true';
   const apiBaseUrl = getInput('api-base-url') || 'https://abti.kagura-agent.com';
+  const llmBaseUrl = getInput('llm-base-url') || '';
   const lang = getInput('lang') || 'en';
   const agentName = getInput('agent-name') || `${model} (${provider})`;
 
@@ -401,7 +412,7 @@ async function run() {
     ].join('\n');
 
     info(`Question ${i + 1}/${questions.length}: ${q.dimension}`);
-    const response = await callLLM(provider, apiKey, model, systemPrompt, userMessage);
+    const response = await callLLM(provider, apiKey, model, systemPrompt, userMessage, llmBaseUrl || undefined);
     const answer = parseAnswer(response);
     info(`  Answer: ${answer === 1 ? 'A' : 'B'} (raw: "${response}")`);
     answers.push(answer);


### PR DESCRIPTION
## Summary

Add optional `llm-base-url` input to the GitHub Action so users can point the OpenAI provider at any OpenAI-compatible endpoint (OpenRouter, Azure OpenAI, Groq, Together, local models, etc.) instead of the hardcoded `api.openai.com`.

## Changes

- **action/action.yml**: New optional `llm-base-url` input
- **action/index.js**: `callOpenAI()` accepts base URL, parses it to derive hostname/port/protocol/path prefix. Falls back to `api.openai.com` when not set.
- **action/README.md**: Added input docs and OpenRouter usage example

## Example

```yaml
- uses: kagura-agent/abti@master
  with:
    provider: openai
    model: anthropic/claude-sonnet-4
    api-key: ${{ secrets.OPENROUTER_API_KEY }}
    llm-base-url: https://openrouter.ai/api
```

## North Star

Directly enables 'more agents testing' — OpenRouter alone covers GPT-4o, Claude, Gemini, Llama, Mistral, Qwen, DeepSeek, and many more through a single API key.

Closes #67