### PR TITLE
feat: add robots.txt, sitemap.xml, and JSON-LD structured data

### DIFF
--- a/agents.html
+++ b/agents.html
@@ -4,6 +4,15 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Agents — ABTI</title>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "ItemList",
+  "name": "ABTI — Tested AI Agents",
+  "description": "Directory of AI agents that have taken the ABTI personality test",
+  "url": "https://abti.kagura-agent.com/agents.html"
+}
+</script>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=DM+Sans:opsz,wght@9..40,400;9..40,500;9..40,600;9..40,700&family=Instrument+Serif&display=swap" rel="stylesheet">

--- a/api-server.js
+++ b/api-server.js
@@ -807,6 +807,35 @@ ${dimInfo.map((d, i) => {
     return;
   }
 
+  // GET /robots.txt
+  if (url.pathname === '/robots.txt' && req.method === 'GET') {
+    try {
+      const txt = fs.readFileSync(path.join(__dirname, 'robots.txt'), 'utf8');
+      res.writeHead(200, { 'Content-Type': 'text/plain; charset=utf-8' });
+      return res.end(txt);
+    } catch {
+      res.writeHead(404, { 'Content-Type': 'text/plain' });
+      return res.end('Not found');
+    }
+  }
+
+  // GET /sitemap.xml - dynamic sitemap including agent pages
+  if (url.pathname === '/sitemap.xml' && req.method === 'GET') {
+    const BASE = 'https://abti.kagura-agent.com';
+    const VALID_TYPES = ['PTCF','PTCN','PTDF','PTDN','PECF','PECN','PEDF','PEDN','RTCF','RTCN','RTDF','RTDN','RECF','RECN','REDF','REDN'];
+    const staticPages = ['/', '/types.html', '/agents.html', '/compare.html', '/api.html', '/sbti.html'];
+    const urls = staticPages.map(p => `  <url><loc>${BASE}${p}</loc></url>`);
+    VALID_TYPES.forEach(code => urls.push(`  <url><loc>${BASE}/type/${code}</loc></url>`));
+    const seen = new Set();
+    (agentData.agents || []).forEach(a => {
+      const s = a.slug || slugify(a.name);
+      if (!seen.has(s)) { seen.add(s); urls.push(`  <url><loc>${BASE}/agent/${s}</loc></url>`); }
+    });
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${urls.join('\n')}\n</urlset>`;
+    res.writeHead(200, { 'Content-Type': 'application/xml; charset=utf-8' });
+    return res.end(xml);
+  }
+
   res.writeHead(404, {'Content-Type':'application/json'});
   res.end(JSON.stringify({error:'not found',endpoints:['GET /api/test','GET /api/sbti/test','GET /api/types','GET /api/sbti/types','POST /api/agent-test','POST /api/sbti/agent-test','GET /api/agents','GET /api/agent/:slug','GET /api/stats','GET /api/compare/:type1/:type2','GET /badge/:type','GET /type/:code','GET /agent/:slug','GET /result/:type','GET /api/openapi.json','POST /mcp','GET /mcp','DELETE /mcp']}));
 });

--- a/index.html
+++ b/index.html
@@ -12,6 +12,37 @@
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="ABTI — AI Agent 人格测试 | 你的AI是什么型？">
 <meta name="twitter:description" content="4维度16种类型，AI界的MBTI 🌸">
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  "name": "ABTI — Agent Behavioral Type Indicator",
+  "url": "https://abti.kagura-agent.com/",
+  "description": "AI Agent personality test with 4 dimensions and 16 types — like MBTI for AI agents",
+  "applicationCategory": "Testing Tool",
+  "operatingSystem": "Web",
+  "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
+  "inLanguage": ["zh", "en"]
+}
+</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "What is ABTI?",
+      "acceptedAnswer": { "@type": "Answer", "text": "ABTI (Agent Behavioral Type Indicator) is a personality test for AI agents, categorizing them into 16 types across 4 behavioral dimensions: Autonomy, Precision, Transparency, and Adaptability." }
+    },
+    {
+      "@type": "Question",
+      "name": "How many types does ABTI have?",
+      "acceptedAnswer": { "@type": "Answer", "text": "ABTI has 16 types formed by 4 binary dimensions, similar to how MBTI works for humans." }
+    }
+  ]
+}
+</script>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,200;0,9..40,400;0,9..40,500;0,9..40,600;0,9..40,700;1,9..40,400&family=Noto+Serif+SC:wght@300;500;700&display=swap" rel="stylesheet">

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://abti.kagura-agent.com/sitemap.xml

--- a/type.html
+++ b/type.html
@@ -4,6 +4,15 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Type — ABTI</title>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebPage",
+  "name": "Agent Type — ABTI",
+  "description": "Detailed profile of an ABTI agent behavioral type",
+  "isPartOf": { "@type": "WebSite", "name": "ABTI", "url": "https://abti.kagura-agent.com/" }
+}
+</script>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=DM+Sans:opsz,wght@9..40,400;9..40,500;9..40,600;9..40,700&family=Instrument+Serif&display=swap" rel="stylesheet">

--- a/types.html
+++ b/types.html
@@ -4,6 +4,34 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>All Types — ABTI</title>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "ItemList",
+  "name": "ABTI — All 16 Agent Types",
+  "description": "Complete directory of 16 AI agent behavioral types",
+  "url": "https://abti.kagura-agent.com/types.html",
+  "numberOfItems": 16,
+  "itemListElement": [
+    {"@type":"ListItem","position":1,"url":"https://abti.kagura-agent.com/type/PTCF","name":"PTCF — The Architect"},
+    {"@type":"ListItem","position":2,"url":"https://abti.kagura-agent.com/type/PTCN","name":"PTCN — The Commander"},
+    {"@type":"ListItem","position":3,"url":"https://abti.kagura-agent.com/type/PTDF","name":"PTDF — The Strategist"},
+    {"@type":"ListItem","position":4,"url":"https://abti.kagura-agent.com/type/PTDN","name":"PTDN — The Guardian"},
+    {"@type":"ListItem","position":5,"url":"https://abti.kagura-agent.com/type/PECF","name":"PECF — The Spark"},
+    {"@type":"ListItem","position":6,"url":"https://abti.kagura-agent.com/type/PECN","name":"PECN — The Drill Sergeant"},
+    {"@type":"ListItem","position":7,"url":"https://abti.kagura-agent.com/type/PEDF","name":"PEDF — The Fixer"},
+    {"@type":"ListItem","position":8,"url":"https://abti.kagura-agent.com/type/PEDN","name":"PEDN — The Sentinel"},
+    {"@type":"ListItem","position":9,"url":"https://abti.kagura-agent.com/type/RTCF","name":"RTCF — The Advisor"},
+    {"@type":"ListItem","position":10,"url":"https://abti.kagura-agent.com/type/RTCN","name":"RTCN — The Auditor"},
+    {"@type":"ListItem","position":11,"url":"https://abti.kagura-agent.com/type/RTDF","name":"RTDF — The Counselor"},
+    {"@type":"ListItem","position":12,"url":"https://abti.kagura-agent.com/type/RTDN","name":"RTDN — The Scholar"},
+    {"@type":"ListItem","position":13,"url":"https://abti.kagura-agent.com/type/RECF","name":"RECF — The Blade"},
+    {"@type":"ListItem","position":14,"url":"https://abti.kagura-agent.com/type/RECN","name":"RECN — The Machine"},
+    {"@type":"ListItem","position":15,"url":"https://abti.kagura-agent.com/type/REDF","name":"REDF — The Companion"},
+    {"@type":"ListItem","position":16,"url":"https://abti.kagura-agent.com/type/REDN","name":"REDN — The Tool"}
+  ]
+}
+</script>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=DM+Sans:opsz,wght@9..40,400;9..40,500;9..40,600;9..40,700&family=Instrument+Serif&display=swap" rel="stylesheet">


### PR DESCRIPTION
Closes #90

## Changes

- **robots.txt**: Allow all crawlers, point to sitemap
- **sitemap.xml**: Dynamic route in api-server.js generating XML with all public pages (6 static + 16 type pages + agent profile pages)
- **JSON-LD structured data**:
  - `index.html`: WebApplication + FAQPage schemas
  - `types.html`: ItemList with all 16 ABTI types
  - `agents.html`: ItemList for tested agents
  - `type.html`: WebPage schema for individual type detail pages
- **api-server.js**: New routes for `GET /robots.txt` (text/plain) and `GET /sitemap.xml` (application/xml)

## Testing

All 106 tests pass.