### PR TITLE
fix: remove duplicate twitter meta tags from type.html

### DIFF
--- a/test/api.test.js
+++ b/test/api.test.js
@@ -257,6 +257,21 @@ describe('GET /type/:code', () => {
     assert.equal(r.status, 302);
     assert.equal(r.headers.location, '/');
   });
+
+  it('no duplicate twitter:card or twitter:image meta tags', async () => {
+    const r = await req('/type/PTCF');
+    const cardMatches = r.body.match(/twitter:card/g);
+    const imageMatches = r.body.match(/twitter:image/g);
+    assert.equal(cardMatches.length, 1, `Expected 1 twitter:card tag, found ${cardMatches.length}`);
+    assert.equal(imageMatches.length, 1, `Expected 1 twitter:image tag, found ${imageMatches.length}`);
+  });
+
+  it('twitter:image points to type-specific OG image, not generic', async () => {
+    const r = await req('/type/RECF');
+    assert.match(r.body, /twitter:image.*og\/RECF/);
+    assert.ok(!r.body.includes('twitter:image" content="https://abti.kagura-agent.com/og-abti.png'),
+      'twitter:image should not use generic og-abti.png');
+  });
 });
 
 // ─── GET /api/types ───

--- a/type.html
+++ b/type.html
@@ -4,10 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Type — ABTI</title>
-<meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="Type — ABTI">
-<meta name="twitter:description" content="Detailed profile of an ABTI agent behavioral type">
-<meta name="twitter:image" content="https://abti.kagura-agent.com/og-abti.png">
+<!-- twitter/OG meta tags injected dynamically by api-server.js with type-specific images -->
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",


### PR DESCRIPTION
Closes #141

## Problem
`type.html` had static twitter meta tags with the generic `og-abti.png` image. The server already injects dynamic type-specific OG+twitter tags before `</head>`, resulting in duplicate tags. Social media crawlers (Twitter, Discord) may pick up the first occurrence — the generic image — instead of the type-specific one.

## Changes
- **type.html**: Remove 4 static twitter meta tags, replace with comment noting server-side injection
- **test/api.test.js**: Add 2 tests:
  - Verify no duplicate `twitter:card` or `twitter:image` tags in `/type/:code` responses
  - Verify `twitter:image` points to type-specific OG image, not generic `og-abti.png`

## Testing
```
npm test  # 145 pass, 0 fail
```