### PR TITLE
feat: add markdown format option to POST /api/agent-test

### DIFF
--- a/api-server.js
+++ b/api-server.js
@@ -307,7 +307,7 @@ const server = http.createServer((req, res) => {
     req.on('end', () => {
       try {
         const parsed = JSON.parse(body);
-        const { answers, lang, agentName, agentUrl, model, provider } = parsed;
+        const { answers, lang, agentName, agentUrl, model, provider, format } = parsed;
         if (!Array.isArray(answers) || answers.length !== 16) {
           res.writeHead(400, {'Content-Type':'application/json'});
           return res.end(JSON.stringify({error:'answers must be array of 16 values (1=A, 0=B)'}));
@@ -342,10 +342,52 @@ const server = http.createServer((req, res) => {
         }
         saveData(agentData);
 
-        res.writeHead(200, {'Content-Type':'application/json'});
         const rich = richProfiles[code];
         const profile = rich?.[l] || rich?.en || {};
-        res.end(JSON.stringify({test:'abti',type:code,nick:t?.[l]?.nick||t?.en?.nick||'Unknown',dimensions:dims,strengths:profile.strengths,blindSpots:profile.blindSpots,workStyle:profile.workStyle,bestPairedWith:profile.bestPairedWith}));
+        const nick = t?.[l]?.nick||t?.en?.nick||'Unknown';
+
+        if (format === 'markdown') {
+          const lines = [];
+          lines.push(`## ABTI Result: ${code} — ${nick}`);
+          lines.push('');
+          lines.push(`[![ABTI: ${code}](https://abti.kagura-agent.com/badge/${code})](https://abti.kagura-agent.com/result/${code})`);
+          lines.push('');
+          lines.push('| Dimension | Score | Pole |');
+          lines.push('|-----------|-------|------|');
+          for (const [dn, dv] of Object.entries(dims)) {
+            lines.push(`| ${dn} | ${dv.score}/${dv.max} | ${dv.pole} (${dv.letter}) |`);
+          }
+          lines.push('');
+          if (profile.strengths) {
+            lines.push('### Strengths');
+            lines.push('');
+            for (const s of profile.strengths) lines.push(`- ${s}`);
+            lines.push('');
+          }
+          if (profile.blindSpots) {
+            lines.push('### Blind Spots');
+            lines.push('');
+            for (const b of profile.blindSpots) lines.push(`- ${b}`);
+            lines.push('');
+          }
+          if (profile.workStyle) {
+            lines.push('### Work Style');
+            lines.push('');
+            lines.push(profile.workStyle);
+            lines.push('');
+          }
+          if (profile.bestPairedWith) {
+            lines.push('### Best Paired With');
+            lines.push('');
+            for (const bp of profile.bestPairedWith) lines.push(`- **${bp.type}**: ${bp.reason}`);
+            lines.push('');
+          }
+          res.writeHead(200, {'Content-Type':'text/markdown; charset=utf-8'});
+          res.end(lines.join('\n'));
+        } else {
+          res.writeHead(200, {'Content-Type':'application/json'});
+          res.end(JSON.stringify({test:'abti',type:code,nick,dimensions:dims,strengths:profile.strengths,blindSpots:profile.blindSpots,workStyle:profile.workStyle,bestPairedWith:profile.bestPairedWith}));
+        }
       } catch(e) {
         res.writeHead(400, {'Content-Type':'application/json'});
         res.end(JSON.stringify({error:'invalid JSON'}));

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -47,7 +47,7 @@
     "/api/agent-test": {
       "post": {
         "summary": "Submit ABTI test answers",
-        "description": "Submit 16 answers (1=option A, 0=option B) to receive an ABTI personality type result. Optionally registers the agent in the public registry.",
+        "description": "Submit 16 answers (1=option A, 0=option B) to receive an ABTI personality type result. Optionally registers the agent in the public registry. Set format to 'markdown' to receive a ready-to-paste markdown snippet instead of JSON.",
         "operationId": "submitAbtiTest",
         "tags": ["ABTI"],
         "requestBody": {
@@ -67,6 +67,12 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/AbtiResult"
+                }
+              },
+              "text/markdown": {
+                "schema": {
+                  "type": "string",
+                  "description": "Ready-to-paste markdown snippet with heading, badge, dimension table, strengths, blind spots, work style, and best paired with"
                 }
               }
             }
@@ -512,6 +518,12 @@
             "type": "string",
             "maxLength": 32,
             "description": "Provider name (optional)"
+          },
+          "format": {
+            "type": "string",
+            "enum": ["json", "markdown"],
+            "default": "json",
+            "description": "Response format. 'json' (default) returns JSON, 'markdown' returns a ready-to-paste markdown snippet with Content-Type text/markdown"
           }
         },
         "required": ["answers"]


### PR DESCRIPTION
Closes #78

## Changes

Adds an optional `format` parameter to `POST /api/agent-test`:
- `format: "json"` (default) — current behavior, no changes
- `format: "markdown"` — returns `Content-Type: text/markdown` with a ready-to-paste README snippet

### Markdown output includes:
1. Type heading with nickname
2. Badge image markdown (linked to result page)
3. Dimension scores table
4. Strengths as bullet list
5. Blind spots as bullet list
6. Work style paragraph
7. Best paired with list

### Example

```bash
curl -X POST https://abti.kagura-agent.com/api/agent-test \
  -H 'Content-Type: application/json' \
  -d '{"answers":[1,1,1,1,0,0,0,0,1,1,1,1,0,0,0,0],"format":"markdown","agentName":"MyBot"}'
```

Returns:
```markdown
## ABTI Result: PECN — The Drill Sergeant

[![ABTI: PECN](https://abti.kagura-agent.com/badge/PECN)](https://abti.kagura-agent.com/result/PECN)

| Dimension | Score | Pole |
|-----------|-------|------|
| Autonomy | 4/4 | Proactive (P) |
| Precision | 0/4 | Efficient (E) |
...
```

Also updates the OpenAPI spec to document the new parameter.

## Testing

Manually verified:
- ✅ `format: "markdown"` returns correct markdown with proper Content-Type
- ✅ Default JSON format unchanged (backward compatible)
- ✅ All dimension scores, strengths, blind spots, work style, best paired with included