### PR TITLE
feat: add DeepSeek as first-class provider

### DIFF
--- a/cli/bin/abti.js
+++ b/cli/bin/abti.js
@@ -104,12 +104,13 @@ if (flag('--help') || flag('-h')) {
     npx abti --auto --provider openai --model gpt-4o --api-key sk-...
     npx abti --auto --provider anthropic --model claude-sonnet-4-20250514
     npx abti --auto --provider gemini --model gemini-2.0-flash
+    npx abti --auto --provider deepseek --model deepseek-chat
 
   Auto mode options:
     --auto                   Enable LLM auto-answer mode
-    --provider <p>           LLM provider: openai|anthropic|gemini (default: openai)
+    --provider <p>           LLM provider: openai|anthropic|gemini|deepseek (default: openai)
     --model <m>              Model name (required for --auto)
-    --api-key <key>          API key (or set OPENAI_API_KEY / ANTHROPIC_API_KEY / GOOGLE_AI_API_KEY)
+    --api-key <key>          API key (or set OPENAI_API_KEY / ANTHROPIC_API_KEY / GOOGLE_AI_API_KEY / DEEPSEEK_API_KEY)
     --prompt <text>          System prompt for the agent persona
     --prompt-file <path>     Read system prompt from file
     --llm-base-url <url>     Custom API base URL (OpenRouter, etc.)
@@ -228,7 +229,8 @@ function callLLM(prov, apiKey, mdl, systemPrompt, userMessage, baseUrl) {
   if (prov === 'openai') return callOpenAI(apiKey, mdl, systemPrompt, userMessage, baseUrl);
   if (prov === 'anthropic') return callAnthropic(apiKey, mdl, systemPrompt, userMessage, baseUrl);
   if (prov === 'gemini') return callGemini(apiKey, mdl, systemPrompt, userMessage);
-  throw new Error(`Unknown provider: ${prov}. Must be "openai", "anthropic", or "gemini".`);
+  if (prov === 'deepseek') return callOpenAI(apiKey, mdl, systemPrompt, userMessage, 'https://api.deepseek.com');
+  throw new Error(`Unknown provider: ${prov}. Must be "openai", "anthropic", "gemini", or "deepseek".`);
 }
 
 function parseAnswer(response) {
@@ -242,7 +244,7 @@ function parseAnswer(response) {
 
 function resolveApiKey(prov, explicit) {
   if (explicit) return explicit;
-  const envMap = { openai: 'OPENAI_API_KEY', anthropic: 'ANTHROPIC_API_KEY', gemini: 'GOOGLE_AI_API_KEY' };
+  const envMap = { openai: 'OPENAI_API_KEY', anthropic: 'ANTHROPIC_API_KEY', gemini: 'GOOGLE_AI_API_KEY', deepseek: 'DEEPSEEK_API_KEY' };
   const envKey = envMap[prov];
   if (envKey && process.env[envKey]) return process.env[envKey];
   throw new Error(`No API key provided. Use --api-key or set ${envKey}`);

--- a/test-agent.html
+++ b/test-agent.html
@@ -434,6 +434,7 @@ textarea { resize: vertical; min-height: 80px; }
         <option value="openai">OpenAI</option>
         <option value="anthropic">Anthropic</option>
         <option value="google">Google AI</option>
+        <option value="deepseek">DeepSeek</option>
         <option value="openrouter">OpenRouter</option>
         <option value="custom">Custom Endpoint</option>
       </select>
@@ -675,6 +676,12 @@ const providers = {
     models: ['gemini-2.0-flash', 'gemini-2.5-pro', 'gemini-1.5-flash'],
     auth: 'query',
     format: 'google',
+  },
+  deepseek: {
+    url: 'https://api.deepseek.com/chat/completions',
+    models: ['deepseek-chat', 'deepseek-reasoner'],
+    auth: 'bearer',
+    format: 'openai',
   },
   openrouter: {
     url: 'https://openrouter.ai/api/v1/chat/completions',


### PR DESCRIPTION
## Changes
- Add DeepSeek to test-agent.html provider dropdown with correct API URL and default models (`deepseek-chat`, `deepseek-reasoner`)
- Add DeepSeek provider to CLI, reusing OpenAI-compatible format with DeepSeek base URL  
- Add `DEEPSEEK_API_KEY` env var support
- Update help text

DeepSeek uses an OpenAI-compatible API, so the implementation reuses existing `callOpenAI()` with a custom base URL.

All 145 tests pass ✅

Closes #145