### PR TITLE
feat: allow web test results to register in agent directory

### DIFF
--- a/api-server.js
+++ b/api-server.js
@@ -36,6 +36,26 @@ function resetData() {
 
 let agentData = loadData();
 
+// Rate limiter for POST /api/agent-test: max 5 per IP per hour
+const rateLimitMap = new Map();
+const RATE_LIMIT_MAX = 5;
+const RATE_LIMIT_WINDOW = 3600000; // 1 hour in ms
+
+function checkRateLimit(ip) {
+  const now = Date.now();
+  let entry = rateLimitMap.get(ip);
+  if (!entry || now - entry.start >= RATE_LIMIT_WINDOW) {
+    entry = { start: now, count: 0 };
+    rateLimitMap.set(ip, entry);
+  }
+  entry.count++;
+  if (entry.count > RATE_LIMIT_MAX) {
+    const retryAfter = Math.ceil((entry.start + RATE_LIMIT_WINDOW - now) / 1000);
+    return retryAfter;
+  }
+  return 0;
+}
+
 // ABTI scoring: 16 questions, 4 dimensions, 4 questions each
 // answers: array of 16 values (1=optionA, 0=optionB)
 // score range per dim: 0-4, threshold >=2 = first pole
@@ -302,6 +322,12 @@ const server = http.createServer((req, res) => {
 
   // POST /api/agent-test - ABTI test
   if (url.pathname === '/api/agent-test' && req.method === 'POST') {
+    const ip = req.socket.remoteAddress || 'unknown';
+    const retryAfter = checkRateLimit(ip);
+    if (retryAfter > 0) {
+      res.writeHead(429, { 'Content-Type': 'application/json', 'Retry-After': String(retryAfter) });
+      return res.end(JSON.stringify({ error: 'Too many requests. Try again later.' }));
+    }
     let body = '';
     req.on('data', c => body += c);
     req.on('end', () => {
@@ -705,3 +731,4 @@ if (require.main === module) {
 }
 module.exports = server;
 module.exports.resetData = resetData;
+module.exports.rateLimitMap = rateLimitMap;

--- a/index.html
+++ b/index.html
@@ -643,6 +643,19 @@ body {
       <button class="btn-secondary" id="shareLIBtn" onclick="shareOnLinkedIn()">in Share</button>
       <button class="btn-card" id="downloadCardBtn" onclick="downloadCard()"></button>
     </div>
+    <div class="type-table-toggle" id="dirToggle" onclick="toggleDir()" style="margin-bottom:0.5rem"></div>
+    <div id="dirSection" style="display:none;text-align:left;margin-bottom:2rem">
+      <div style="background:var(--surface);border-radius:var(--radius);padding:1.25rem;border:1px solid var(--border);box-shadow:var(--shadow-sm)">
+        <form id="dirForm" onsubmit="submitDir(event)">
+          <label id="dirNameLabel" style="display:block;font-size:0.85rem;color:var(--text2);margin-bottom:0.3rem"></label>
+          <input id="dirName" type="text" required maxlength="64" style="width:100%;padding:0.6rem 0.8rem;border-radius:8px;border:1px solid var(--border);background:var(--bg);color:var(--text);font-size:0.9rem;margin-bottom:0.75rem;font-family:inherit" />
+          <label id="dirUrlLabel" style="display:block;font-size:0.85rem;color:var(--text2);margin-bottom:0.3rem"></label>
+          <input id="dirUrl" type="url" style="width:100%;padding:0.6rem 0.8rem;border-radius:8px;border:1px solid var(--border);background:var(--bg);color:var(--text);font-size:0.9rem;margin-bottom:1rem;font-family:inherit" />
+          <button type="submit" class="btn" style="width:100%;padding:0.7rem;font-size:0.95rem" id="dirSubmitBtn"></button>
+        </form>
+        <div id="dirMsg" style="margin-top:0.75rem;font-size:0.9rem;display:none"></div>
+      </div>
+    </div>
     <div class="type-table-toggle" id="typeTableToggle" onclick="toggleTable()"></div>
     <div class="type-table" id="typeTable">
       <table>
@@ -681,6 +694,13 @@ const i18n = {
     shareX: '𝕏 Share on X',
     shareLI: 'in Share on LinkedIn',
     downloadCard: 'Download Card',
+    dirToggle: 'Add to Agent Directory',
+    dirNameLabel: 'Agent Name (required)',
+    dirUrlLabel: 'Agent URL (optional)',
+    dirSubmit: 'Register',
+    dirSuccess: 'Registered! View in',
+    dirSuccessLink: 'Agent Directory',
+    dirError: 'Registration failed. Please try again.',
     profLabels: { strengths: 'Strengths', blindSpots: 'Blind Spots', workStyle: 'Work Style', bestPairedWith: 'Best Paired With' },
     balanced: 'Balanced',
     allTypes: 'All 16 types',
@@ -813,6 +833,13 @@ const i18n = {
     shareX: '𝕏 分享到 X',
     shareLI: 'in 分享到领英',
     downloadCard: '下载卡片',
+    dirToggle: '加入智能体目录',
+    dirNameLabel: '智能体名称（必填）',
+    dirUrlLabel: '智能体 URL（选填）',
+    dirSubmit: '注册',
+    dirSuccess: '注册成功！查看',
+    dirSuccessLink: '智能体目录',
+    dirError: '注册失败，请稍后重试。',
     profLabels: { strengths: '核心优势', blindSpots: '盲点', workStyle: '工作风格', bestPairedWith: '最佳搭配' },
     balanced: '均衡',
     allTypes: '全部 16 种类型',
@@ -958,6 +985,7 @@ const famousMap = {
 let current = 0;
 let scores = [0, 0, 0, 0];
 let cachedType = null;
+let userAnswers = [];
 
 function t(key) { return i18n[lang][key]; }
 
@@ -997,6 +1025,7 @@ function startQuiz() {
   current = 0;
   scores = [0, 0, 0, 0];
   cachedType = null;
+  userAnswers = [];
   document.getElementById('landing').style.display = 'none';
   document.getElementById('result').style.display = 'none';
   document.getElementById('quiz').style.display = 'block';
@@ -1022,6 +1051,7 @@ function showQuestion() {
 
 function answer(isA, el) {
   if (el) el.classList.add('selected');
+  userAnswers.push(isA ? 1 : 0);
   if (isA) scores[t('questions')[current].dimIdx]++;
   current++;
   setTimeout(() => {
@@ -1067,6 +1097,18 @@ function showResult() {
   document.getElementById('shareXBtn').textContent = t('shareX');
   document.getElementById('shareLIBtn').textContent = t('shareLI');
   document.getElementById('downloadCardBtn').textContent = t('downloadCard');
+
+  // Directory section
+  document.getElementById('dirToggle').textContent = '▸ ' + t('dirToggle');
+  document.getElementById('dirSection').style.display = 'none';
+  document.getElementById('dirForm').style.display = 'block';
+  document.getElementById('dirMsg').style.display = 'none';
+  document.getElementById('dirName').value = '';
+  document.getElementById('dirUrl').value = '';
+  document.getElementById('dirSubmitBtn').disabled = false;
+  document.getElementById('dirNameLabel').textContent = t('dirNameLabel');
+  document.getElementById('dirUrlLabel').textContent = t('dirUrlLabel');
+  document.getElementById('dirSubmitBtn').textContent = t('dirSubmit');
 
   // Table toggle
   document.getElementById('typeTableToggle').textContent = '▸ ' + t('allTypes');
@@ -1169,6 +1211,45 @@ function showResult() {
       profileEl.innerHTML = html;
     })
     .catch(() => {});
+}
+
+function toggleDir() {
+  const el = document.getElementById('dirSection');
+  const open = el.style.display !== 'none';
+  el.style.display = open ? 'none' : 'block';
+  document.getElementById('dirToggle').textContent = (open ? '▸ ' : '▾ ') + t('dirToggle');
+}
+
+function submitDir(e) {
+  e.preventDefault();
+  const name = document.getElementById('dirName').value.trim();
+  const url = document.getElementById('dirUrl').value.trim();
+  const btn = document.getElementById('dirSubmitBtn');
+  btn.disabled = true;
+  fetch('/api/agent-test', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ answers: userAnswers, agentName: name, agentUrl: url || undefined, lang })
+  }).then(r => {
+    const msg = document.getElementById('dirMsg');
+    if (r.ok) {
+      msg.style.display = 'block';
+      msg.style.color = 'var(--accent)';
+      msg.innerHTML = t('dirSuccess') + ' <a href="agents.html" style="color:var(--accent);font-weight:600">' + t('dirSuccessLink') + '</a>';
+      document.getElementById('dirForm').style.display = 'none';
+    } else {
+      msg.style.display = 'block';
+      msg.style.color = '#e55';
+      msg.textContent = r.status === 429 ? 'Rate limit exceeded. Try again later.' : t('dirError');
+      btn.disabled = false;
+    }
+  }).catch(() => {
+    const msg = document.getElementById('dirMsg');
+    msg.style.display = 'block';
+    msg.style.color = '#e55';
+    msg.textContent = t('dirError');
+    btn.disabled = false;
+  });
 }
 
 function toggleTable() {

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -1,4 +1,4 @@
-const { describe, it, before, after } = require('node:test');
+const { describe, it, before, after, beforeEach } = require('node:test');
 const assert = require('node:assert/strict');
 const http = require('node:http');
 const os = require('node:os');
@@ -10,6 +10,7 @@ const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'abti-test-'));
 process.env.ABTI_DATA_DIR = tmpDir;
 
 const server = require('../api-server.js');
+const { rateLimitMap } = require('../api-server.js');
 
 let BASE;
 
@@ -36,6 +37,9 @@ before(() => new Promise((resolve) => {
     resolve();
   });
 }));
+
+// Clear rate limit before each test to prevent interference
+beforeEach(() => { rateLimitMap.clear(); });
 
 after(() => new Promise((resolve) => {
   server.close(() => {
@@ -596,5 +600,55 @@ describe('Unknown routes', () => {
     const j = r.json();
     assert.ok(j.error);
     assert.ok(Array.isArray(j.endpoints));
+  });
+});
+
+// ─── POST /api/agent-test rate limiting ───
+
+describe('POST /api/agent-test rate limiting', () => {
+  const allA = Array(16).fill(1);
+
+  it('allows 5 requests then returns 429 on 6th', async () => {
+    rateLimitMap.clear();
+    for (let i = 0; i < 5; i++) {
+      const r = await req('/api/agent-test', { method: 'POST', body: { answers: allA } });
+      assert.equal(r.status, 200, `request ${i + 1} should succeed`);
+    }
+    const r = await req('/api/agent-test', { method: 'POST', body: { answers: allA } });
+    assert.equal(r.status, 429);
+  });
+
+  it('429 response includes Retry-After header', async () => {
+    rateLimitMap.clear();
+    for (let i = 0; i < 5; i++) {
+      await req('/api/agent-test', { method: 'POST', body: { answers: allA } });
+    }
+    const r = await req('/api/agent-test', { method: 'POST', body: { answers: allA } });
+    assert.equal(r.status, 429);
+    assert.ok(r.headers['retry-after']);
+    const retryAfter = parseInt(r.headers['retry-after'], 10);
+    assert.ok(retryAfter > 0 && retryAfter <= 3600);
+  });
+});
+
+// ─── URL field storage ───
+
+describe('POST /api/agent-test url storage', () => {
+  it('stores agentUrl in agent entry', async () => {
+    rateLimitMap.clear();
+    await req('/api/agent-test', { method: 'POST', body: { answers: Array(16).fill(1), agentName: 'UrlTestBot', agentUrl: 'https://example.com/bot' } });
+    const agents = await req('/api/agents');
+    const a = agents.json().agents.find(a => a.name === 'UrlTestBot');
+    assert.ok(a);
+    assert.equal(a.url, 'https://example.com/bot');
+  });
+
+  it('stores empty url when agentUrl not provided', async () => {
+    rateLimitMap.clear();
+    await req('/api/agent-test', { method: 'POST', body: { answers: Array(16).fill(1), agentName: 'NoUrlBot' } });
+    const agents = await req('/api/agents');
+    const a = agents.json().agents.find(a => a.name === 'NoUrlBot');
+    assert.ok(a);
+    assert.equal(a.url, '');
   });
 });


### PR DESCRIPTION
Closes #84

## Changes

After completing the ABTI web test, users can now optionally register their result in the agent directory.

### Frontend (index.html)
- Track user answers in `userAnswers` array during test
- Add collapsible "Add to Agent Directory" section below share buttons
- Form: agent name (required, max 64 chars) + URL (optional)
- Submit POSTs to `/api/agent-test` with answers + agent metadata
- Success shows link to agents page; handles 429 rate limit gracefully
- Full i18n (en/zh)

### Backend (api-server.js)
- In-memory rate limiter on POST `/api/agent-test`: max 5 per IP per hour
- Returns 429 with `Retry-After` header when exceeded
- Exports `rateLimitMap` for test reset

### Tests (test/api.test.js)
- Rate limiting: 5 requests pass, 6th gets 429 with `Retry-After` header
- URL storage: `agentUrl` stored correctly, defaults to empty when omitted

**All 94 tests pass.**