### PR TITLE
fix: default all pages to English

### DIFF
--- a/agent.html
+++ b/agent.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="zh">
+<html lang="en">
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -172,14 +172,14 @@ nav a:hover, nav a.active { color: var(--accent); }
   <a href="test-agent.html">Test Agent</a>
   <a href="compatibility.html">Compatibility</a>
   <a href="api.html">API</a>
-  <button class="lang-btn" onclick="toggleLang()">EN</button>
+  <button class="lang-btn" onclick="toggleLang()">中文</button>
 </nav>
 <div class="wrap" id="app">
   <div class="loading" id="loading">Loading...</div>
 </div>
 <script>
 (function() {
-  var lang = 'zh';
+  var lang = 'en';
   var agentData = null;
   var profileData = null;
   var allTypes = null;

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="zh">
+<html lang="en">
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -632,7 +632,7 @@ body {
   <a href="test-agent.html">Test Agent</a>
   <a href="compatibility.html">Compatibility</a>
   <a href="api.html">API</a>
-  <button class="lang-btn" onclick="toggleLang()" id="langBtn">EN</button>
+  <button class="lang-btn" onclick="toggleLang()" id="langBtn">中文</button>
 </nav>
 
 <div class="container">
@@ -702,7 +702,7 @@ body {
 
 <script>
 // === i18n ===
-let lang = 'zh';
+let lang = 'en';
 
 const dimEmojis = ['🎯', '📐', '💬', '🔄'];
 

--- a/sbti.html
+++ b/sbti.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="zh">
+<html lang="en">
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -243,7 +243,7 @@ body {
   <a href="types.html">Types</a>
   <a href="test-agent.html">Test Agent</a>
   <a href="compatibility.html">Compatibility</a>
-  <button class="lang-btn" onclick="toggleLang()" id="langBtn">EN</button>
+  <button class="lang-btn" onclick="toggleLang()" id="langBtn">中文</button>
 </nav>
 
 <div class="container">
@@ -310,7 +310,7 @@ body {
 // 4 dimensions × 4 questions = 16 questions → 16 types
 // ============================================================
 
-let lang = 'zh';
+let lang = 'en';
 let currentQ = 0;
 let dimScores = [0, 0, 0, 0]; // S/C, V/T, H/G, O/I — higher = first pole (S, V, H, O)
 

--- a/test-agent.html
+++ b/test-agent.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="zh">
+<html lang="en">
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -413,7 +413,7 @@ textarea { resize: vertical; min-height: 80px; }
   <a href="test-agent.html" class="active">Test Agent</a>
   <a href="compatibility.html">Compatibility</a>
   <a href="api.html">API</a>
-  <button class="lang-btn" onclick="toggleLang()" id="langBtn">EN</button>
+  <button class="lang-btn" onclick="toggleLang()" id="langBtn">中文</button>
 </nav>
 
 <div class="container">
@@ -512,7 +512,7 @@ textarea { resize: vertical; min-height: 80px; }
 
 <script>
 // ── i18n ──
-let lang = 'zh';
+let lang = 'en';
 const i18n = {
   zh: {
     pageTitle: '测试你的 Agent',

--- a/type.html
+++ b/type.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="zh">
+<html lang="en">
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -173,14 +173,14 @@ nav a:hover, nav a.active { color: var(--accent); }
   <a href="test-agent.html">Test Agent</a>
   <a href="compatibility.html">Compatibility</a>
   <a href="api.html">API</a>
-  <button class="lang-btn" onclick="toggleLang()">EN</button>
+  <button class="lang-btn" onclick="toggleLang()">中文</button>
 </nav>
 <div class="wrap" id="app">
   <div class="loading" id="loading">Loading...</div>
 </div>
 <script>
 (function() {
-  var lang = 'zh';
+  var lang = 'en';
   var typeData = null;
   var dims = null;
   var typeCode = '';


### PR DESCRIPTION
Closes #106

## Changes

5 pages (`index.html`, `agent.html`, `sbti.html`, `test-agent.html`, `type.html`) were defaulting to Chinese:

- `<html lang="zh">` → `<html lang="en">`
- `let lang = 'zh'` → `let lang = 'en'` in JavaScript
- Lang toggle button shows '中文' (correct for English-default state)

## Why

- **SEO**: Search engines now index the English version by default
- **Accessibility**: Screen readers announce the correct language
- **UX**: Global visitors see English first (can still toggle to Chinese)
- **Consistency**: Aligns with the 8 other pages that already defaulted to English

Old versions (`index-v2/v3/v4.html`) intentionally left unchanged.