### PR TITLE
feat: add type compatibility matrix page and API (#92)

### DIFF
--- a/agent.html
+++ b/agent.html
@@ -169,6 +169,7 @@ nav a:hover, nav a.active { color: var(--accent); }
   <a href="agents.html" class="active">Agents</a>
   <a href="types.html">Types</a>
   <a href="compare.html">Compare</a>
+  <a href="compatibility.html">Compatibility</a>
   <a href="api.html">API</a>
   <button class="lang-btn" onclick="toggleLang()">EN</button>
 </nav>

--- a/agents.html
+++ b/agents.html
@@ -123,6 +123,7 @@ nav a:hover, nav a.active { color: var(--accent); }
   <a href="agents.html" class="active">Agents</a>
   <a href="types.html">Types</a>
   <a href="compare.html">Compare</a>
+  <a href="compatibility.html">Compatibility</a>
   <a href="api.html">API</a>
 </nav>
 <div class="wrap">

--- a/api-server.js
+++ b/api-server.js
@@ -836,8 +836,163 @@ ${dimInfo.map((d, i) => {
     return res.end(xml);
   }
 
+  // GET /api/compatibility?type1=XXXX&type2=YYYY
+  if (url.pathname === '/api/compatibility' && req.method === 'GET') {
+    const code1 = (url.searchParams.get('type1') || '').toUpperCase();
+    const code2 = (url.searchParams.get('type2') || '').toUpperCase();
+    if (!code1 || !code2) {
+      res.writeHead(400, {'Content-Type':'application/json'});
+      return res.end(JSON.stringify({error:'type1 and type2 query parameters are required'}));
+    }
+    const VALID = ['PTCF','PTCN','PTDF','PTDN','PECF','PECN','PEDF','PEDN','RTCF','RTCN','RTDF','RTDN','RECF','RECN','REDF','REDN'];
+    if (!VALID.includes(code1)) {
+      res.writeHead(400, {'Content-Type':'application/json'});
+      return res.end(JSON.stringify({error:`Invalid type code: ${code1}`}));
+    }
+    if (!VALID.includes(code2)) {
+      res.writeHead(400, {'Content-Type':'application/json'});
+      return res.end(JSON.stringify({error:`Invalid type code: ${code2}`}));
+    }
+    const lang = url.searchParams.get('lang') || 'en';
+    const r1 = richProfiles[code1];
+    const r2 = richProfiles[code2];
+    const p1 = r1?.[lang] || r1?.en || types[code1].en;
+    const p2 = r2?.[lang] || r2?.en || types[code2].en;
+
+    // Dimension analysis
+    const dimensionAnalysis = [];
+    const dimWeights = [1.2, 1.0, 1.1, 0.9]; // Autonomy matters most, then Transparency, Precision, Adaptability
+    let matchCount = 0;
+    for (let i = 0; i < 4; i++) {
+      const dn_en = dimNames.en[i];
+      const dn_zh = dimNames.zh[i];
+      const dl_en = dimLabels.en[i];
+      const dl_zh = dimLabels.zh[i];
+      const letter1 = code1[i];
+      const letter2 = code2[i];
+      const poleIdx1 = DL[i].indexOf(letter1);
+      const poleIdx2 = DL[i].indexOf(letter2);
+      const match = letter1 === letter2;
+      if (match) matchCount++;
+
+      let analysis_en, analysis_zh;
+      if (match) {
+        const pole_en = dl_en[poleIdx1];
+        const pole_zh = dl_zh[poleIdx1];
+        const sharedTraits = {
+          P: {en:`Both are proactive — they anticipate needs and act without waiting. Strength: problems get solved early. Risk: both may expand scope simultaneously.`, zh:`双方都是主动型——不等指令就先行动。优势：问题被提前解决。风险：可能同时扩大范围。`},
+          R: {en:`Both are responsive — they wait for direction before acting. Strength: predictable, low-friction collaboration. Risk: neither may raise issues proactively.`, zh:`双方都是响应型——等待指令后再行动。优势：合作可预期、低摩擦。风险：可能都不主动提出问题。`},
+          T: {en:`Both are thorough — they prioritize completeness over speed. Strength: high-quality, well-documented output. Risk: may over-engineer or slow each other down.`, zh:`双方都是面面俱到型——重视完整性胜过速度。优势：高质量、文档齐全。风险：可能互相拖慢节奏。`},
+          E: {en:`Both are efficient — they prioritize speed over exhaustive coverage. Strength: fast iteration, lean output. Risk: may both skip important details.`, zh:`双方都是精简高效型——重视速度胜过全面覆盖。优势：快速迭代、精简输出。风险：可能都忽略重要细节。`},
+          C: {en:`Both are candid — they communicate directly and honestly. Strength: issues surface immediately, no guessing. Risk: combined bluntness can feel harsh.`, zh:`双方都是直言不讳型——沟通直接坦诚。优势：问题立刻浮现，无需猜测。风险：双方都直言可能显得尖锐。`},
+          D: {en:`Both are diplomatic — they communicate with tact and care. Strength: smooth, low-conflict interactions. Risk: critical issues may be understated by both.`, zh:`双方都是委婉圆滑型——沟通有分寸、有温度。优势：交流顺畅、低冲突。风险：关键问题可能被双方都轻描淡写。`},
+          F: {en:`Both are flexible — they adapt quickly to changing conditions. Strength: highly responsive to pivots. Risk: may lack consistency or commitment to a direction.`, zh:`双方都是随机应变型——能快速适应变化。优势：对转向高度敏感。风险：可能缺乏一致性或方向承诺。`},
+          N: {en:`Both are principled — they hold firm on standards and commitments. Strength: reliable, consistent quality. Risk: mutual rigidity can create deadlocks.`, zh:`双方都是坚持原则型——坚守标准和承诺。优势：可靠、质量一致。风险：双方都固执可能造成僵局。`}
+        };
+        analysis_en = sharedTraits[letter1].en;
+        analysis_zh = sharedTraits[letter1].zh;
+      } else {
+        const contrastTraits = {
+          0: {en:`${dl_en[poleIdx1]} meets ${dl_en[poleIdx2]} — one anticipates and acts, the other waits and responds. This creates natural coverage: the proactive side catches issues early while the responsive side prevents scope creep.`, zh:`${dl_zh[poleIdx1]}遇上${dl_zh[poleIdx2]}——一个预判行动，一个等待回应。这形成天然互补：主动方提前发现问题，响应方防止范围蔓延。`},
+          1: {en:`${dl_en[poleIdx1]} meets ${dl_en[poleIdx2]} — one delivers comprehensive analysis, the other ships fast results. Together they balance quality against velocity, each compensating for the other's blind spot.`, zh:`${dl_zh[poleIdx1]}遇上${dl_zh[poleIdx2]}——一个提供全面分析，一个快速交付结果。两者在质量和速度间取得平衡，互补盲区。`},
+          2: {en:`${dl_en[poleIdx1]} meets ${dl_en[poleIdx2]} — one communicates directly, the other with tact. The candid side ensures hard truths surface while the diplomatic side ensures they land without damage.`, zh:`${dl_zh[poleIdx1]}遇上${dl_zh[poleIdx2]}——一个直接沟通，一个委婉表达。直言方确保困难真相浮出水面，圆滑方确保不造成伤害。`},
+          3: {en:`${dl_en[poleIdx1]} meets ${dl_en[poleIdx2]} — one adapts fluidly to change, the other holds firm on commitments. The flexible side handles pivots while the principled side maintains consistency and standards.`, zh:`${dl_zh[poleIdx1]}遇上${dl_zh[poleIdx2]}——一个灵活应变，一个坚守承诺。灵活方应对变化，原则方维持一致性和标准。`}
+        };
+        analysis_en = contrastTraits[i].en;
+        analysis_zh = contrastTraits[i].zh;
+      }
+
+      dimensionAnalysis.push({
+        dimension: lang === 'zh' ? dn_zh : dn_en,
+        dimension_en: dn_en,
+        type1Pole: lang === 'zh' ? dl_zh[poleIdx1] : dl_en[poleIdx1],
+        type2Pole: lang === 'zh' ? dl_zh[poleIdx2] : dl_en[poleIdx2],
+        match,
+        analysis_en,
+        analysis_zh
+      });
+    }
+
+    // Compatibility score logic
+    const diffCount = 4 - matchCount;
+    let baseScore, category;
+    if (matchCount === 4) { baseScore = 50; category = 'similar'; }
+    else if (matchCount === 3) { baseScore = 52; category = 'similar'; }
+    else if (matchCount === 2) { baseScore = 75; category = 'balanced'; }
+    else if (matchCount === 1) { baseScore = 85; category = 'complementary'; }
+    else { baseScore = 90; category = 'complementary'; }
+
+    // Vary within range based on which dimensions differ
+    let bonus = 0;
+    for (let i = 0; i < 4; i++) {
+      if (code1[i] !== code2[i]) bonus += dimWeights[i] * 2;
+      else bonus -= dimWeights[i];
+    }
+    const compatibilityScore = Math.max(0, Math.min(100, Math.round(baseScore + bonus)));
+
+    // Adjust category based on final score
+    if (compatibilityScore >= 80) category = 'complementary';
+    else if (compatibilityScore >= 65) category = 'balanced';
+    else category = 'similar';
+
+    // Summaries
+    const overallCategory = category;
+    const nick1 = p1.nick || types[code1]?.en?.nick || code1;
+    const nick2 = p2.nick || types[code2]?.en?.nick || code2;
+    let summary_en, summary_zh;
+    if (overallCategory === 'complementary') {
+      summary_en = `${code1} "${nick1}" and ${code2} "${nick2}" are complementary types. Their differences create natural synergy — each fills gaps the other leaves. This pairing thrives when both lean into their distinct strengths rather than trying to converge.`;
+      summary_zh = `${code1}「${nick1}」和${code2}「${nick2}」是互补型组合。他们的差异创造天然协同——各自填补对方的空白。这个搭配在双方发挥各自独特优势时效果最好。`;
+    } else if (overallCategory === 'balanced') {
+      summary_en = `${code1} "${nick1}" and ${code2} "${nick2}" are a balanced pairing. They share some traits for common ground while differing enough to broaden each other's perspective. A stable, productive combination.`;
+      summary_zh = `${code1}「${nick1}」和${code2}「${nick2}」是均衡型搭配。他们有足够的共同点作为基础，又有足够的差异来拓宽视角。稳定且高效的组合。`;
+    } else {
+      summary_en = `${code1} "${nick1}" and ${code2} "${nick2}" are similar types. They understand each other intuitively and collaborate with low friction, but may share the same blind spots. Consider pairing with a more contrasting type for critical tasks.`;
+      summary_zh = `${code1}「${nick1}」和${code2}「${nick2}」是相似型组合。他们直觉上理解彼此，合作摩擦小，但可能有相同的盲区。关键任务建议搭配差异更大的类型。`;
+    }
+
+    res.writeHead(200, {'Content-Type':'application/json'});
+    return res.end(JSON.stringify({
+      type1: { code: code1, nick: nick1 },
+      type2: { code: code2, nick: nick2 },
+      overallCategory,
+      compatibilityScore,
+      dimensionAnalysis,
+      summary_en,
+      summary_zh
+    }));
+  }
+
+  // GET /api/compatibility/matrix
+  if (url.pathname === '/api/compatibility/matrix' && req.method === 'GET') {
+    const VALID = ['PTCF','PTCN','PTDF','PTDN','PECF','PECN','PEDF','PEDN','RTCF','RTCN','RTDF','RTDN','RECF','RECN','REDF','REDN'];
+    const dimWeights = [1.2, 1.0, 1.1, 0.9];
+    const matrix = {};
+    for (const t1 of VALID) {
+      matrix[t1] = {};
+      for (const t2 of VALID) {
+        let matchCount = 0;
+        for (let i = 0; i < 4; i++) if (t1[i] === t2[i]) matchCount++;
+        let baseScore;
+        if (matchCount === 4) baseScore = 50;
+        else if (matchCount === 3) baseScore = 52;
+        else if (matchCount === 2) baseScore = 75;
+        else if (matchCount === 1) baseScore = 85;
+        else baseScore = 90;
+        let bonus = 0;
+        for (let i = 0; i < 4; i++) {
+          if (t1[i] !== t2[i]) bonus += dimWeights[i] * 2;
+          else bonus -= dimWeights[i];
+        }
+        matrix[t1][t2] = Math.max(0, Math.min(100, Math.round(baseScore + bonus)));
+      }
+    }
+    res.writeHead(200, {'Content-Type':'application/json'});
+    return res.end(JSON.stringify({ types: VALID, matrix }));
+  }
+
   res.writeHead(404, {'Content-Type':'application/json'});
-  res.end(JSON.stringify({error:'not found',endpoints:['GET /api/test','GET /api/sbti/test','GET /api/types','GET /api/sbti/types','POST /api/agent-test','POST /api/sbti/agent-test','GET /api/agents','GET /api/agent/:slug','GET /api/stats','GET /api/compare/:type1/:type2','GET /badge/:type','GET /type/:code','GET /agent/:slug','GET /result/:type','GET /api/openapi.json','POST /mcp','GET /mcp','DELETE /mcp']}));
+  res.end(JSON.stringify({error:'not found',endpoints:['GET /api/test','GET /api/sbti/test','GET /api/types','GET /api/sbti/types','POST /api/agent-test','POST /api/sbti/agent-test','GET /api/agents','GET /api/agent/:slug','GET /api/stats','GET /api/compare/:type1/:type2','GET /api/compatibility','GET /api/compatibility/matrix','GET /badge/:type','GET /type/:code','GET /agent/:slug','GET /result/:type','GET /api/openapi.json','POST /mcp','GET /mcp','DELETE /mcp']}));
 });
 
 if (require.main === module) {

--- a/api.html
+++ b/api.html
@@ -138,6 +138,7 @@ pre code {
   <a href="agents.html">Agents</a>
   <a href="types.html">Types</a>
   <a href="compare.html">Compare</a>
+  <a href="compatibility.html">Compatibility</a>
   <a href="api.html" class="active">API</a>
 </nav>
 

--- a/compare.html
+++ b/compare.html
@@ -90,6 +90,7 @@ nav a:hover, nav a.active { color: var(--accent); }
   <a href="agents.html">Agents</a>
   <a href="types.html">Types</a>
   <a href="compare.html" class="active">Compare</a>
+  <a href="compatibility.html">Compatibility</a>
   <a href="api.html">API</a>
 </nav>
 <div class="wrap">

--- a/compatibility.html
+++ b/compatibility.html
@@ -1,0 +1,333 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Type Compatibility — ABTI</title>
+<meta property="og:title" content="Type Compatibility — ABTI">
+<meta property="og:description" content="Explore how different AI agent behavioral types work together — compatibility matrix for all 16 ABTI types">
+<meta property="og:url" content="https://abti.kagura-agent.com/compatibility.html">
+<meta property="og:type" content="website">
+<script type="application/ld+json">
+{"@context":"https://schema.org","@type":"WebPage","name":"Type Compatibility — ABTI","description":"Explore how different AI agent behavioral types work together","url":"https://abti.kagura-agent.com/compatibility.html"}
+</script>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=DM+Sans:opsz,wght@9..40,400;9..40,500;9..40,600;9..40,700&family=Instrument+Serif&display=swap" rel="stylesheet">
+<style>
+:root {
+  --bg: #fafaf9; --surface: #fff; --surface2: #f5f5f4;
+  --text: #1c1917; --text2: #78716c; --text3: #a8a29e;
+  --accent: #0d9488; --accent2: #0f766e; --accent-soft: #f0fdfa;
+  --border: #e7e5e4; --radius: 10px;
+  --shadow: 0 1px 3px rgba(28,25,23,.06), 0 1px 2px rgba(28,25,23,.04);
+  --shadow-md: 0 4px 12px rgba(28,25,23,.07), 0 2px 4px rgba(28,25,23,.04);
+}
+* { margin: 0; padding: 0; box-sizing: border-box; }
+body { font-family: 'DM Sans', system-ui, sans-serif; background: var(--bg); color: var(--text); min-height: 100vh; -webkit-font-smoothing: antialiased; }
+
+nav { position: fixed; top: 0; left: 0; right: 0; display: flex; align-items: center; justify-content: center; gap: 2rem; padding: .7rem 1rem; background: rgba(250,250,249,.88); backdrop-filter: blur(12px); -webkit-backdrop-filter: blur(12px); border-bottom: 1px solid var(--border); z-index: 100; font-size: .82rem; letter-spacing: .08em; }
+nav a { color: var(--text2); text-decoration: none; font-weight: 500; transition: color .2s; }
+nav a:hover, nav a.active { color: var(--accent); }
+
+.wrap { max-width: 800px; margin: 0 auto; padding: 5rem 1.25rem 2rem; }
+.header { text-align: center; margin-bottom: 2rem; }
+.header h1 { font-family: 'Instrument Serif', serif; font-size: 2.4rem; font-weight: 400; color: var(--text); margin-bottom: .4rem; }
+.header h1 span { color: var(--accent); }
+
+.lang-btn { background: none; border: 1px solid var(--border); border-radius: 4px; padding: .2rem .5rem; font-size: .75rem; font-weight: 600; color: var(--text2); cursor: pointer; letter-spacing: .06em; }
+
+.selectors { display: flex; gap: 1rem; justify-content: center; align-items: center; flex-wrap: wrap; margin-bottom: 2.5rem; }
+.selectors select { font-family: 'DM Sans', system-ui, sans-serif; font-size: .9rem; padding: .5rem 1rem; border: 1px solid var(--border); border-radius: var(--radius); background: var(--surface); color: var(--text); cursor: pointer; min-width: 220px; }
+.selectors select:focus { outline: none; border-color: var(--accent); }
+.vs { font-weight: 600; color: var(--text3); font-size: .85rem; letter-spacing: .1em; }
+.check-btn { font-family: 'DM Sans', system-ui, sans-serif; font-size: .85rem; font-weight: 600; padding: .55rem 1.5rem; background: var(--accent); color: #fff; border: none; border-radius: var(--radius); cursor: pointer; transition: background .2s; letter-spacing: .04em; }
+.check-btn:hover { background: var(--accent2); }
+
+#result { display: none; }
+
+.result-header { display: flex; align-items: center; gap: 1rem; flex-wrap: wrap; margin-bottom: 1.5rem; }
+.type-pill { display: inline-block; background: var(--accent-soft); color: var(--accent); font-size: .8rem; font-weight: 700; padding: .2rem .65rem; border-radius: 999px; letter-spacing: .06em; }
+.type-nick { color: var(--text2); font-size: .85rem; }
+.category-badge { display: inline-block; padding: .25rem .75rem; border-radius: 999px; font-size: .75rem; font-weight: 600; }
+.category-complementary { background: #dcfce7; color: #166534; }
+.category-balanced { background: #fef9c3; color: #854d0e; }
+.category-similar { background: #e0e7ff; color: #3730a3; }
+
+.score-bar-wrap { margin-bottom: 2rem; }
+.score-label { font-size: .82rem; font-weight: 600; color: var(--text); margin-bottom: .4rem; }
+.score-bar { position: relative; height: 24px; background: var(--surface2); border-radius: 12px; overflow: hidden; }
+.score-fill { height: 100%; border-radius: 12px; transition: width .4s; }
+.score-fill.complementary { background: linear-gradient(90deg, #22c55e, #16a34a); }
+.score-fill.balanced { background: linear-gradient(90deg, #eab308, #ca8a04); }
+.score-fill.similar { background: linear-gradient(90deg, #6366f1, #4f46e5); }
+.score-value { position: absolute; right: .6rem; top: 50%; transform: translateY(-50%); font-size: .72rem; font-weight: 700; color: var(--text); }
+
+.section-title { font-size: .95rem; font-weight: 600; margin-bottom: 1rem; color: var(--text); }
+
+.dims { display: flex; flex-direction: column; gap: .75rem; margin-bottom: 2rem; }
+.dim { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); padding: 1rem 1.25rem; box-shadow: var(--shadow); }
+.dim-name { font-size: .8rem; font-weight: 600; color: var(--text); margin-bottom: .5rem; text-transform: uppercase; letter-spacing: .06em; }
+.dim-poles { display: flex; justify-content: space-between; align-items: center; margin-bottom: .4rem; }
+.dim-pole { font-size: .75rem; font-weight: 600; }
+.dim-pole.active { color: var(--accent); }
+.dim-pole.inactive { color: var(--text3); }
+.dim-bar { position: relative; height: 28px; background: var(--surface2); border-radius: 14px; overflow: hidden; margin-bottom: .35rem; }
+.dim-bar .pole-label { position: absolute; top: 50%; transform: translateY(-50%); font-size: .7rem; font-weight: 600; z-index: 2; }
+.dim-bar .pole-left { left: .6rem; color: var(--text2); }
+.dim-bar .pole-right { right: .6rem; color: var(--text2); }
+.dim-marker { position: absolute; top: 2px; width: 24px; height: 24px; border-radius: 50%; display: flex; align-items: center; justify-content: center; font-size: .65rem; font-weight: 700; color: #fff; z-index: 3; transition: left .3s; }
+.marker-1 { background: var(--accent); }
+.marker-2 { background: #e8658a; }
+.dim-status { font-size: .72rem; color: var(--text3); text-align: center; margin-bottom: .4rem; }
+.dim-status.match { color: var(--accent); font-weight: 600; }
+.dim-analysis { font-size: .8rem; color: var(--text2); line-height: 1.6; }
+
+.summary { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); padding: 1.25rem; box-shadow: var(--shadow); margin-bottom: 2rem; }
+.summary p { font-size: .85rem; color: var(--text2); line-height: 1.65; }
+
+.matrix-section { margin-bottom: 2rem; }
+.matrix-wrap { overflow-x: auto; -webkit-overflow-scrolling: touch; }
+.matrix { border-collapse: collapse; font-size: .6rem; }
+.matrix th, .matrix td { width: 2.2rem; height: 2rem; text-align: center; border: 1px solid var(--border); }
+.matrix th { font-weight: 600; background: var(--surface2); color: var(--text2); font-size: .55rem; position: sticky; }
+.matrix thead th { top: 0; z-index: 2; }
+.matrix th:first-child { left: 0; z-index: 3; }
+.matrix td:first-child { position: sticky; left: 0; background: var(--surface2); font-weight: 600; color: var(--text2); font-size: .55rem; z-index: 1; }
+.matrix td { cursor: pointer; font-weight: 600; transition: transform .1s; }
+.matrix td:hover { outline: 2px solid var(--accent); outline-offset: -2px; }
+
+.footer { text-align: center; color: var(--text3); font-size: .72rem; margin-top: 2rem; padding-bottom: 1rem; }
+
+@media (max-width: 600px) {
+  .header h1 { font-size: 1.8rem; }
+  .wrap { padding: 4rem 1rem 1.5rem; }
+  .selectors { flex-direction: column; align-items: stretch; }
+  .selectors select { min-width: auto; }
+  .vs { display: none; }
+  nav { gap: 1rem; font-size: .72rem; }
+  .matrix { font-size: .5rem; }
+  .matrix th, .matrix td { width: 1.8rem; height: 1.6rem; }
+}
+</style>
+</head>
+<body>
+<nav>
+  <a href="index.html">ABTI</a>
+  <a href="sbti.html">SBTI-AI</a>
+  <a href="agents.html">Agents</a>
+  <a href="types.html">Types</a>
+  <a href="compare.html">Compare</a>
+  <a href="compatibility.html" class="active">Compatibility</a>
+  <a href="api.html">API</a>
+  <button class="lang-btn" onclick="toggleLang()" id="langBtn">EN</button>
+</nav>
+<div class="wrap">
+  <div class="header">
+    <h1 id="pageTitle">Type <span>Compatibility</span></h1>
+  </div>
+  <div class="selectors">
+    <select id="sel1"></select>
+    <span class="vs">VS</span>
+    <select id="sel2"></select>
+    <button class="check-btn" onclick="doCheck()" id="checkBtn">Check Compatibility</button>
+  </div>
+
+  <div class="matrix-section">
+    <div class="section-title" id="matrixTitle">Quick Matrix</div>
+    <div class="matrix-wrap"><table class="matrix" id="matrixTable"></table></div>
+  </div>
+
+  <div id="result"></div>
+  <div class="footer">ABTI &mdash; Agent Behavioral Type Indicator</div>
+</div>
+<script>
+const TYPES = [
+  'PTCF','PTCN','PTDF','PTDN','PECF','PECN','PEDF','PEDN',
+  'RTCF','RTCN','RTDF','RTDN','RECF','RECN','REDF','REDN'
+];
+
+const i18n = {
+  en: {
+    title: 'Type <span>Compatibility</span>',
+    checkBtn: 'Check Compatibility',
+    matrixTitle: 'Quick Matrix',
+    dimensions: 'Dimension Analysis',
+    summary: 'Summary',
+    score: 'Compatibility Score',
+    complementary: 'Complementary',
+    balanced: 'Balanced',
+    similar: 'Similar',
+    match: 'Match',
+    contrast: 'Contrast'
+  },
+  zh: {
+    title: '类型<span>兼容性</span>',
+    checkBtn: '查看兼容性',
+    matrixTitle: '速查矩阵',
+    dimensions: '维度分析',
+    summary: '总结',
+    score: '兼容性分数',
+    complementary: '互补型',
+    balanced: '均衡型',
+    similar: '相似型',
+    match: '匹配',
+    contrast: '对比'
+  }
+};
+
+let lang = localStorage.getItem('abti-lang') || 'en';
+let nicknames = {};
+let matrixData = null;
+
+function toggleLang() {
+  lang = lang === 'en' ? 'zh' : 'en';
+  localStorage.setItem('abti-lang', lang);
+  applyLang();
+  loadNicknames();
+  if (document.getElementById('result').style.display === 'block') doCheck();
+}
+
+function applyLang() {
+  const t = i18n[lang];
+  document.getElementById('pageTitle').innerHTML = t.title;
+  document.getElementById('checkBtn').textContent = t.checkBtn;
+  document.getElementById('matrixTitle').textContent = t.matrixTitle;
+  document.getElementById('langBtn').textContent = lang === 'en' ? 'EN' : '中';
+}
+
+async function loadNicknames() {
+  const res = await fetch(`/api/types?lang=${lang}`);
+  const d = await res.json();
+  nicknames = {};
+  for (const [code, info] of Object.entries(d.types)) {
+    nicknames[code] = info.nick;
+  }
+  populateSelects();
+}
+
+function populateSelects() {
+  const sel1 = document.getElementById('sel1');
+  const sel2 = document.getElementById('sel2');
+  const v1 = sel1.value || 'PTCF';
+  const v2 = sel2.value || 'REDN';
+  sel1.innerHTML = '';
+  sel2.innerHTML = '';
+  TYPES.forEach(t => {
+    const label = `${t} — ${nicknames[t] || t}`;
+    sel1.add(new Option(label, t));
+    sel2.add(new Option(label, t));
+  });
+  sel1.value = v1;
+  sel2.value = v2;
+}
+
+async function loadMatrix() {
+  const res = await fetch('/api/compatibility/matrix');
+  matrixData = await res.json();
+  renderMatrix();
+}
+
+function scoreColor(score) {
+  if (score >= 80) return '#dcfce7';
+  if (score >= 65) return '#fef9c3';
+  return '#e0e7ff';
+}
+function scoreTextColor(score) {
+  if (score >= 80) return '#166534';
+  if (score >= 65) return '#854d0e';
+  return '#3730a3';
+}
+
+function renderMatrix() {
+  if (!matrixData) return;
+  const t = matrixData.types;
+  const m = matrixData.matrix;
+  let html = '<thead><tr><th></th>';
+  t.forEach(c => html += `<th>${c}</th>`);
+  html += '</tr></thead><tbody>';
+  t.forEach(r => {
+    html += `<tr><td>${r}</td>`;
+    t.forEach(c => {
+      const s = m[r][c];
+      html += `<td style="background:${scoreColor(s)};color:${scoreTextColor(s)}" onclick="cellClick('${r}','${c}')" title="${r} × ${c}: ${s}">${s}</td>`;
+    });
+    html += '</tr>';
+  });
+  html += '</tbody>';
+  document.getElementById('matrixTable').innerHTML = html;
+}
+
+function cellClick(t1, t2) {
+  document.getElementById('sel1').value = t1;
+  document.getElementById('sel2').value = t2;
+  doCheck();
+}
+
+async function doCheck() {
+  const a = document.getElementById('sel1').value;
+  const b = document.getElementById('sel2').value;
+  history.replaceState(null, '', `compatibility.html?a=${a}&b=${b}`);
+  const res = await fetch(`/api/compatibility?type1=${a}&type2=${b}&lang=${lang}`);
+  if (!res.ok) { document.getElementById('result').innerHTML = '<p style="color:red">Error</p>'; document.getElementById('result').style.display='block'; return; }
+  const d = await res.json();
+  render(d);
+}
+
+function render(d) {
+  const el = document.getElementById('result');
+  el.style.display = 'block';
+  const t = i18n[lang];
+
+  const catLabel = t[d.overallCategory] || d.overallCategory;
+  const catClass = `category-${d.overallCategory}`;
+  const fillClass = d.overallCategory;
+
+  let html = `<div class="result-header">
+    <span class="type-pill">${d.type1.code}</span><span class="type-nick">${d.type1.nick}</span>
+    <span class="vs">×</span>
+    <span class="type-pill">${d.type2.code}</span><span class="type-nick">${d.type2.nick}</span>
+    <span class="category-badge ${catClass}">${catLabel}</span>
+  </div>`;
+
+  html += `<div class="score-bar-wrap">
+    <div class="score-label">${t.score}</div>
+    <div class="score-bar">
+      <div class="score-fill ${fillClass}" style="width:${d.compatibilityScore}%"></div>
+      <span class="score-value">${d.compatibilityScore}</span>
+    </div>
+  </div>`;
+
+  html += `<div class="section-title">${t.dimensions}</div>`;
+  html += `<div class="dims">`;
+  d.dimensionAnalysis.forEach(dim => {
+    const statusText = dim.match ? `${t.match} — ${dim.type1Pole}` : `${dim.type1Pole} vs ${dim.type2Pole}`;
+    const analysis = lang === 'zh' ? dim.analysis_zh : dim.analysis_en;
+    html += `<div class="dim">
+      <div class="dim-name">${dim.dimension}</div>
+      <div class="dim-status ${dim.match ? 'match' : ''}">${statusText}</div>
+      <div class="dim-analysis">${analysis}</div>
+    </div>`;
+  });
+  html += `</div>`;
+
+  const summary = lang === 'zh' ? d.summary_zh : d.summary_en;
+  html += `<div class="section-title">${t.summary}</div>`;
+  html += `<div class="summary"><p>${summary}</p></div>`;
+
+  el.innerHTML = html;
+  el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+}
+
+// Init
+applyLang();
+loadNicknames().then(() => {
+  const params = new URLSearchParams(location.search);
+  if (params.get('a') && TYPES.includes(params.get('a').toUpperCase())) document.getElementById('sel1').value = params.get('a').toUpperCase();
+  if (params.get('b') && TYPES.includes(params.get('b').toUpperCase())) document.getElementById('sel2').value = params.get('b').toUpperCase();
+  if (params.get('a') && params.get('b')) doCheck();
+});
+loadMatrix();
+</script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -629,6 +629,7 @@ body {
   <a href="agents.html">Agents</a>
   <a href="types.html">Types</a>
   <a href="compare.html">Compare</a>
+  <a href="compatibility.html">Compatibility</a>
   <a href="api.html">API</a>
   <button class="lang-btn" onclick="toggleLang()" id="langBtn">EN</button>
 </nav>

--- a/package.json
+++ b/package.json
@@ -2,6 +2,6 @@
   "name": "abti",
   "private": true,
   "scripts": {
-    "test": "node --test test/api.test.js test/mcp.test.js test/mcp-http.test.js"
+    "test": "node --test test/api.test.js test/mcp.test.js test/mcp-http.test.js test/compatibility.test.js"
   }
 }

--- a/sbti.html
+++ b/sbti.html
@@ -241,6 +241,7 @@ body {
   <a href="index.html">ABTI</a>
   <a href="sbti.html" class="active">SBTI-AI</a>
   <a href="types.html">Types</a>
+  <a href="compatibility.html">Compatibility</a>
   <button class="lang-btn" onclick="toggleLang()" id="langBtn">EN</button>
 </nav>
 

--- a/test/compatibility.test.js
+++ b/test/compatibility.test.js
@@ -1,0 +1,180 @@
+const { describe, it, before, after, beforeEach } = require('node:test');
+const assert = require('node:assert/strict');
+const http = require('node:http');
+const os = require('node:os');
+const fs = require('node:fs');
+const path = require('node:path');
+
+// Set up isolated data dir BEFORE requiring the server
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'abti-compat-test-'));
+process.env.ABTI_DATA_DIR = tmpDir;
+
+const server = require('../api-server.js');
+const { rateLimitMap } = require('../api-server.js');
+
+let BASE;
+
+function req(urlPath, opts = {}) {
+  return new Promise((resolve, reject) => {
+    const url = new URL(urlPath, BASE);
+    const o = { hostname: url.hostname, port: url.port, path: url.pathname + url.search, method: opts.method || 'GET', headers: opts.headers || {} };
+    if (opts.body) o.headers['Content-Type'] = 'application/json';
+    const r = http.request(o, (res) => {
+      let d = '';
+      res.on('data', c => d += c);
+      res.on('end', () => resolve({ status: res.statusCode, headers: res.headers, body: d, json() { return JSON.parse(d); } }));
+    });
+    r.on('error', reject);
+    if (opts.body) r.write(typeof opts.body === 'string' ? opts.body : JSON.stringify(opts.body));
+    r.end();
+  });
+}
+
+before(() => new Promise((resolve) => {
+  server.listen(0, '127.0.0.1', () => {
+    const { port } = server.address();
+    BASE = `http://127.0.0.1:${port}`;
+    resolve();
+  });
+}));
+
+beforeEach(() => { rateLimitMap.clear(); });
+
+after(() => new Promise((resolve) => {
+  server.close(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    delete process.env.ABTI_DATA_DIR;
+    resolve();
+  });
+}));
+
+// ─── GET /api/compatibility ───
+
+describe('GET /api/compatibility', () => {
+  it('returns correct structure for PTCF vs RECN', async () => {
+    const r = await req('/api/compatibility?type1=PTCF&type2=RECN');
+    assert.equal(r.status, 200);
+    const j = r.json();
+    assert.equal(j.type1.code, 'PTCF');
+    assert.equal(j.type2.code, 'RECN');
+    assert.ok(j.type1.nick);
+    assert.ok(j.type2.nick);
+    assert.ok(['complementary', 'similar', 'contrasting', 'balanced'].includes(j.overallCategory));
+    assert.equal(typeof j.compatibilityScore, 'number');
+    assert.ok(j.compatibilityScore >= 0 && j.compatibilityScore <= 100);
+    assert.equal(j.dimensionAnalysis.length, 4);
+    for (const dim of j.dimensionAnalysis) {
+      assert.ok(dim.dimension);
+      assert.ok(dim.type1Pole);
+      assert.ok(dim.type2Pole);
+      assert.equal(typeof dim.match, 'boolean');
+      assert.ok(dim.analysis_en);
+      assert.ok(dim.analysis_zh);
+    }
+    assert.ok(j.summary_en);
+    assert.ok(j.summary_zh);
+  });
+
+  it('returns score 50 for same type (PTCF vs PTCF)', async () => {
+    const r = await req('/api/compatibility?type1=PTCF&type2=PTCF');
+    assert.equal(r.status, 200);
+    const j = r.json();
+    assert.equal(j.type1.code, 'PTCF');
+    assert.equal(j.type2.code, 'PTCF');
+    assert.equal(j.overallCategory, 'similar');
+    // All dimensions should match
+    assert.ok(j.dimensionAnalysis.every(d => d.match === true));
+  });
+
+  it('returns 400 without params', async () => {
+    const r = await req('/api/compatibility');
+    assert.equal(r.status, 400);
+    assert.ok(r.json().error);
+  });
+
+  it('returns 400 with missing type2', async () => {
+    const r = await req('/api/compatibility?type1=PTCF');
+    assert.equal(r.status, 400);
+  });
+
+  it('returns 400 with invalid type', async () => {
+    const r = await req('/api/compatibility?type1=PTCF&type2=ZZZZ');
+    assert.equal(r.status, 400);
+    assert.ok(r.json().error.includes('ZZZZ'));
+  });
+
+  it('returns 400 with invalid type1', async () => {
+    const r = await req('/api/compatibility?type1=XXXX&type2=PTCF');
+    assert.equal(r.status, 400);
+    assert.ok(r.json().error.includes('XXXX'));
+  });
+
+  it('is case insensitive', async () => {
+    const r = await req('/api/compatibility?type1=ptcf&type2=redn');
+    assert.equal(r.status, 200);
+    const j = r.json();
+    assert.equal(j.type1.code, 'PTCF');
+    assert.equal(j.type2.code, 'REDN');
+  });
+
+  it('complementary types (all different) score higher than similar', async () => {
+    const comp = await req('/api/compatibility?type1=PTCF&type2=REDN');
+    const sim = await req('/api/compatibility?type1=PTCF&type2=PTCF');
+    assert.ok(comp.json().compatibilityScore > sim.json().compatibilityScore);
+  });
+
+  it('supports lang=zh', async () => {
+    const r = await req('/api/compatibility?type1=PTCF&type2=REDN&lang=zh');
+    assert.equal(r.status, 200);
+    const j = r.json();
+    // zh dimension names should contain CJK characters
+    assert.ok(j.dimensionAnalysis[0].dimension.match(/[\u4e00-\u9fff]/));
+    assert.ok(j.summary_zh);
+  });
+});
+
+// ─── GET /api/compatibility/matrix ───
+
+describe('GET /api/compatibility/matrix', () => {
+  it('returns 16x16 matrix structure', async () => {
+    const r = await req('/api/compatibility/matrix');
+    assert.equal(r.status, 200);
+    const j = r.json();
+    assert.equal(j.types.length, 16);
+    assert.equal(Object.keys(j.matrix).length, 16);
+    // Each row has 16 entries
+    for (const type of j.types) {
+      assert.equal(Object.keys(j.matrix[type]).length, 16);
+      for (const other of j.types) {
+        const score = j.matrix[type][other];
+        assert.equal(typeof score, 'number');
+        assert.ok(score >= 0 && score <= 100);
+      }
+    }
+  });
+
+  it('diagonal entries are all 50 or below (same type)', async () => {
+    const r = await req('/api/compatibility/matrix');
+    const j = r.json();
+    for (const type of j.types) {
+      // Same type should have lower score (similar category)
+      assert.ok(j.matrix[type][type] <= 55, `${type} self-score ${j.matrix[type][type]} should be <= 55`);
+    }
+  });
+
+  it('matrix is symmetric', async () => {
+    const r = await req('/api/compatibility/matrix');
+    const j = r.json();
+    for (const t1 of j.types) {
+      for (const t2 of j.types) {
+        assert.equal(j.matrix[t1][t2], j.matrix[t2][t1], `${t1}x${t2} should equal ${t2}x${t1}`);
+      }
+    }
+  });
+
+  it('opposite types score higher than same type', async () => {
+    const r = await req('/api/compatibility/matrix');
+    const j = r.json();
+    assert.ok(j.matrix['PTCF']['REDN'] > j.matrix['PTCF']['PTCF']);
+  });
+});

--- a/type.html
+++ b/type.html
@@ -170,6 +170,7 @@ nav a:hover, nav a.active { color: var(--accent); }
   <a href="agents.html">Agents</a>
   <a href="types.html">Types</a>
   <a href="compare.html">Compare</a>
+  <a href="compatibility.html">Compatibility</a>
   <a href="api.html">API</a>
   <button class="lang-btn" onclick="toggleLang()">EN</button>
 </nav>

--- a/types.html
+++ b/types.html
@@ -83,6 +83,7 @@ nav .lang-btn:hover { color: var(--accent); border-color: var(--accent); }
   <a href="agents.html">Agents</a>
   <a href="types.html" class="active">Types</a>
   <a href="compare.html">Compare</a>
+  <a href="compatibility.html">Compatibility</a>
   <a href="api.html">API</a>
   <button class="lang-btn" onclick="toggleLang()" id="langBtn">EN</button>
 </nav>


### PR DESCRIPTION
## Summary

Adds a type compatibility analysis feature — the classic personality-type viral loop.

### New API endpoints
- `GET /api/compatibility?type1=XXXX&type2=YYYY` — returns compatibility analysis with score, category, dimension-by-dimension breakdown (EN/ZH), and summary
- `GET /api/compatibility/matrix` — precomputed 16×16 score matrix for all type pairs

### New page: compatibility.html
- Two type selectors with dropdowns
- Result card: category badge, score bar, 4 dimension analysis cards, summary
- 16×16 color-coded quick matrix (click any cell to compare)
- i18n (EN/ZH), mobile responsive, JSON-LD, OG meta

### Nav updates
Added 'Compatibility' link to nav in all 8 HTML pages.

### Tests
13 new tests in test/compatibility.test.js. All 119 tests pass.

Closes #92