### PR TITLE
fix: align all scoring paths with MCP threshold (>= 2, closes #112)

### DIFF
--- a/api-server.js
+++ b/api-server.js
@@ -105,9 +105,7 @@ function scoreABTI(answers) {
   for (let i = 0; i < 16; i++) scores[qMap[i]] += answers[i] ? 1 : 0;
   let code = '';
   for (let i = 0; i < 4; i++) {
-    if (scores[i] >= 3) code += DL[i][0];
-    else if (scores[i] <= 1) code += DL[i][1];
-    else code += DL[i][Math.random() < 0.5 ? 0 : 1];
+    code += scores[i] >= 2 ? DL[i][0] : DL[i][1];
   }
   return { code, scores };
 }
@@ -358,8 +356,8 @@ const server = http.createServer((req, res) => {
         for (let i = 0; i < 4; i++) {
           const dn = (dimNames[l]||dimNames.en)[i];
           const dl = (dimLabels[l]||dimLabels.en)[i];
-          const letter = scores[i] >= 3 ? DL[i][0] : scores[i] <= 1 ? DL[i][1] : DL[i][Math.random() < 0.5 ? 0 : 1];
-          const pole = scores[i] >= 3 ? dl[0] : scores[i] <= 1 ? dl[1] : dl[Math.random() < 0.5 ? 0 : 1];
+          const letter = scores[i] >= 2 ? DL[i][0] : DL[i][1];
+          const pole = scores[i] >= 2 ? dl[0] : dl[1];
           dims[dn] = { score: scores[i], max: 4, pole, letter };
         }
         // Persist result

--- a/index.html
+++ b/index.html
@@ -1100,9 +1100,7 @@ function getType() {
   if (cachedType) return cachedType;
   let code = '';
   for (let i = 0; i < 4; i++) {
-    if (scores[i] >= 3) code += dimLetters[i][0];
-    else if (scores[i] <= 1) code += dimLetters[i][1];
-    else code += dimLetters[i][Math.round(Math.random())]; // tie: random to remove bias
+    code += scores[i] >= 2 ? dimLetters[i][0] : dimLetters[i][1];
   }
   cachedType = code;
   return code;
@@ -1157,8 +1155,8 @@ function showResult() {
   const labels = t('dimLabels');
   for (let i = 0; i < 4; i++) {
     const pct = (scores[i] / 4) * 100;
-    const leftActive = scores[i] >= 3;
-    const rightActive = scores[i] <= 1;
+    const leftActive = scores[i] >= 2;
+    const rightActive = scores[i] < 2;
     const isBalanced = scores[i] === 2;
     const row = document.createElement('div');
     row.className = 'dim-row';


### PR DESCRIPTION
## Summary

PR #111 fixed the MCP scoring to use `>= 2` as the deterministic threshold, but the same fix was not applied to the API server and web frontend. This PR completes that alignment.

## Changes

### api-server.js
- `scoreABTI()` function: replaced `>= 3 / <= 1 / random tiebreak` with `>= 2 = first pole`
- POST `/api/agent-test` display code: same fix for dimension letter/pole assignment

### index.html
- Client-side `getType()`: replaced `>= 3 / <= 1 / random tiebreak` with `>= 2`
- `showResult()` dimension bar display: aligned `leftActive`/`rightActive` thresholds

## Impact

Before this fix, the same agent taking the test via MCP vs web vs API could get **different type results** for identical answers when any dimension scored exactly 2/4. Now all paths are deterministic and consistent.

## Testing

All 120 tests pass.

Closes #112