### PR TITLE
fix: install mcp dependencies in CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,4 +15,5 @@ jobs:
         with:
           node-version: 22
       - run: npm install
+      - run: cd mcp && npm install
       - run: npm test


### PR DESCRIPTION
Closes #121

## Problem

All CI tests fail with `MODULE_NOT_FOUND` because the test workflow only runs `npm install` at the root, which doesn't install `@modelcontextprotocol/sdk` in `mcp/node_modules/`.

## Fix

Add `cd mcp && npm install` step before `npm test`.

## Verification

- All 120 tests pass locally
- This matches the same pattern used for monorepos with subdirectory dependencies