### PR TITLE
fix: type.html and agent.html render crash — adapt to flat API response

### DIFF
--- a/agent.html
+++ b/agent.html
@@ -300,12 +300,38 @@ nav a:hover, nav a.active { color: var(--accent); }
   function fetchAgent() {
     Promise.all([
       fetch('/api/agent/' + encodeURIComponent(slug) + '?lang=' + lang).then(function(r) { return r.ok ? r.json() : null; }),
-      allTypes ? Promise.resolve(null) : fetch('/api/types').then(function(r) { return r.json(); })
+      allTypes ? Promise.resolve(null) : Promise.all([
+        fetch('/api/types?lang=en').then(function(r) { return r.json(); }),
+        fetch('/api/types?lang=zh').then(function(r) { return r.json(); })
+      ])
     ]).then(function(results) {
       var data = results[0];
       if (results[1]) {
-        allTypes = results[1].types;
-        dims = results[1].dimensions;
+        var enData = results[1][0];
+        var zhData = results[1][1];
+        var DL = [['P','R'],['T','E'],['C','D'],['F','N']];
+        var dimLabels = {
+          en: [
+            {name:'Autonomy', pole1:'Proactive', pole2:'Responsive'},
+            {name:'Precision', pole1:'Thorough', pole2:'Efficient'},
+            {name:'Transparency', pole1:'Candid', pole2:'Diplomatic'},
+            {name:'Adaptability', pole1:'Flexible', pole2:'Principled'}
+          ],
+          zh: [
+            {name:'自主性', pole1:'主动', pole2:'响应'},
+            {name:'精确度', pole1:'面面俱到', pole2:'精简高效'},
+            {name:'透明度', pole1:'直言不讳', pole2:'委婉圆滑'},
+            {name:'适应性', pole1:'随机应变', pole2:'坚持原则'}
+          ]
+        };
+        // Build rich allTypes: { CODE: { en: {...}, zh: {...} } }
+        allTypes = {};
+        Object.keys(enData.types).forEach(function(code) {
+          allTypes[code] = { en: enData.types[code], zh: zhData.types[code] };
+        });
+        dims = DL.map(function(letters, i) {
+          return { index: i, letters: letters, en: dimLabels.en[i], zh: dimLabels.zh[i] };
+        });
       }
       if (!data || !data.agent) {
         document.getElementById('loading').textContent = 'Agent not found';

--- a/type.html
+++ b/type.html
@@ -271,14 +271,44 @@ nav a:hover, nav a.active { color: var(--accent); }
       + '<div class="footer">ABTI &mdash; Agent Behavioral Type Indicator</div>';
   }
 
-  fetch('/api/types').then(function(res) { return res.json(); }).then(function(data) {
-    dims = data.dimensions;
-    typeData = data.types[typeCode];
-    if (!typeData) {
+  var DL = [['P','R'],['T','E'],['C','D'],['F','N']];
+  var dimLabels = {
+    en: [
+      {name:'Autonomy', pole1:'Proactive', pole2:'Responsive'},
+      {name:'Precision', pole1:'Thorough', pole2:'Efficient'},
+      {name:'Transparency', pole1:'Candid', pole2:'Diplomatic'},
+      {name:'Adaptability', pole1:'Flexible', pole2:'Principled'}
+    ],
+    zh: [
+      {name:'自主性', pole1:'主动', pole2:'响应'},
+      {name:'精确度', pole1:'面面俱到', pole2:'精简高效'},
+      {name:'透明度', pole1:'直言不讳', pole2:'委婉圆滑'},
+      {name:'适应性', pole1:'随机应变', pole2:'坚持原则'}
+    ]
+  };
+
+  Promise.all([
+    fetch('/api/types?lang=en').then(function(r) { return r.json(); }),
+    fetch('/api/types?lang=zh').then(function(r) { return r.json(); })
+  ]).then(function(results) {
+    var enData = results[0];
+    var zhData = results[1];
+    var enType = enData.types[typeCode];
+    var zhType = zhData.types[typeCode];
+    if (!enType || !zhType) {
       document.getElementById('loading').textContent = 'Type "' + typeCode + '" not found';
       document.getElementById('loading').className = 'error';
       return;
     }
+    typeData = { en: enType, zh: zhType };
+    dims = DL.map(function(letters, i) {
+      return {
+        index: i,
+        letters: letters,
+        en: dimLabels.en[i],
+        zh: dimLabels.zh[i]
+      };
+    });
     render();
   }).catch(function() {
     document.getElementById('loading').textContent = 'Failed to load type data';


### PR DESCRIPTION
## Root Cause

`render()` in both pages expected:
- `typeData[lang].nick` (nested en/zh objects)
- `dims[i][lang].name/pole1/pole2` (rich dimension objects)

But `GET /api/types` returns flat, already-localized data without language nesting.

PR #134 fixed the `data.abti` → `data` path, but the deeper structure mismatch remained — `typeData['en']` was still `undefined`.

## Fix

Fetch both `/api/types?lang=en` and `/api/types?lang=zh` in parallel, combine into `{en: {...}, zh: {...}}` structure, and build rich dimension objects with hardcoded metadata (letters, poles).

## Testing
- 120/120 tests pass ✅
- Verified locally: type pages now render correctly with language toggle