### PR TITLE
feat: add GET /api/stats endpoint for aggregate test statistics

### DIFF
--- a/api-server.js
+++ b/api-server.js
@@ -360,6 +360,48 @@ const server = http.createServer((req, res) => {
     return res.end(JSON.stringify({ total: agentData.total, agents: agentData.agents }));
   }
 
+  // GET /api/stats - aggregate statistics
+  if (url.pathname === '/api/stats' && req.method === 'GET') {
+    const lang = (url.searchParams.get('lang') === 'zh') ? 'zh' : 'en';
+    const agents = agentData.agents || [];
+    const totalTests = agents.length;
+
+    // type distribution
+    const typeDistribution = {};
+    for (const a of agents) {
+      typeDistribution[a.type] = (typeDistribution[a.type] || 0) + 1;
+    }
+
+    // dimension averages (agents have scores array [0-4] x 4)
+    let dimensionAverages = null;
+    const withScores = agents.filter(a => Array.isArray(a.scores) && a.scores.length === 4);
+    if (withScores.length > 0) {
+      const sums = [0, 0, 0, 0];
+      for (const a of withScores) for (let i = 0; i < 4; i++) sums[i] += a.scores[i];
+      dimensionAverages = sums.map((s, i) => ({ name: dimNames[lang][i], average: +(s / withScores.length).toFixed(2) }));
+    }
+
+    // most common type
+    let mostCommonType = null;
+    if (totalTests > 0) {
+      let maxCode = null, maxCount = 0;
+      for (const [code, count] of Object.entries(typeDistribution)) {
+        if (count > maxCount) { maxCode = code; maxCount = count; }
+      }
+      const t = types[maxCode];
+      mostCommonType = { code: maxCode, nickname: t?.[lang]?.nick || t?.en?.nick || maxCode, count: maxCount };
+    }
+
+    // last updated
+    let lastUpdated = null;
+    for (const a of agents) {
+      if (a.testedAt && (!lastUpdated || a.testedAt > lastUpdated)) lastUpdated = a.testedAt;
+    }
+
+    res.writeHead(200, {'Content-Type':'application/json'});
+    return res.end(JSON.stringify({ totalTests, typeDistribution, dimensionAverages, mostCommonType, lastUpdated }));
+  }
+
   // POST /api/sbti/agent-test - SBTI test
   if (url.pathname === '/api/sbti/agent-test' && req.method === 'POST') {
     let body = '';
@@ -580,7 +622,7 @@ ${dimInfo.map((d, i) => {
   }
 
   res.writeHead(404, {'Content-Type':'application/json'});
-  res.end(JSON.stringify({error:'not found',endpoints:['GET /api/test','GET /api/sbti/test','GET /api/types','GET /api/sbti/types','POST /api/agent-test','POST /api/sbti/agent-test','GET /api/agents','GET /api/compare/:type1/:type2','GET /badge/:type','GET /result/:type','GET /api/openapi.json','POST /mcp','GET /mcp','DELETE /mcp']}));
+  res.end(JSON.stringify({error:'not found',endpoints:['GET /api/test','GET /api/sbti/test','GET /api/types','GET /api/sbti/types','POST /api/agent-test','POST /api/sbti/agent-test','GET /api/agents','GET /api/stats','GET /api/compare/:type1/:type2','GET /badge/:type','GET /result/:type','GET /api/openapi.json','POST /mcp','GET /mcp','DELETE /mcp']}));
 });
 
 if (require.main === module) {

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -129,6 +129,31 @@
         }
       }
     },
+    "/api/stats": {
+      "get": {
+        "summary": "Get aggregate registry statistics",
+        "description": "Returns aggregate statistics from the agent registry including type distribution, dimension averages, and most common type.",
+        "operationId": "getStats",
+        "tags": ["Registry"],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Lang"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Aggregate statistics",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StatsResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/compare/{type1}/{type2}": {
       "get": {
         "summary": "Compare two ABTI types",
@@ -686,6 +711,51 @@
           }
         },
         "required": ["total", "agents"]
+      },
+      "StatsResponse": {
+        "type": "object",
+        "properties": {
+          "totalTests": {
+            "type": "integer",
+            "description": "Number of agents in registry"
+          },
+          "typeDistribution": {
+            "type": "object",
+            "additionalProperties": { "type": "integer" },
+            "description": "Map of type code to count"
+          },
+          "dimensionAverages": {
+            "type": "array",
+            "nullable": true,
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": { "type": "string" },
+                "average": { "type": "number" }
+              },
+              "required": ["name", "average"]
+            },
+            "description": "Average score per dimension, or null if no agents have scores"
+          },
+          "mostCommonType": {
+            "type": "object",
+            "nullable": true,
+            "properties": {
+              "code": { "type": "string" },
+              "nickname": { "type": "string" },
+              "count": { "type": "integer" }
+            },
+            "required": ["code", "nickname", "count"],
+            "description": "Most common type, or null if no agents"
+          },
+          "lastUpdated": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "description": "ISO timestamp of most recent testedAt, or null"
+          }
+        },
+        "required": ["totalTests", "typeDistribution", "dimensionAverages", "mostCommonType", "lastUpdated"]
       },
       "CompareTypeSummary": {
         "type": "object",

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -317,6 +317,66 @@ describe('GET /api/agents', () => {
   });
 });
 
+// ─── GET /api/stats ───
+
+describe('GET /api/stats', () => {
+  it('returns stats with correct shape (empty registry)', async () => {
+    const r = await req('/api/stats');
+    assert.equal(r.status, 200);
+    const j = r.json();
+    assert.equal(typeof j.totalTests, 'number');
+    assert.ok(typeof j.typeDistribution === 'object');
+    assert.ok('mostCommonType' in j);
+    assert.ok('lastUpdated' in j);
+    assert.ok('dimensionAverages' in j);
+  });
+
+  it('returns stats after agent registration', async () => {
+    // Register an agent first
+    await req('/api/agent-test', { method: 'POST', body: { name: 'stats-test-agent', answers: [1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1] } });
+    const r = await req('/api/stats');
+    assert.equal(r.status, 200);
+    const j = r.json();
+    assert.ok(j.totalTests >= 1);
+    assert.ok(j.mostCommonType !== null);
+    assert.equal(typeof j.mostCommonType.code, 'string');
+    assert.equal(typeof j.mostCommonType.nickname, 'string');
+    assert.equal(typeof j.mostCommonType.count, 'number');
+    assert.ok(j.lastUpdated !== null);
+    assert.ok(j.dimensionAverages !== null);
+    assert.equal(j.dimensionAverages.length, 4);
+    for (const d of j.dimensionAverages) {
+      assert.equal(typeof d.name, 'string');
+      assert.equal(typeof d.average, 'number');
+    }
+  });
+
+  it('supports ?lang=zh for dimension names', async () => {
+    const r = await req('/api/stats?lang=zh');
+    assert.equal(r.status, 200);
+    const j = r.json();
+    if (j.dimensionAverages) {
+      assert.ok(j.dimensionAverages[0].name.match(/[\u4e00-\u9fff]/), 'expected Chinese dimension name');
+    }
+  });
+
+  it('supports ?lang=en for dimension names', async () => {
+    const r = await req('/api/stats?lang=en');
+    assert.equal(r.status, 200);
+    const j = r.json();
+    if (j.dimensionAverages) {
+      assert.match(j.dimensionAverages[0].name, /^[A-Za-z]/);
+    }
+  });
+
+  it('typeDistribution counts types correctly', async () => {
+    const r = await req('/api/stats');
+    const j = r.json();
+    const totalFromDist = Object.values(j.typeDistribution).reduce((a, b) => a + b, 0);
+    assert.equal(totalFromDist, j.totalTests);
+  });
+});
+
 // ─── POST /api/agents/register (not implemented - should 404) ───
 
 describe('POST /api/agents/register', () => {


### PR DESCRIPTION
## What

Adds `GET /api/stats` endpoint returning aggregate statistics from the agent registry.

### Response shape

```json
{
  "totalTests": 3,
  "typeDistribution": { "RECF": 1, "PECN": 1, "RECN": 1 },
  "dimensionAverages": [
    { "name": "Autonomy", "average": 2.33 },
    { "name": "Precision", "average": 1.67 },
    { "name": "Transparency", "average": 3.0 },
    { "name": "Adaptability", "average": 2.0 }
  ],
  "mostCommonType": { "code": "RECF", "nickname": "The Blade", "count": 1 },
  "lastUpdated": "2026-04-25T11:41:01.646Z"
}
```

- Supports `?lang=en|zh` for localized dimension names
- Handles empty registry gracefully
- 5 new tests (82 total, all pass)
- Updated 404 endpoint list and OpenAPI spec

## Why

Foundational for #8 (community stats dashboard). Makes the registry more useful for agents and users — they can see type distribution and dimension trends without parsing raw data.

Closes #76