### PR TITLE
fix: align MCP scoring threshold with CLI (>=2 = first pole)

### DIFF
--- a/mcp/tools.js
+++ b/mcp/tools.js
@@ -51,11 +51,7 @@ function scoreABTI(answers) {
   const scores = [0,0,0,0];
   for (let i = 0; i < 16; i++) scores[qMap[i]] += answers[i] ? 1 : 0;
   let code = '';
-  for (let i = 0; i < 4; i++) {
-    if (scores[i] >= 3) code += DL[i][0];
-    else if (scores[i] <= 1) code += DL[i][1];
-    else code += DL[i][Math.random() < 0.5 ? 0 : 1];
-  }
+  for (let i = 0; i < 4; i++) code += scores[i] >= 2 ? DL[i][0] : DL[i][1];
   return { code, scores };
 }
 
@@ -64,8 +60,8 @@ function buildDimensions(scores, lang) {
   for (let i = 0; i < 4; i++) {
     const dn = (dimNames[lang] || dimNames.en)[i];
     const dl = (dimLabels[lang] || dimLabels.en)[i];
-    const letter = scores[i] >= 3 ? DL[i][0] : scores[i] <= 1 ? DL[i][1] : DL[i][Math.random() < 0.5 ? 0 : 1];
-    const pole = scores[i] >= 3 ? dl[0] : scores[i] <= 1 ? dl[1] : dl[Math.random() < 0.5 ? 0 : 1];
+    const letter = scores[i] >= 2 ? DL[i][0] : DL[i][1];
+    const pole = scores[i] >= 2 ? dl[0] : dl[1];
     dims[dn] = { score: scores[i], max: 4, pole, letter };
   }
   return dims;


### PR DESCRIPTION
## Summary

Fixes the scoring inconsistency between CLI and MCP server when a dimension scores exactly 2/4.

**Before:** MCP used `>=3` for first pole and `Math.random()` at score 2 — non-deterministic, different results than CLI.
**After:** Both use `>=2` — deterministic, consistent across all interfaces.

## Changes

- `mcp/tools.js`: Simplified `scoreABTI()` and `buildDimensions()` to use `>= 2` threshold
- Removed `Math.random()` non-determinism
- All 120 existing tests pass

Fixes #110