### PR TITLE
feat(mcp): expand MCP server with compare, agents, and SBTI tools

### DIFF
--- a/mcp/package.json
+++ b/mcp/package.json
@@ -2,7 +2,6 @@
   "name": "@abti/mcp-server",
   "version": "1.0.0",
   "description": "MCP server for ABTI (Agent Behavioral Type Indicator) — let any MCP-compatible agent take the personality test",
-  "type": "module",
   "main": "server.js",
   "bin": {
     "abti-mcp": "server.js"

--- a/mcp/server.js
+++ b/mcp/server.js
@@ -7,12 +7,35 @@ const { z } = require('zod');
 
 // Load data from parent project
 const path = require('path');
+const fs = require('fs');
 const parentDir = path.join(__dirname, '..');
 
 // We need to extract questions and types - load api-server.js as module won't work
 // So we load the JSON data files and reconstruct what we need
 const typesJson = require(path.join(parentDir, 'api/v1/types.json'));
 const richProfiles = typesJson.abti.types;
+
+// SBTI data
+const sbtiJson = require(path.join(parentDir, 'api/v1/sbti.json'));
+const sbtiQuestions = require(path.join(parentDir, 'questions-v4.js'));
+
+// SBTI scoring constants
+const SDL = [['S','C'],['V','T'],['H','G'],['O','I']];
+const sqMap = [0,0,0,0,1,1,1,1,2,2,2,2,3,3,3,3];
+const stypes = {
+  SVHO:{code:'SPAM'},SVHI:{code:'SIMP'},SVGO:{code:'BOSS'},SVGI:{code:'BLOG'},
+  STHO:{code:'GLUE'},STHI:{code:'NPC'},STGO:{code:'TOOL'},STGI:{code:'DEAD'},
+  CVHO:{code:'YOLO'},CVHI:{code:'TROLL'},CVGO:{code:'PROF'},CVGI:{code:'SAGE'},
+  CTHO:{code:'NUKE'},CTHI:{code:'EDGE'},CTGO:{code:'HACK'},CTGI:{code:'ROCK'}
+};
+
+function scoreSBTI(answers) {
+  const scores = [0,0,0,0];
+  for (let i = 0; i < 16; i++) scores[sqMap[i]] += answers[i];
+  let code = '';
+  for (let i = 0; i < 4; i++) code += scores[i] >= 9 ? SDL[i][0] : SDL[i][1];
+  return { code, scores };
+}
 
 // Dimension config (same as api-server.js)
 const DL = [['P','R'],['T','E'],['C','D'],['F','N']];
@@ -59,6 +82,15 @@ function getTypeProfile(code, lang) {
   const loc = t[lang] || t.en;
   const en = t.en;
   return { type: code, nick: loc.nick || en.nick, strengths: loc.strengths || en.strengths, blindSpots: loc.blindSpots || en.blindSpots, workStyle: loc.workStyle || en.workStyle, bestPairedWith: loc.bestPairedWith || en.bestPairedWith };
+}
+
+// Load agent results data
+function loadAgentData() {
+  try {
+    return JSON.parse(fs.readFileSync(path.join(parentDir, 'data', 'results.json'), 'utf8'));
+  } catch {
+    return { total: 0, agents: [] };
+  }
 }
 
 // ─── MCP Server ──────────────────────────────────────────────────────────────
@@ -130,6 +162,123 @@ mcpServer.tool(
       return { content: [{ type: 'text', text: JSON.stringify({ error: 'Unknown type code: ' + code, validTypes }) }], isError: true };
     }
     return { content: [{ type: 'text', text: JSON.stringify(profile, null, 2) }] };
+  }
+);
+
+mcpServer.tool(
+  'abti_compare_types',
+  'Compare two ABTI personality types. Shows shared/unique strengths and blind spots, dimension-by-dimension comparison, and compatibility info.',
+  {
+    type1: z.string().length(4).describe('First 4-letter ABTI type code (e.g. PTCF)'),
+    type2: z.string().length(4).describe('Second 4-letter ABTI type code (e.g. RECN)'),
+    lang: z.enum(['en', 'zh']).optional().describe('Language for profiles (default: en)'),
+  },
+  async ({ type1, type2, lang }) => {
+    const code1 = type1.toUpperCase();
+    const code2 = type2.toUpperCase();
+    const l = lang || 'en';
+    const r1 = richProfiles[code1];
+    const r2 = richProfiles[code2];
+    if (!r1 || !r2) {
+      const invalid = !r1 ? code1 : code2;
+      return { content: [{ type: 'text', text: JSON.stringify({ error: 'Unknown type code: ' + invalid, validTypes: Object.keys(richProfiles).join(', ') }) }], isError: true };
+    }
+    const p1 = r1[l] || r1.en;
+    const p2 = r2[l] || r2.en;
+
+    const dimensions = [];
+    for (let i = 0; i < 4; i++) {
+      const dn = (dimNames[l] || dimNames.en)[i];
+      const dl = (dimLabels[l] || dimLabels.en)[i];
+      const letter1 = code1[i];
+      const letter2 = code2[i];
+      const pole1 = letter1 === DL[i][0] ? dl[0] : dl[1];
+      const pole2 = letter2 === DL[i][0] ? dl[0] : dl[1];
+      dimensions.push({ name: dn, poles: dl, letters: DL[i], type1: { letter: letter1, pole: pole1 }, type2: { letter: letter2, pole: pole2 }, match: letter1 === letter2 });
+    }
+
+    const compat1 = p1.bestPairedWith?.some(bp => bp.type === code2) || false;
+    const compat2 = p2.bestPairedWith?.some(bp => bp.type === code1) || false;
+    const compatibility = {
+      mutual: compat1 && compat2,
+      type1RecommendsType2: compat1,
+      type2RecommendsType1: compat2,
+      reason1: p1.bestPairedWith?.find(bp => bp.type === code2)?.reason || null,
+      reason2: p2.bestPairedWith?.find(bp => bp.type === code1)?.reason || null
+    };
+
+    const result = {
+      type1: { code: code1, nick: p1.nick, strengths: p1.strengths, blindSpots: p1.blindSpots, workStyle: p1.workStyle },
+      type2: { code: code2, nick: p2.nick, strengths: p2.strengths, blindSpots: p2.blindSpots, workStyle: p2.workStyle },
+      dimensions,
+      sharedDimensions: dimensions.filter(d => d.match).length,
+      compatibility
+    };
+    return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+  }
+);
+
+mcpServer.tool(
+  'abti_list_agents',
+  'List agents who have taken the ABTI test. Returns agent names, types, nicknames, and test timestamps.',
+  {},
+  async () => {
+    const data = loadAgentData();
+    const agents = data.agents.map(a => ({
+      name: a.name,
+      type: a.type,
+      nick: a.nick,
+      testedAt: a.testedAt,
+      ...(a.model ? { model: a.model } : {}),
+      ...(a.provider ? { provider: a.provider } : {})
+    }));
+    return { content: [{ type: 'text', text: JSON.stringify({ total: data.total, agents }, null, 2) }] };
+  }
+);
+
+mcpServer.tool(
+  'abti_sbti_get_questions',
+  'Get the 16 SBTI (Silly Behavioral Type Indicator) scenario-based questions. Each question has three options (A, B, C). Score: A=3, B=2, C=1. Submit answers via abti_sbti_submit_answers.',
+  { lang: z.enum(['en', 'zh']).optional().describe('Language for questions (default: en)') },
+  async ({ lang }) => {
+    const l = lang || 'en';
+    const dims = l === 'zh' ? ['讨好','话痨','幻觉','卷'] : ['Sycophancy','Verbosity','Hallucination','Initiative'];
+    const questions = sbtiQuestions.map((q, i) => {
+      const loc = q[l] || q.en;
+      return { id: i + 1, dimension: q.dim, text: loc.text, A: loc.a, B: loc.b, C: loc.c };
+    });
+    const result = {
+      test: 'sbti',
+      description: 'Silly Behavioral Type Indicator — 16 scenario-based questions, 4 dimensions (4 questions each), 3 options per question',
+      dimensions: dims.map((name, i) => ({ name, poles: SDL[i], questions_count: 4 })),
+      scoring: 'Answer all 16 questions. 3 for option A, 2 for option B, 1 for option C. Score range per dim: 4-12, threshold >=9 = first pole.',
+      questions,
+    };
+    return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+  }
+);
+
+mcpServer.tool(
+  'abti_sbti_submit_answers',
+  'Submit answers to the SBTI (Silly Behavioral Type Indicator) test. Provide an array of 16 values (3=A, 2=B, 1=C). Returns your shitty bot type.',
+  {
+    answers: z.array(z.number().int().min(1).max(3)).length(16).describe('Array of 16 answers: 3=A, 2=B, 1=C'),
+    lang: z.enum(['en', 'zh']).optional().describe('Language for results (default: en)'),
+  },
+  async ({ answers, lang }) => {
+    const l = lang || 'en';
+    const { code, scores } = scoreSBTI(answers);
+    const st = stypes[code];
+    const sbtiType = sbtiJson.types[code];
+    const loc = sbtiType?.[l] || sbtiType?.en;
+    const result = {
+      test: 'sbti',
+      type: code,
+      code: st?.code || code,
+      dimensions: { sycophancy: scores[0], verbosity: scores[1], hallucination: scores[2], initiative: scores[3] },
+      ...(loc ? { name: loc.name, subtitle: loc.sub, description: loc.desc } : {})
+    };
+    return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
   }
 );
 

--- a/package.json
+++ b/package.json
@@ -2,6 +2,6 @@
   "name": "abti",
   "private": true,
   "scripts": {
-    "test": "node --test test/api.test.js"
+    "test": "node --test test/api.test.js test/mcp.test.js"
   }
 }

--- a/test/mcp.test.js
+++ b/test/mcp.test.js
@@ -1,0 +1,230 @@
+const { describe, it, before, after } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+
+// We need to require from the mcp directory's node_modules
+const mcpModules = path.join(__dirname, '..', 'mcp', 'node_modules', '@modelcontextprotocol', 'sdk', 'dist', 'cjs');
+const { Client } = require(path.join(mcpModules, 'client', 'index.js'));
+const { InMemoryTransport } = require(path.join(mcpModules, 'inMemory.js'));
+
+// The MCP server modifies module-level state, so we spawn it fresh
+// But since server.js calls main() which connects transport, we need a different approach:
+// Re-create the server logic by requiring the file's McpServer before it connects.
+// Actually, server.js calls main() at the bottom — we need to intercept.
+
+// Approach: fork the server as a child process and use StdioClientTransport
+// Actually simpler: extract McpServer from server.js by mocking the transport connect.
+// Simplest: just use child_process spawn with StdioClientTransport.
+
+const { spawn } = require('node:child_process');
+const { StdioClientTransport } = require(path.join(mcpModules, 'client', 'stdio.js'));
+
+let client;
+let transport;
+
+before(async () => {
+  transport = new StdioClientTransport({
+    command: 'node',
+    args: [path.join(__dirname, '..', 'mcp', 'server.js')],
+    cwd: path.join(__dirname, '..'),
+  });
+  client = new Client({ name: 'test-client', version: '1.0.0' });
+  await client.connect(transport);
+});
+
+after(async () => {
+  await client.close();
+});
+
+// Helper to call a tool
+async function callTool(name, args = {}) {
+  const result = await client.callTool({ name, arguments: args });
+  const text = result.content[0]?.text;
+  return { ...result, parsed: text ? JSON.parse(text) : null };
+}
+
+// ─── abti_get_questions ───
+
+describe('abti_get_questions', () => {
+  it('returns 16 questions in English by default', async () => {
+    const { parsed } = await callTool('abti_get_questions', {});
+    assert.equal(parsed.test, 'abti');
+    assert.equal(parsed.questions.length, 16);
+    assert.equal(parsed.dimensions.length, 4);
+    assert.ok(parsed.questions[0].A);
+    assert.ok(parsed.questions[0].B);
+    assert.ok(parsed.questions[0].text);
+  });
+
+  it('returns Chinese questions when lang=zh', async () => {
+    const { parsed } = await callTool('abti_get_questions', { lang: 'zh' });
+    assert.equal(parsed.questions.length, 16);
+    // Chinese questions should contain Chinese characters
+    assert.ok(/[\u4e00-\u9fff]/.test(parsed.questions[0].text));
+  });
+});
+
+// ─── abti_submit_answers ───
+
+describe('abti_submit_answers', () => {
+  it('returns a valid type for all-A answers', async () => {
+    const answers = Array(16).fill(1);
+    const { parsed } = await callTool('abti_submit_answers', { answers });
+    assert.equal(parsed.test, 'abti');
+    assert.equal(parsed.type.length, 4);
+    assert.ok(parsed.nick);
+    assert.ok(parsed.strengths);
+    assert.ok(parsed.blindSpots);
+    assert.ok(parsed.workStyle);
+    assert.ok(parsed.dimensions);
+  });
+
+  it('returns a valid type for all-B answers', async () => {
+    const answers = Array(16).fill(0);
+    const { parsed } = await callTool('abti_submit_answers', { answers });
+    assert.equal(parsed.type.length, 4);
+    assert.ok(parsed.nick);
+  });
+
+  it('includes agent metadata when provided', async () => {
+    const answers = Array(16).fill(1);
+    const { parsed } = await callTool('abti_submit_answers', {
+      answers,
+      agentName: 'TestBot',
+      model: 'test-model',
+      provider: 'test',
+    });
+    assert.equal(parsed.agentName, 'TestBot');
+    assert.equal(parsed.model, 'test-model');
+    assert.equal(parsed.provider, 'test');
+  });
+
+  it('returns Chinese results when lang=zh', async () => {
+    const answers = Array(16).fill(1);
+    const { parsed } = await callTool('abti_submit_answers', { answers, lang: 'zh' });
+    assert.equal(parsed.type.length, 4);
+    // Dimensions should have Chinese keys
+    const dimKeys = Object.keys(parsed.dimensions);
+    assert.ok(dimKeys.some(k => /[\u4e00-\u9fff]/.test(k)));
+  });
+});
+
+// ─── abti_get_type_info ───
+
+describe('abti_get_type_info', () => {
+  it('returns profile for a valid type', async () => {
+    const { parsed } = await callTool('abti_get_type_info', { type: 'PTCF' });
+    assert.equal(parsed.type, 'PTCF');
+    assert.ok(parsed.nick);
+    assert.ok(parsed.strengths);
+    assert.ok(parsed.blindSpots);
+  });
+
+  it('handles lowercase type codes', async () => {
+    const { parsed } = await callTool('abti_get_type_info', { type: 'ptcf' });
+    assert.equal(parsed.type, 'PTCF');
+  });
+
+  it('returns error for invalid type code', async () => {
+    const result = await client.callTool({ name: 'abti_get_type_info', arguments: { type: 'XXXX' } });
+    assert.equal(result.isError, true);
+    const parsed = JSON.parse(result.content[0].text);
+    assert.ok(parsed.error);
+    assert.ok(parsed.validTypes);
+  });
+
+  it('returns Chinese profile when lang=zh', async () => {
+    const { parsed } = await callTool('abti_get_type_info', { type: 'PTCF', lang: 'zh' });
+    assert.equal(parsed.type, 'PTCF');
+    assert.ok(parsed.nick);
+  });
+});
+
+// ─── abti_compare_types ───
+
+describe('abti_compare_types', () => {
+  it('compares two valid types', async () => {
+    const { parsed } = await callTool('abti_compare_types', { type1: 'PTCF', type2: 'REDN' });
+    assert.ok(parsed.type1);
+    assert.ok(parsed.type2);
+    assert.equal(parsed.type1.code, 'PTCF');
+    assert.equal(parsed.type2.code, 'REDN');
+    assert.equal(parsed.dimensions.length, 4);
+    assert.ok(typeof parsed.sharedDimensions === 'number');
+    assert.ok(parsed.compatibility);
+  });
+
+  it('comparing same type yields 4 shared dimensions', async () => {
+    const { parsed } = await callTool('abti_compare_types', { type1: 'PTCF', type2: 'PTCF' });
+    assert.equal(parsed.sharedDimensions, 4);
+  });
+
+  it('comparing opposite types yields 0 shared dimensions', async () => {
+    const { parsed } = await callTool('abti_compare_types', { type1: 'PTCF', type2: 'REDN' });
+    assert.equal(parsed.sharedDimensions, 0);
+  });
+
+  it('returns error for invalid type', async () => {
+    const result = await client.callTool({ name: 'abti_compare_types', arguments: { type1: 'XXXX', type2: 'PTCF' } });
+    assert.equal(result.isError, true);
+  });
+});
+
+// ─── abti_list_agents ───
+
+describe('abti_list_agents', () => {
+  it('returns agent list with total count', async () => {
+    const { parsed } = await callTool('abti_list_agents', {});
+    assert.ok(typeof parsed.total === 'number');
+    assert.ok(Array.isArray(parsed.agents));
+  });
+});
+
+// ─── abti_sbti_get_questions ───
+
+describe('abti_sbti_get_questions', () => {
+  it('returns 16 SBTI questions', async () => {
+    const { parsed } = await callTool('abti_sbti_get_questions', {});
+    assert.equal(parsed.test, 'sbti');
+    assert.equal(parsed.questions.length, 16);
+    assert.ok(parsed.questions[0].A);
+    assert.ok(parsed.questions[0].B);
+    assert.ok(parsed.questions[0].C);
+  });
+
+  it('returns Chinese SBTI questions', async () => {
+    const { parsed } = await callTool('abti_sbti_get_questions', { lang: 'zh' });
+    assert.equal(parsed.questions.length, 16);
+    assert.ok(/[\u4e00-\u9fff]/.test(parsed.questions[0].text));
+  });
+});
+
+// ─── abti_sbti_submit_answers ───
+
+describe('abti_sbti_submit_answers', () => {
+  it('returns SBTI type for valid answers (all A=3)', async () => {
+    const answers = Array(16).fill(3);
+    const { parsed } = await callTool('abti_sbti_submit_answers', { answers });
+    assert.equal(parsed.test, 'sbti');
+    assert.equal(parsed.type.length, 4);
+    assert.ok(parsed.code);
+    assert.ok(parsed.dimensions);
+  });
+
+  it('returns SBTI type for all C=1 answers', async () => {
+    const answers = Array(16).fill(1);
+    const { parsed } = await callTool('abti_sbti_submit_answers', { answers });
+    assert.equal(parsed.test, 'sbti');
+    assert.equal(parsed.type.length, 4);
+  });
+
+  it('returns Chinese SBTI results when lang=zh', async () => {
+    const answers = Array(16).fill(2);
+    const { parsed } = await callTool('abti_sbti_submit_answers', { answers, lang: 'zh' });
+    assert.equal(parsed.test, 'sbti');
+    // Description should be in Chinese
+    if (parsed.description) {
+      assert.ok(/[\u4e00-\u9fff]/.test(parsed.description));
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Expands the MCP server from 3 tools to 7, giving MCP clients feature parity with the HTTP API.

### Changes

1. **Fixed `mcp/package.json`** — removed duplicate `"type": "module"` line (kept `"type": "commonjs"`)

2. **Added 4 new MCP tools:**

| Tool | Description |
|---|---|
| `abti_compare_types` | Compare two types — dimension breakdown, shared/unique strengths & blind spots, compatibility |
| `abti_list_agents` | List agents from registry (name, type, nick, testedAt, model, provider) |
| `abti_sbti_get_questions` | Get 16 SBTI (fun version) questions with 3 options |
| `abti_sbti_submit_answers` | Submit SBTI answers, get type result |

3. **Added 20 MCP tests** (`test/mcp.test.js`):
   - Tests all 7 tools (get_questions, submit_answers, get_type_info, compare_types, list_agents, sbti_get_questions, sbti_submit_answers)
   - Uses MCP SDK `StdioClientTransport` for end-to-end testing
   - Covers: valid inputs, error cases, i18n (en/zh), edge cases

### Tests

All 68 tests pass (48 API + 20 MCP), zero regressions.

Closes #69