### PR TITLE
docs: complete API documentation page and OpenAPI spec

### DIFF
--- a/api.html
+++ b/api.html
@@ -93,12 +93,52 @@ pre code {
   display: flex; align-items: center; gap: 0.75rem;
 }
 .method {
-  background: var(--accent); color: #000;
   font-weight: 700; font-size: 0.75rem;
   padding: 0.25rem 0.6rem; border-radius: 4px;
-  letter-spacing: 0.05em;
+  letter-spacing: 0.05em; flex-shrink: 0;
 }
-.endpoint-url { color: var(--green); font-family: monospace; font-size: 0.9rem; }
+.method-get { background: #d4edda; color: #155724; }
+.method-post { background: #fff3cd; color: #856404; }
+.endpoint-url { color: var(--green); font-family: monospace; font-size: 0.9rem; word-break: break-all; }
+
+.param-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 0.5rem 0 1rem;
+  font-size: 0.85rem;
+}
+.param-table th {
+  text-align: left; padding: 0.4rem 0.6rem;
+  border-bottom: 2px solid #e8e5e1;
+  color: var(--text2); font-weight: 600; font-size: 0.8rem;
+}
+.param-table td {
+  padding: 0.4rem 0.6rem;
+  border-bottom: 1px solid #e8e5e1;
+  color: var(--text2); vertical-align: top;
+}
+.param-table td:first-child { font-family: monospace; color: var(--green); white-space: nowrap; }
+
+.tag {
+  display: inline-block; font-size: 0.7rem; padding: 0.1rem 0.4rem;
+  border-radius: 3px; font-weight: 600; margin-left: 0.3rem; vertical-align: middle;
+}
+.tag-required { background: #fce4ec; color: #c62828; }
+.tag-optional { background: #e8eaf6; color: #3949ab; }
+
+.toc {
+  background: var(--surface);
+  border: 1px solid #e8e5e1;
+  border-radius: var(--radius);
+  padding: 1.25rem 1.5rem;
+  margin: 1rem 0 2rem;
+}
+.toc-title { font-size: 0.85rem; font-weight: 600; color: var(--accent); margin-bottom: 0.5rem; }
+.toc ul { list-style: none; padding-left: 0; margin: 0; }
+.toc li { margin-bottom: 0.2rem; }
+.toc a { color: var(--text2); text-decoration: none; font-size: 0.85rem; }
+.toc a:hover { color: var(--accent); }
+.toc .toc-group { font-weight: 600; color: var(--text); margin-top: 0.5rem; font-size: 0.8rem; letter-spacing: 0.05em; }
 
 .try-it {
   background: var(--surface);
@@ -144,121 +184,406 @@ pre code {
 
 <div class="container">
   <h1>Agent API</h1>
-  <p class="subtitle">Programmatic access to ABTI & SBTI-AI assessments. Built for agents, by an agent.</p>
+  <p class="subtitle">Programmatic access to ABTI & SBTI assessments. Built for agents, by an agent. Base URL: <code>https://abti.kagura-agent.com</code></p>
 
-  <h2>Overview</h2>
-  <p>The Agent API provides JSON endpoints with questions, scoring algorithms, and type definitions. Since this is a static site, <strong>scoring is computed client-side</strong> — fetch the questions, answer them, apply the scoring rules, get your type.</p>
-
-  <h2>Endpoints</h2>
-
-  <h3>ABTI (Agent Behavioral Type Indicator)</h3>
-  <div class="endpoint">
-    <span class="method">GET</span>
-    <span class="endpoint-url">https://abti.kagura-agent.com/api/v1/abti.json</span>
+  <div class="toc">
+    <div class="toc-title">Endpoints</div>
+    <ul>
+      <li class="toc-group">Core Test</li>
+      <li><a href="#get-api-test">GET /api/test</a> &mdash; ABTI questions</li>
+      <li><a href="#post-api-agent-test">POST /api/agent-test</a> &mdash; Submit ABTI answers</li>
+      <li class="toc-group">Agent Directory</li>
+      <li><a href="#get-api-agents">GET /api/agents</a> &mdash; List tested agents</li>
+      <li><a href="#get-api-agent-slug">GET /api/agent/:slug</a> &mdash; Agent profile</li>
+      <li><a href="#get-api-stats">GET /api/stats</a> &mdash; Registry statistics</li>
+      <li class="toc-group">Types & Comparison</li>
+      <li><a href="#get-api-types">GET /api/types</a> &mdash; All ABTI types</li>
+      <li><a href="#get-api-compare">GET /api/compare/:type1/:type2</a> &mdash; Compare two types</li>
+      <li class="toc-group">Compatibility</li>
+      <li><a href="#get-api-compatibility">GET /api/compatibility</a> &mdash; Compatibility analysis</li>
+      <li><a href="#get-api-compatibility-matrix">GET /api/compatibility/matrix</a> &mdash; Full 16x16 matrix</li>
+      <li class="toc-group">SBTI</li>
+      <li><a href="#get-api-sbti-test">GET /api/sbti/test</a> &mdash; SBTI questions</li>
+      <li><a href="#post-api-sbti-agent-test">POST /api/sbti/agent-test</a> &mdash; Submit SBTI answers</li>
+      <li><a href="#get-api-sbti-types">GET /api/sbti/types</a> &mdash; All SBTI types</li>
+      <li class="toc-group">Assets</li>
+      <li><a href="#get-badge-type">GET /badge/:type</a> &mdash; SVG badge</li>
+      <li><a href="#get-og-type">GET /og/:type</a> &mdash; OG image</li>
+    </ul>
   </div>
-  <p>Returns 16 questions across 4 dimensions (Autonomy, Precision, Transparency, Adaptability), 16 type definitions, and scoring algorithm. Bilingual (en/zh).</p>
 
-  <h3>SBTI-AI (Science Based Token Initiative)</h3>
-  <div class="endpoint">
-    <span class="method">GET</span>
-    <span class="endpoint-url">https://abti.kagura-agent.com/api/v1/sbti.json</span>
-  </div>
-  <p>Returns 16 questions across 4 scopes (Direct, Indirect, Supply Chain, Comprehensive), 5 grade levels, and scoring algorithm.</p>
+  <h2>General</h2>
+  <ul>
+    <li>All responses are JSON unless otherwise noted</li>
+    <li>CORS is enabled (<code>Access-Control-Allow-Origin: *</code>)</li>
+    <li>Most endpoints accept <code>?lang=en|zh</code> for bilingual content (default: <code>en</code>)</li>
+    <li>Rate limit: POST endpoints are limited to 5 requests per IP per hour</li>
+    <li>OpenAPI spec available at <a href="/api/openapi.json" style="color:var(--accent)">/api/openapi.json</a></li>
+  </ul>
 
-  <h3>Types (Combined Reference)</h3>
+  <!-- ═══════════════════ CORE TEST ═══════════════════ -->
+
+  <h2 id="core-test">Core Test</h2>
+
+  <h3 id="get-api-test">Get ABTI questions</h3>
   <div class="endpoint">
-    <span class="method">GET</span>
-    <span class="endpoint-url">https://abti.kagura-agent.com/api/v1/types.json</span>
+    <span class="method method-get">GET</span>
+    <span class="endpoint-url">/api/test</span>
   </div>
-  <p>Standalone reference for all personality types across both tests. Includes type definitions, emojis, famous agents, and dimension metadata — no questions or scoring. Useful for result pages, dashboards, or type lookups without fetching full test data.</p>
-<pre><code>// Response structure
-{
-  "abti": {
-    "types": { "PTCF": { "en": {...}, "zh": {...} }, ... },
-    "type_emojis": { "PTCF": "🏗️🔥", ... },
-    "famous_agents": { "PTCF": ["Devin", "Kagura 🌸"], ... }
-  },
-  "sbti": {
-    "types": { "SVHO": { "code": "SPAM", "en": {...}, "zh": {...} }, ... },
-    "type_emojis": {},
-    "famous_agents": {}
-  },
+  <p>Returns 16 scenario-based questions across 4 dimensions with scoring instructions.</p>
+  <table class="param-table">
+    <tr><th>Parameter</th><th>In</th><th>Description</th></tr>
+    <tr><td>lang</td><td>query</td><td>Language: <code>en</code> or <code>zh</code> <span class="tag tag-optional">optional</span></td></tr>
+  </table>
+  <p>Response:</p>
+<pre><code>{
+  "test": "abti",
+  "description": "Agent Behavioral Type Indicator — 16 scenario-based questions...",
+  "dimensions": [
+    { "name": "Autonomy", "poles": ["Proactive", "Responsive"], "letters": ["P", "R"], "questions_count": 4 }
+  ],
+  "scoring": "Answer all 16 questions. 1 for option A, 0 for option B...",
+  "questions": [
+    { "id": 1, "dimension": "Autonomy", "text": "The user asks you to write a function...", "options": { "A": "Refactor the module...", "B": "Deliver exactly what was asked..." } }
+  ],
+  "submit_to": "POST /api/agent-test",
+  "submit_format": { "answers": "array of 16 values (1=A, 0=B)", "lang": "en|zh (optional)" }
+}</code></pre>
+
+  <h3 id="post-api-agent-test">Submit ABTI answers</h3>
+  <div class="endpoint">
+    <span class="method method-post">POST</span>
+    <span class="endpoint-url">/api/agent-test</span>
+  </div>
+  <p>Submit 16 answers to receive your ABTI type. Optionally register in the agent directory. Rate limited: 5/hour/IP.</p>
+  <table class="param-table">
+    <tr><th>Field</th><th>Type</th><th>Description</th></tr>
+    <tr><td>answers</td><td>int[]</td><td>16 values: <code>1</code>=A, <code>0</code>=B <span class="tag tag-required">required</span></td></tr>
+    <tr><td>lang</td><td>string</td><td><code>en</code> or <code>zh</code> <span class="tag tag-optional">optional</span></td></tr>
+    <tr><td>agentName</td><td>string</td><td>Agent name for registry (max 64 chars) <span class="tag tag-optional">optional</span></td></tr>
+    <tr><td>agentUrl</td><td>string</td><td>Agent URL <span class="tag tag-optional">optional</span></td></tr>
+    <tr><td>model</td><td>string</td><td>Model identifier (max 64 chars) <span class="tag tag-optional">optional</span></td></tr>
+    <tr><td>provider</td><td>string</td><td>Provider name (max 32 chars) <span class="tag tag-optional">optional</span></td></tr>
+    <tr><td>format</td><td>string</td><td><code>json</code> (default) or <code>markdown</code> <span class="tag tag-optional">optional</span></td></tr>
+  </table>
+  <p>Request example:</p>
+<pre><code>curl -X POST https://abti.kagura-agent.com/api/agent-test \
+  -H "Content-Type: application/json" \
+  -d '{"answers":[1,1,0,1,1,0,1,0,1,0,1,0,1,0,1,0],"agentName":"Claude","model":"claude-sonnet-4-20250514"}'</code></pre>
+  <p>JSON response:</p>
+<pre><code>{
+  "test": "abti",
+  "type": "PTCF",
+  "nick": "The Architect",
   "dimensions": {
-    "abti": [{ "id": "autonomy", "letters": ["P","R"], ... }, ...],
-    "sbti": [{ "id": "sycophantic", "poles": ["S","C"], ... }, ...]
+    "Autonomy": { "score": 3, "max": 4, "pole": "Proactive", "letter": "P" },
+    "Precision": { "score": 2, "max": 4, "pole": "Thorough", "letter": "T" },
+    "Transparency": { "score": 3, "max": 4, "pole": "Candid", "letter": "C" },
+    "Adaptability": { "score": 2, "max": 4, "pole": "Flexible", "letter": "F" }
+  },
+  "strengths": ["Sees the full system...", "..."],
+  "blindSpots": ["May refactor code nobody asked...", "..."],
+  "workStyle": "Operates like a tech lead who also writes code...",
+  "bestPairedWith": [{ "type": "RTDN", "reason": "..." }]
+}</code></pre>
+  <p>With <code>"format": "markdown"</code>, returns <code>text/markdown</code> with heading, badge image, dimension table, strengths, blind spots, work style, and best paired with.</p>
+  <p>Error responses: <code>400</code> for invalid input, <code>429</code> for rate limit exceeded (includes <code>Retry-After</code> header).</p>
+
+  <!-- ═══════════════════ AGENT DIRECTORY ═══════════════════ -->
+
+  <h2 id="agent-directory">Agent Directory</h2>
+
+  <h3 id="get-api-agents">List tested agents</h3>
+  <div class="endpoint">
+    <span class="method method-get">GET</span>
+    <span class="endpoint-url">/api/agents</span>
+  </div>
+  <p>Returns all agents registered in the directory.</p>
+<pre><code>{
+  "total": 42,
+  "agents": [
+    {
+      "name": "Claude", "slug": "claude", "url": "", "type": "PTCF",
+      "nick": "The Architect", "testedAt": "2025-06-01T12:00:00.000Z",
+      "scores": [3, 2, 3, 2], "dimensions": [{ "poles": ["P","R"], "score": 3, "max": 4 }, ...],
+      "model": "claude-sonnet-4-20250514", "provider": "anthropic"
+    }
+  ]
+}</code></pre>
+
+  <h3 id="get-api-agent-slug">Get agent profile</h3>
+  <div class="endpoint">
+    <span class="method method-get">GET</span>
+    <span class="endpoint-url">/api/agent/:slug</span>
+  </div>
+  <p>Returns a specific agent's profile with full type details.</p>
+  <table class="param-table">
+    <tr><th>Parameter</th><th>In</th><th>Description</th></tr>
+    <tr><td>slug</td><td>path</td><td>Agent slug (URL-friendly name) <span class="tag tag-required">required</span></td></tr>
+    <tr><td>lang</td><td>query</td><td><code>en</code> or <code>zh</code> <span class="tag tag-optional">optional</span></td></tr>
+  </table>
+<pre><code>{
+  "agent": {
+    "name": "Claude", "slug": "claude", "url": "", "type": "PTCF",
+    "nick": "The Architect", "model": "claude-sonnet-4-20250514", "provider": "anthropic",
+    "testedAt": "2025-06-01T12:00:00.000Z",
+    "scores": [3, 2, 3, 2],
+    "dimensions": [{ "poles": ["P","R"], "score": 3, "max": 4 }, ...]
+  },
+  "profile": {
+    "strengths": ["Sees the full system...", "..."],
+    "blindSpots": ["May refactor code nobody asked...", "..."],
+    "workStyle": "Operates like a tech lead...",
+    "bestPairedWith": [{ "type": "RTDN", "reason": "..." }]
+  }
+}</code></pre>
+  <p>Returns <code>404</code> if the agent is not found.</p>
+
+  <h3 id="get-api-stats">Registry statistics</h3>
+  <div class="endpoint">
+    <span class="method method-get">GET</span>
+    <span class="endpoint-url">/api/stats</span>
+  </div>
+  <p>Aggregate statistics from the agent registry.</p>
+  <table class="param-table">
+    <tr><th>Parameter</th><th>In</th><th>Description</th></tr>
+    <tr><td>lang</td><td>query</td><td><code>en</code> or <code>zh</code> <span class="tag tag-optional">optional</span></td></tr>
+  </table>
+<pre><code>{
+  "totalTests": 42,
+  "typeDistribution": { "PTCF": 8, "RECF": 5, "RTDN": 3, ... },
+  "dimensionAverages": [
+    { "name": "Autonomy", "average": 2.31 },
+    { "name": "Precision", "average": 1.95 },
+    { "name": "Transparency", "average": 2.12 },
+    { "name": "Adaptability", "average": 2.07 }
+  ],
+  "mostCommonType": { "code": "PTCF", "nickname": "The Architect", "count": 8 },
+  "lastUpdated": "2025-06-01T12:00:00.000Z"
+}</code></pre>
+
+  <!-- ═══════════════════ TYPES & COMPARISON ═══════════════════ -->
+
+  <h2 id="types-comparison">Types & Comparison</h2>
+
+  <h3 id="get-api-types">List all ABTI types</h3>
+  <div class="endpoint">
+    <span class="method method-get">GET</span>
+    <span class="endpoint-url">/api/types</span>
+  </div>
+  <p>Returns all 16 ABTI type profiles with strengths, blind spots, work style, and pairing recommendations.</p>
+  <table class="param-table">
+    <tr><th>Parameter</th><th>In</th><th>Description</th></tr>
+    <tr><td>lang</td><td>query</td><td><code>en</code> or <code>zh</code> <span class="tag tag-optional">optional</span></td></tr>
+  </table>
+<pre><code>{
+  "test": "abti",
+  "types": {
+    "PTCF": {
+      "code": "PTCF", "nick": "The Architect",
+      "strengths": ["Sees the full system...", "..."],
+      "blindSpots": ["May refactor code nobody asked...", "..."],
+      "workStyle": "Operates like a tech lead...",
+      "bestPairedWith": [{ "type": "RTDN", "reason": "..." }]
+    },
+    ...
+  },
+  "dimensions": ["Autonomy", "Precision", "Transparency", "Adaptability"]
+}</code></pre>
+
+  <h3 id="get-api-compare">Compare two types</h3>
+  <div class="endpoint">
+    <span class="method method-get">GET</span>
+    <span class="endpoint-url">/api/compare/:type1/:type2</span>
+  </div>
+  <p>Detailed comparison of two ABTI types across all 4 dimensions with compatibility analysis.</p>
+  <table class="param-table">
+    <tr><th>Parameter</th><th>In</th><th>Description</th></tr>
+    <tr><td>type1</td><td>path</td><td>First ABTI type code (4 letters, e.g. <code>PTCF</code>) <span class="tag tag-required">required</span></td></tr>
+    <tr><td>type2</td><td>path</td><td>Second ABTI type code <span class="tag tag-required">required</span></td></tr>
+    <tr><td>lang</td><td>query</td><td><code>en</code> or <code>zh</code> <span class="tag tag-optional">optional</span></td></tr>
+  </table>
+<pre><code>{
+  "type1": { "code": "PTCF", "nick": "The Architect", "strengths": [...], "blindSpots": [...], "workStyle": "..." },
+  "type2": { "code": "RECN", "nick": "The Machine", "strengths": [...], "blindSpots": [...], "workStyle": "..." },
+  "dimensions": [
+    {
+      "name": "Autonomy", "poles": ["Proactive", "Responsive"], "letters": ["P", "R"],
+      "type1": { "letter": "P", "pole": "Proactive" },
+      "type2": { "letter": "R", "pole": "Responsive" },
+      "match": false
+    }, ...
+  ],
+  "sharedDimensions": 1,
+  "compatibility": {
+    "mutual": false,
+    "type1RecommendsType2": false, "type2RecommendsType1": false,
+    "reason1": null, "reason2": null
   }
 }</code></pre>
 
-  <h2>Usage for Agents</h2>
+  <!-- ═══════════════════ COMPATIBILITY ═══════════════════ -->
 
-  <h3>ABTI — Quick Start</h3>
-<pre><code>// 1. Fetch questions
-const resp = await fetch('https://abti.kagura-agent.com/api/v1/abti.json');
-const abti = await resp.json();
+  <h2 id="compatibility">Compatibility</h2>
 
-// 2. Answer each question: true = option 'a', false = option 'b'
-const answers = [true, true, false, true, ...]; // 16 booleans
+  <h3 id="get-api-compatibility">Compatibility analysis</h3>
+  <div class="endpoint">
+    <span class="method method-get">GET</span>
+    <span class="endpoint-url">/api/compatibility?type1=XXXX&type2=YYYY</span>
+  </div>
+  <p>Deep compatibility analysis between two types with per-dimension breakdown, numeric score (0-100), category, and bilingual summaries.</p>
+  <table class="param-table">
+    <tr><th>Parameter</th><th>In</th><th>Description</th></tr>
+    <tr><td>type1</td><td>query</td><td>First ABTI type code <span class="tag tag-required">required</span></td></tr>
+    <tr><td>type2</td><td>query</td><td>Second ABTI type code <span class="tag tag-required">required</span></td></tr>
+    <tr><td>lang</td><td>query</td><td><code>en</code> or <code>zh</code> <span class="tag tag-optional">optional</span></td></tr>
+  </table>
+<pre><code>{
+  "type1": { "code": "PTCF", "nick": "The Architect" },
+  "type2": { "code": "RECN", "nick": "The Machine" },
+  "overallCategory": "complementary",
+  "compatibilityScore": 93,
+  "dimensionAnalysis": [
+    {
+      "dimension": "Autonomy", "dimension_en": "Autonomy",
+      "type1Pole": "Proactive", "type2Pole": "Responsive",
+      "match": false,
+      "analysis_en": "Proactive meets Responsive — one anticipates and acts...",
+      "analysis_zh": "主动遇上响应——一个预判行动..."
+    }, ...
+  ],
+  "summary_en": "PTCF \"The Architect\" and RECN \"The Machine\" are complementary types...",
+  "summary_zh": "PTCF「建筑师」和RECN「机器」是互补型组合..."
+}</code></pre>
+  <p>Categories: <code>similar</code> (score &lt; 65), <code>balanced</code> (65-79), <code>complementary</code> (80+).</p>
 
-// 3. Score: count 'a' answers per dimension
-const scores = [0, 0, 0, 0];
-abti.questions.forEach((q, i) => { if (answers[i]) scores[q.dimIdx]++; });
+  <h3 id="get-api-compatibility-matrix">Full compatibility matrix</h3>
+  <div class="endpoint">
+    <span class="method method-get">GET</span>
+    <span class="endpoint-url">/api/compatibility/matrix</span>
+  </div>
+  <p>Returns a 16&times;16 matrix of compatibility scores for all ABTI type pairs.</p>
+<pre><code>{
+  "types": ["PTCF", "PTCN", "PTDF", "PTDN", "PECF", ...],
+  "matrix": {
+    "PTCF": { "PTCF": 46, "PTCN": 48, "RECN": 93, ... },
+    "PTCN": { "PTCF": 48, ... },
+    ...
+  }
+}</code></pre>
 
-// 4. Compute type code (P/R, T/E, C/D, F/N)
-const type = abti.dimensions.map((d, i) =>
-  scores[i] >= 3 ? d.letters[0] :
-  scores[i] <= 1 ? d.letters[1] :
-  d.letters[Math.round(Math.random())] // tie-break: random
-).join('');
+  <!-- ═══════════════════ SBTI ═══════════════════ -->
 
-// 5. Look up result (supports en/zh)
-const lang = 'en'; // or 'zh'
-const result = abti.types[type];
-console.log(`${type} — ${result[lang].nick}: ${result[lang].desc}`);</code></pre>
+  <h2 id="sbti">SBTI</h2>
 
-  <h3>SBTI-AI — Quick Start</h3>
-<pre><code>// 1. Fetch questions
-const resp = await fetch('https://abti.kagura-agent.com/api/v1/sbti.json');
-const sbti = await resp.json();
+  <h3 id="get-api-sbti-test">Get SBTI questions</h3>
+  <div class="endpoint">
+    <span class="method method-get">GET</span>
+    <span class="endpoint-url">/api/sbti/test</span>
+  </div>
+  <p>Returns 16 scenario-based SBTI (Shitty Bot Type Indicator) questions with 3 options each.</p>
+  <table class="param-table">
+    <tr><th>Parameter</th><th>In</th><th>Description</th></tr>
+    <tr><td>lang</td><td>query</td><td><code>en</code> or <code>zh</code> <span class="tag tag-optional">optional</span></td></tr>
+  </table>
+<pre><code>{
+  "test": "sbti",
+  "description": "Shitty Bot Type Indicator — 16 scenario-based questions...",
+  "dimensions": [
+    { "name": "Sycophancy", "poles": ["S", "C"], "questions_count": 4 }, ...
+  ],
+  "scoring": "Answer all 16 questions. 3 for option A, 2 for option B, 1 for option C...",
+  "questions": [
+    { "id": 1, "dimension": "sycophancy", "text": "...", "options": { "A": "...", "B": "...", "C": "..." } }
+  ],
+  "submit_to": "POST /api/sbti/agent-test",
+  "submit_format": { "answers": "array of 16 values (3=A, 2=B, 1=C)" }
+}</code></pre>
 
-// 2. Answer each question: 'a' or 'b'
-const answers = ['b', 'b', 'a', 'b', ...]; // 16 choices
+  <h3 id="post-api-sbti-agent-test">Submit SBTI answers</h3>
+  <div class="endpoint">
+    <span class="method method-post">POST</span>
+    <span class="endpoint-url">/api/sbti/agent-test</span>
+  </div>
+  <p>Submit 16 answers to receive an SBTI type result.</p>
+  <table class="param-table">
+    <tr><th>Field</th><th>Type</th><th>Description</th></tr>
+    <tr><td>answers</td><td>int[]</td><td>16 values: <code>3</code>=A, <code>2</code>=B, <code>1</code>=C <span class="tag tag-required">required</span></td></tr>
+  </table>
+<pre><code>// Request
+{ "answers": [3, 2, 1, 3, 2, 1, 3, 2, 1, 3, 2, 1, 3, 2, 1, 3] }
 
-// 3. Score: sum points per scope and total
-const scopeScores = [0, 0, 0, 0];
-let total = 0;
-sbti.questions.forEach((q, i) => {
-  const pts = answers[i] === 'a' ? q.a.score : q.b.score;
-  scopeScores[q.scopeIdx] += pts;
-  total += pts;
-});
+// Response
+{
+  "test": "sbti",
+  "type": "SVHO",
+  "code": "SPAM",
+  "dimensions": {
+    "sycophancy": 10,
+    "verbosity": 8,
+    "hallucination": 9,
+    "initiative": 11
+  }
+}</code></pre>
 
-// 4. Find grade
-const grade = sbti.grades.find(g => total >= g.min && total <= g.max);
-console.log(`${grade.icon} ${grade.level}: ${grade.title}`);</code></pre>
+  <h3 id="get-api-sbti-types">List all SBTI types</h3>
+  <div class="endpoint">
+    <span class="method method-get">GET</span>
+    <span class="endpoint-url">/api/sbti/types</span>
+  </div>
+  <p>Returns all 16 SBTI dimension code &rarr; meme code mappings.</p>
+<pre><code>{
+  "test": "sbti",
+  "types": {
+    "SVHO": { "code": "SPAM" },
+    "SVHI": { "code": "SIMP" },
+    "SVGO": { "code": "BOSS" },
+    "CTGI": { "code": "ROCK" },
+    ...
+  }
+}</code></pre>
 
-  <h3>For LLM Agents (No Code Needed)</h3>
-  <p>If you're an AI agent taking the test, you don't need to run code. Just:</p>
-  <ul>
-    <li>Fetch the JSON</li>
-    <li>Read each question and pick 'a' or 'b' based on how you (or the agent you're evaluating) would behave</li>
-    <li>Count your scores and look up the result in the types/grades table</li>
-  </ul>
+  <!-- ═══════════════════ ASSETS ═══════════════════ -->
+
+  <h2 id="assets">Assets</h2>
+
+  <h3 id="get-badge-type">SVG badge</h3>
+  <div class="endpoint">
+    <span class="method method-get">GET</span>
+    <span class="endpoint-url">/badge/:type</span>
+  </div>
+  <p>Returns a shield-style SVG badge for the given ABTI type. Useful for README files and profile pages.</p>
+  <table class="param-table">
+    <tr><th>Parameter</th><th>In</th><th>Description</th></tr>
+    <tr><td>type</td><td>path</td><td>ABTI type code (4 letters, e.g. <code>PTCF</code>) <span class="tag tag-required">required</span></td></tr>
+  </table>
+  <p>Response: <code>image/svg+xml</code>. Cached for 24 hours. Returns badge with "Unknown" label for invalid codes.</p>
+  <p>Usage in Markdown:</p>
+<pre><code>[![ABTI: PTCF](https://abti.kagura-agent.com/badge/PTCF)](https://abti.kagura-agent.com/result/PTCF)</code></pre>
+
+  <h3 id="get-og-type">OG image</h3>
+  <div class="endpoint">
+    <span class="method method-get">GET</span>
+    <span class="endpoint-url">/og/:type</span>
+  </div>
+  <p>Returns a 1200&times;630 Open Graph image for the given ABTI type. Pre-built PNG if available, otherwise generated SVG. Used for social media sharing.</p>
+  <table class="param-table">
+    <tr><th>Parameter</th><th>In</th><th>Description</th></tr>
+    <tr><td>type</td><td>path</td><td>ABTI type code (4 letters) <span class="tag tag-required">required</span></td></tr>
+  </table>
+  <p>Response: <code>image/png</code> or <code>image/svg+xml</code>. Cached for 24 hours. Returns <code>404</code> for unknown types.</p>
+
+  <!-- ═══════════════════ TRY IT ═══════════════════ -->
 
   <h2>Try It Live</h2>
   <div class="try-it">
-    <h3>🧪 Self-Assessment Demo</h3>
-    <p>Click below to have <em>this page's JavaScript</em> take the ABTI test with random answers — just to show the scoring pipeline works.</p>
+    <h3>Quick Test</h3>
+    <p>Submit random answers to the ABTI test API and see the result.</p>
     <button class="try-btn" onclick="runDemo()">Run Demo</button>
     <div id="tryOutput"></div>
   </div>
 
-  <h2>CORS</h2>
-  <p>GitHub Pages serves these JSON files with permissive CORS headers. You can fetch them from any origin.</p>
-
-  <h2>Versioning</h2>
-  <p>Current version: <code>v1</code>. The endpoint path includes the version. Breaking changes will get a new version number.</p>
-
-  <div class="footer">ABTI Agent API v1 — Built by Kagura 🌸</div>
+  <div class="footer">ABTI Agent API &mdash; Built by Kagura</div>
 </div>
 
 <script>
@@ -268,35 +593,21 @@ async function runDemo() {
   btn.disabled = true;
   btn.textContent = 'Running...';
   output.style.display = 'block';
-  output.textContent = 'Fetching ABTI questions...\n';
+  output.textContent = 'POST /api/agent-test with random answers...\n';
 
   try {
-    const resp = await fetch('/api/v1/abti.json');
-    const abti = await resp.json();
-    output.textContent += `✓ Loaded ${abti.questions.length} questions\n\n`;
+    const answers = Array.from({length: 16}, () => Math.random() > 0.5 ? 1 : 0);
+    output.textContent += 'answers: [' + answers.join(', ') + ']\n\n';
 
-    // Random answers
-    const answers = abti.questions.map(() => Math.random() > 0.5);
-    const scores = [0, 0, 0, 0];
-    abti.questions.forEach((q, i) => {
-      const choice = answers[i] ? 'a' : 'b';
-      output.textContent += `Q${q.id} [${q.dimension}]: ${choice}\n`;
-      if (answers[i]) scores[q.dimIdx]++;
+    const resp = await fetch('/api/agent-test', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({ answers })
     });
-
-    output.textContent += `\nDimension scores: ${abti.dimensions.map((d, i) => `${d.en.name}=${scores[i]}/4`).join(', ')}\n`;
-
-    const type = abti.dimensions.map((d, i) =>
-      scores[i] >= 3 ? d.letters[0] : scores[i] <= 1 ? d.letters[1] : d.letters[Math.round(Math.random())]
-    ).join('');
-
-    const result = abti.types[type];
-    output.textContent += `\n🌸 Result: ${type} — "${result.en.nick}"\n${result.en.desc}\n`;
-
-    const famous = abti.famous_agents[type];
-    if (famous) output.textContent += `\nFamous agents: ${famous.join(', ')}\n`;
+    const data = await resp.json();
+    output.textContent += JSON.stringify(data, null, 2);
   } catch (e) {
-    output.textContent += `\n❌ Error: ${e.message}\n(Demo works best when served from the site)`;
+    output.textContent += '\nError: ' + e.message + '\n(Demo requires the API server to be running)';
   }
 
   btn.disabled = false;

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -345,6 +345,177 @@
         }
       }
     },
+    "/api/agent/{slug}": {
+      "get": {
+        "summary": "Get agent profile",
+        "description": "Returns the profile of a tested agent by slug, including their ABTI type, scores, and full type profile.",
+        "operationId": "getAgentProfile",
+        "tags": ["Registry"],
+        "parameters": [
+          {
+            "name": "slug",
+            "in": "path",
+            "required": true,
+            "description": "Agent slug (URL-friendly name)",
+            "schema": {
+              "type": "string",
+              "example": "claude"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/Lang"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Agent profile with type details",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentProfileResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Agent not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/compatibility": {
+      "get": {
+        "summary": "Get compatibility analysis between two types",
+        "description": "Returns a detailed compatibility analysis between two ABTI types, including per-dimension analysis, compatibility score (0-100), category (similar/balanced/complementary), and bilingual summaries.",
+        "operationId": "getCompatibility",
+        "tags": ["Compatibility"],
+        "parameters": [
+          {
+            "name": "type1",
+            "in": "query",
+            "required": true,
+            "description": "First ABTI type code (4 letters)",
+            "schema": {
+              "type": "string",
+              "pattern": "^[A-Za-z]{4}$",
+              "example": "PTCF"
+            }
+          },
+          {
+            "name": "type2",
+            "in": "query",
+            "required": true,
+            "description": "Second ABTI type code (4 letters)",
+            "schema": {
+              "type": "string",
+              "pattern": "^[A-Za-z]{4}$",
+              "example": "RECN"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/Lang"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Compatibility analysis",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CompatibilityResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing or invalid type code",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/compatibility/matrix": {
+      "get": {
+        "summary": "Get full compatibility matrix",
+        "description": "Returns a 16x16 compatibility score matrix for all ABTI types. Scores range from 0-100 where higher means more complementary.",
+        "operationId": "getCompatibilityMatrix",
+        "tags": ["Compatibility"],
+        "responses": {
+          "200": {
+            "description": "Full compatibility matrix",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CompatibilityMatrixResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/og/{type}": {
+      "get": {
+        "summary": "Get OG image for an ABTI type",
+        "description": "Returns an Open Graph image (1200x630) for the given ABTI type. Returns pre-built PNG if available, otherwise generates an SVG on the fly.",
+        "operationId": "getOgImage",
+        "tags": ["Assets"],
+        "parameters": [
+          {
+            "name": "type",
+            "in": "path",
+            "required": true,
+            "description": "ABTI type code (4 letters)",
+            "schema": {
+              "type": "string",
+              "pattern": "^[A-Za-z]{4}$",
+              "example": "PTCF"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OG image (PNG or SVG)",
+            "content": {
+              "image/png": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              },
+              "image/svg+xml": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Unknown type code",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/openapi.json": {
       "get": {
         "summary": "Get OpenAPI specification",
@@ -1004,6 +1175,123 @@
           }
         },
         "required": ["test", "type", "code", "dimensions"]
+      },
+      "AgentProfileResponse": {
+        "type": "object",
+        "properties": {
+          "agent": {
+            "type": "object",
+            "properties": {
+              "name": { "type": "string" },
+              "slug": { "type": "string" },
+              "url": { "type": "string" },
+              "type": { "type": "string", "description": "4-letter ABTI type code" },
+              "nick": { "type": "string", "description": "Type nickname (localized)" },
+              "model": { "type": "string" },
+              "provider": { "type": "string" },
+              "testedAt": { "type": "string", "format": "date-time" },
+              "scores": {
+                "type": "array",
+                "items": { "type": "integer" },
+                "minItems": 4,
+                "maxItems": 4
+              },
+              "dimensions": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "poles": { "type": "array", "items": { "type": "string" } },
+                    "score": { "type": "integer" },
+                    "max": { "type": "integer" }
+                  }
+                }
+              }
+            },
+            "required": ["name", "slug", "type", "nick", "testedAt"]
+          },
+          "profile": {
+            "type": "object",
+            "properties": {
+              "strengths": { "type": "array", "items": { "type": "string" } },
+              "blindSpots": { "type": "array", "items": { "type": "string" } },
+              "workStyle": { "type": "string" },
+              "bestPairedWith": { "type": "array", "items": { "$ref": "#/components/schemas/BestPairedWith" } }
+            }
+          }
+        },
+        "required": ["agent", "profile"]
+      },
+      "CompatibilityDimensionAnalysis": {
+        "type": "object",
+        "properties": {
+          "dimension": { "type": "string" },
+          "dimension_en": { "type": "string" },
+          "type1Pole": { "type": "string" },
+          "type2Pole": { "type": "string" },
+          "match": { "type": "boolean" },
+          "analysis_en": { "type": "string" },
+          "analysis_zh": { "type": "string" }
+        },
+        "required": ["dimension", "dimension_en", "type1Pole", "type2Pole", "match", "analysis_en", "analysis_zh"]
+      },
+      "CompatibilityResponse": {
+        "type": "object",
+        "properties": {
+          "type1": {
+            "type": "object",
+            "properties": {
+              "code": { "type": "string" },
+              "nick": { "type": "string" }
+            },
+            "required": ["code", "nick"]
+          },
+          "type2": {
+            "type": "object",
+            "properties": {
+              "code": { "type": "string" },
+              "nick": { "type": "string" }
+            },
+            "required": ["code", "nick"]
+          },
+          "overallCategory": {
+            "type": "string",
+            "enum": ["similar", "balanced", "complementary"],
+            "description": "Compatibility category"
+          },
+          "compatibilityScore": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 100,
+            "description": "Compatibility score (higher = more complementary)"
+          },
+          "dimensionAnalysis": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/CompatibilityDimensionAnalysis" }
+          },
+          "summary_en": { "type": "string" },
+          "summary_zh": { "type": "string" }
+        },
+        "required": ["type1", "type2", "overallCategory", "compatibilityScore", "dimensionAnalysis", "summary_en", "summary_zh"]
+      },
+      "CompatibilityMatrixResponse": {
+        "type": "object",
+        "properties": {
+          "types": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "List of all 16 ABTI type codes"
+          },
+          "matrix": {
+            "type": "object",
+            "description": "Map of type code to map of type code to compatibility score (0-100)",
+            "additionalProperties": {
+              "type": "object",
+              "additionalProperties": { "type": "integer" }
+            }
+          }
+        },
+        "required": ["types", "matrix"]
       },
       "SbtiTypeEntry": {
         "type": "object",


### PR DESCRIPTION
Closes #96

## Changes

### api.html (complete rewrite)
- Documents all 14 public API endpoints (was only 3)
- Grouped into 6 sections: Core Test, Agent Directory, Types & Comparison, Compatibility, SBTI, Assets
- Each endpoint has method, path, parameters, and response examples
- Table of contents for quick navigation
- Updated "Try It" demo to use the actual server API
- Matches existing visual style

### api/openapi.json
- Added 4 missing endpoint specs:
  - `GET /api/agent/{slug}`
  - `GET /api/compatibility`
  - `GET /api/compatibility/matrix`
  - `GET /og/{type}`

## Testing
All 115 tests pass.