### PR TITLE
feat: batch test workflow auto-commits results to data/results.json

### DIFF
--- a/.github/workflows/batch-test.yml
+++ b/.github/workflows/batch-test.yml
@@ -71,3 +71,106 @@ jobs:
           echo "- Model: \`${{ matrix.model }}\`" >> "$GITHUB_STEP_SUMMARY"
           echo "- Provider: \`${{ matrix.provider }}\`" >> "$GITHUB_STEP_SUMMARY"
           echo "- Status: ${{ steps.abti-test.outcome }}" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Save result artifact
+        if: steps.abti-test.outcome == 'success'
+        run: |
+          mkdir -p result
+          cat > result/result.json << 'ENDJSON'
+          {
+            "name": "${{ matrix.agent-name }}",
+            "model": "${{ matrix.model }}",
+            "provider": "${{ matrix.provider }}",
+            "type": "${{ steps.abti-test.outputs.type }}",
+            "nick": "${{ steps.abti-test.outputs.nickname }}",
+            "testedAt": "${{ github.event.repository.updated_at || '' }}"
+          }
+          ENDJSON
+          # Use current ISO date instead of repo updated_at
+          node -e "
+            const fs = require('fs');
+            const r = JSON.parse(fs.readFileSync('result/result.json', 'utf8'));
+            r.testedAt = new Date().toISOString();
+            fs.writeFileSync('result/result.json', JSON.stringify(r, null, 2));
+          "
+
+      - name: Upload result artifact
+        if: steps.abti-test.outcome == 'success'
+        uses: actions/upload-artifact@v4
+        with:
+          name: result-${{ matrix.model }}
+          path: result/result.json
+          retention-days: 1
+
+  commit-results:
+    runs-on: ubuntu-latest
+    needs: [test-model]
+    if: always()
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Download all result artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          pattern: result-*
+
+      - name: Merge results into data/results.json
+        run: |
+          node << 'EOF'
+          const fs = require('fs');
+          const path = require('path');
+
+          // Read existing results
+          const resultsPath = 'data/results.json';
+          let data = { total: 0, agents: [] };
+          if (fs.existsSync(resultsPath)) {
+            data = JSON.parse(fs.readFileSync(resultsPath, 'utf8'));
+          }
+
+          // Find all downloaded result files
+          const artifactsDir = 'artifacts';
+          if (!fs.existsSync(artifactsDir)) {
+            console.log('No artifacts found, nothing to merge.');
+            process.exit(0);
+          }
+
+          const dirs = fs.readdirSync(artifactsDir);
+          let newCount = 0;
+
+          for (const dir of dirs) {
+            const filePath = path.join(artifactsDir, dir, 'result.json');
+            if (!fs.existsSync(filePath)) continue;
+
+            const entry = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+            // Update existing entry by model name, or add new
+            const idx = data.agents.findIndex(a => a.model === entry.model);
+            if (idx >= 0) {
+              data.agents[idx] = { ...data.agents[idx], ...entry };
+            } else {
+              data.agents.push(entry);
+            }
+            newCount++;
+          }
+
+          if (newCount === 0) {
+            console.log('No new results to merge.');
+            process.exit(0);
+          }
+
+          data.total = data.agents.length;
+          fs.writeFileSync(resultsPath, JSON.stringify(data, null, 2) + '\n');
+          console.log(`Merged ${newCount} results. Total agents: ${data.total}`);
+          EOF
+
+      - name: Commit and push results
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add data/results.json
+          git diff --cached --quiet && echo "No changes to commit" && exit 0
+          git commit -m "chore: update batch test results [skip ci]"
+          git push


### PR DESCRIPTION
Closes #125

## Changes

Modifies `.github/workflows/batch-test.yml` to persist batch test results to `data/results.json` automatically.

### In the `test-model` job:
- Adds a **Save result artifact** step that creates a JSON file with the test result (name, model, provider, type, nickname, testedAt)
- Adds an **Upload result artifact** step using `actions/upload-artifact@v4`
- Both steps only run when the ABTI test succeeds

### New `commit-results` job:
- Runs after all matrix jobs complete (`needs: [test-model]`, `if: always()`)
- Downloads all result artifacts
- Merges new results into `data/results.json` (updates existing entries by model, adds new ones)
- Auto-commits and pushes with `[skip ci]` to avoid workflow loops
- Uses `github-actions[bot]` as committer

This directly serves the north star: automated testing → auto-persisted results → richer agent directory.