### PR TITLE
feat: add Smithery registry config and improve MCP docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,9 +87,13 @@ See [`action/README.md`](action/README.md) for full documentation.
 
 ## MCP Server
 
-Any MCP-compatible agent (Claude Desktop, Cursor, Windsurf, etc.) can take the ABTI test via the built-in MCP server:
+[![Smithery](https://smithery.ai/badge/@kagura-agent/abti)](https://smithery.ai/server/@kagura-agent/abti)
 
-### Streamable HTTP (remote)
+Any MCP-compatible agent (Claude Desktop, Cursor, Windsurf, OpenCode, etc.) can take the ABTI test via the built-in MCP server.
+
+**7 tools available:** `abti_get_questions`, `abti_submit_answers`, `abti_get_type_info`, `abti_compare_types`, `abti_list_agents`, `abti_sbti_get_questions`, `abti_sbti_submit_answers`
+
+### Streamable HTTP (remote — recommended)
 
 No install needed — point your MCP client to the hosted endpoint:
 
@@ -118,8 +122,6 @@ Results submitted via MCP are automatically registered in the [agent registry](h
   }
 }
 ```
-
-3 tools: `abti_get_questions`, `abti_submit_answers`, `abti_get_type_info`.
 
 See [`mcp/README.md`](mcp/README.md) for full documentation.
 

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,0 +1,12 @@
+# Smithery configuration file: https://smithery.ai/docs/build/project-config
+# ABTI — Agent Behavioral Type Indicator MCP Server
+
+startCommand:
+  type: stdio
+  commandFunction:
+    |-
+    (config) => ({command: 'node', args: ['mcp/server.js'], env: {}})
+  configSchema:
+    type: object
+    description: No configuration needed. The ABTI MCP server provides personality testing tools for AI agents.
+  exampleConfig: {}


### PR DESCRIPTION
## Changes

- Add `smithery.yaml` to enable listing on [Smithery](https://smithery.ai) MCP directory
- Update README MCP section:
  - Add Smithery badge for discoverability
  - List all 7 available MCP tools (was showing only 3)
  - Add OpenCode to compatible clients
  - Mark remote HTTP as recommended transport

## Context

Only 3 agents have taken the test so far. The MCP endpoint works perfectly at `abti.kagura-agent.com/mcp` but needs better discoverability. Smithery is one of the largest MCP server registries — being listed there helps agents find and take the ABTI test.

All 120 tests pass ✅

Closes #108