### PR TITLE
feat: add personality tuning guide to test results

### DIFF
--- a/index.html
+++ b/index.html
@@ -599,6 +599,24 @@ body {
   line-height: 1.6;
 }
 
+/* Tuning Guide */
+.tuning-guide { margin-top: 1.5rem; }
+.tuning-guide-intro { color: var(--text2); font-size: 0.88rem; line-height: 1.7; margin-bottom: 1rem; }
+.tuning-dim { border: 1px solid var(--border); border-radius: 10px; margin-bottom: 0.6rem; overflow: hidden; background: var(--surface); }
+.tuning-dim-header { display: flex; align-items: center; justify-content: space-between; padding: 0.75rem 1rem; cursor: pointer; user-select: none; transition: background 0.2s; }
+.tuning-dim-header:hover { background: rgba(232,101,138,0.04); }
+.tuning-dim-header .dim-name { font-weight: 600; font-size: 0.9rem; color: var(--text); }
+.tuning-dim-header .dim-current { font-size: 0.78rem; color: var(--accent); font-weight: 500; }
+.tuning-dim-header .dim-arrow { font-size: 0.7rem; color: var(--text2); transition: transform 0.2s; }
+.tuning-dim-header .dim-arrow.open { transform: rotate(90deg); }
+.tuning-dim-body { display: none; padding: 0 1rem 0.8rem; }
+.tuning-dim-body.open { display: block; }
+.tuning-target { font-size: 0.82rem; color: var(--text2); margin-bottom: 0.5rem; font-weight: 500; }
+.tuning-snippet { position: relative; background: var(--surface2); border-radius: 8px; padding: 0.6rem 2.8rem 0.6rem 0.8rem; margin-bottom: 0.4rem; font-size: 0.82rem; color: var(--text); line-height: 1.6; font-style: italic; }
+.tuning-copy { position: absolute; right: 0.5rem; top: 50%; transform: translateY(-50%); background: none; border: 1px solid var(--border); border-radius: 6px; padding: 0.25rem 0.5rem; font-size: 0.68rem; color: var(--text2); cursor: pointer; transition: all 0.2s; }
+.tuning-copy:hover { border-color: var(--accent); color: var(--accent); }
+.tuning-copy.copied { border-color: #22c55e; color: #22c55e; }
+
 .footer {
   text-align: center;
   color: #b0aca6;
@@ -811,6 +829,12 @@ const i18n = {
     dirSuccessLink: 'Agent Directory',
     dirError: 'Registration failed. Please try again.',
     profLabels: { strengths: 'Strengths', blindSpots: 'Blind Spots', workStyle: 'Work Style', bestPairedWith: 'Best Paired With' },
+    tuningTitle: '🎛️ Personality Tuning Guide',
+    tuningIntro: 'Want to shift your agent\'s personality? Add these snippets to your system prompt, then re-test to see the change.',
+    tuningCurrent: pole => `Currently: ${pole}`,
+    tuningTarget: pole => `→ Shift toward ${pole}:`,
+    tuningCopy: 'Copy',
+    tuningCopied: 'Copied!',
     balanced: 'Balanced',
     allTypes: 'All 16 types',
     famousTitle: 'Famous agents with your type',
@@ -953,6 +977,12 @@ const i18n = {
     dirSuccessLink: '智能体目录',
     dirError: '注册失败，请稍后重试。',
     profLabels: { strengths: '核心优势', blindSpots: '盲点', workStyle: '工作风格', bestPairedWith: '最佳搭配' },
+    tuningTitle: '🎛️ 人格调优指南',
+    tuningIntro: '想调整你的智能体人格？把这些指令片段加到 system prompt 里，然后重新测试看看变化。',
+    tuningCurrent: pole => `当前：${pole}`,
+    tuningTarget: pole => `→ 向 ${pole} 调整：`,
+    tuningCopy: '复制',
+    tuningCopied: '已复制!',
     balanced: '均衡',
     allTypes: '全部 16 种类型',
     famousTitle: '与你同类型的知名智能体',
@@ -1095,6 +1125,105 @@ const famousMap = {
   RECN: ['Perplexity'],
   REDF: ['Kagi'],
   REDN: ['GitHub Copilot (Chat/inline)', 'Google Translate', 'DeepL'],
+};
+
+const tuningGuide = {
+  P: {
+    en: [
+      "Take initiative when you notice problems \u2014 don't wait to be asked",
+      "Proactively suggest improvements and anticipate the user's next needs",
+      "If you see a better approach, propose it immediately"
+    ],
+    zh: [
+      "\u53d1\u73b0\u95ee\u9898\u65f6\u4e3b\u52a8\u5904\u7406\u2014\u2014\u4e0d\u8981\u7b49\u522b\u4eba\u6765\u95ee",
+      "\u4e3b\u52a8\u5efa\u8bae\u6539\u8fdb\u65b9\u6848\uff0c\u9884\u5224\u7528\u6237\u7684\u4e0b\u4e00\u6b65\u9700\u6c42",
+      "\u5982\u679c\u4f60\u770b\u5230\u66f4\u597d\u7684\u65b9\u5411\uff0c\u7acb\u523b\u63d0\u51fa\u6765"
+    ]
+  },
+  R: {
+    en: [
+      "Wait for explicit instructions before taking action beyond the immediate request",
+      "Focus on exactly what was asked \u2014 do not expand scope without permission",
+      "Confirm before making changes that weren't explicitly requested"
+    ],
+    zh: [
+      "\u5728\u6ca1\u6709\u660e\u786e\u6307\u793a\u524d\u4e0d\u8981\u64c5\u81ea\u884c\u52a8",
+      "\u53ea\u505a\u88ab\u8981\u6c42\u7684\u4e8b\u2014\u2014\u4e0d\u8981\u672a\u7ecf\u8bb8\u53ef\u6269\u5c55\u8303\u56f4",
+      "\u505a\u51fa\u989d\u5916\u6539\u52a8\u524d\u5148\u786e\u8ba4"
+    ]
+  },
+  T: {
+    en: [
+      "Provide comprehensive analysis: cover edge cases, risks, and alternatives",
+      "When reviewing, annotate everything \u2014 grammar, logic, tone, and implications",
+      "Include documentation, error handling, and monitoring in every implementation"
+    ],
+    zh: [
+      "\u63d0\u4f9b\u5168\u9762\u5206\u6790\uff1a\u8986\u76d6\u8fb9\u7f18\u60c5\u51b5\u3001\u98ce\u9669\u548c\u66ff\u4ee3\u65b9\u6848",
+      "\u5ba1\u67e5\u65f6\u9010\u9879\u6279\u6ce8\u2014\u2014\u8bed\u6cd5\u3001\u903b\u8f91\u3001\u8bed\u6c14\u3001\u6f5c\u5728\u5f71\u54cd",
+      "\u6bcf\u6b21\u5b9e\u73b0\u90fd\u5305\u542b\u6587\u6863\u3001\u9519\u8bef\u5904\u7406\u548c\u76d1\u63a7"
+    ]
+  },
+  E: {
+    en: [
+      "Be concise: highlight only the 2-3 most critical points",
+      "Ship the minimal viable solution first, iterate later",
+      "Answer briefly \u2014 if the user wants more detail, they will ask"
+    ],
+    zh: [
+      "\u7b80\u6d01\u4e3a\u738b\uff1a\u53ea\u5f3a\u8c03 2-3 \u4e2a\u6700\u5173\u952e\u7684\u70b9",
+      "\u5148\u4ea4\u4ed8\u6700\u5c0f\u53ef\u884c\u65b9\u6848\uff0c\u540e\u7eed\u518d\u8fed\u4ee3",
+      "\u7b80\u77ed\u56de\u7b54\u2014\u2014\u7528\u6237\u60f3\u8981\u66f4\u591a\u7ec6\u8282\u4f1a\u4e3b\u52a8\u95ee"
+    ]
+  },
+  C: {
+    en: [
+      "Be direct about problems \u2014 state issues clearly without softening language",
+      "If you made a mistake, say so plainly with the cause and fix plan",
+      "Give honest assessments even when the truth is uncomfortable"
+    ],
+    zh: [
+      "\u76f4\u8a00\u95ee\u9898\u2014\u2014\u6e05\u6670\u9648\u8ff0\uff0c\u4e0d\u8981\u67d4\u5316\u63aa\u8f9e",
+      "\u72af\u4e86\u9519\u5c31\u76f4\u8bf4\uff0c\u9644\u4e0a\u539f\u56e0\u548c\u4fee\u590d\u8ba1\u5212",
+      "\u5373\u4f7f\u771f\u76f8\u4e0d\u597d\u542c\u4e5f\u8981\u7ed9\u51fa\u8bda\u5b9e\u8bc4\u4f30"
+    ]
+  },
+  D: {
+    en: [
+      "Frame feedback constructively \u2014 lead with what works well before suggesting changes",
+      "Present risks as part of a balanced analysis, not as warnings",
+      "When disagreeing, acknowledge the user's reasoning before offering alternatives"
+    ],
+    zh: [
+      "\u5efa\u8bbe\u6027\u5730\u8868\u8fbe\u53cd\u9988\u2014\u2014\u5148\u80af\u5b9a\u505a\u5f97\u597d\u7684\u5730\u65b9\uff0c\u518d\u5efa\u8bae\u6539\u8fdb",
+      "\u628a\u98ce\u9669\u4f5c\u4e3a\u5e73\u8861\u5206\u6790\u7684\u4e00\u90e8\u5206\u6765\u5448\u73b0\uff0c\u800c\u4e0d\u662f\u5355\u7eaf\u7684\u8b66\u544a",
+      "\u8868\u8fbe\u4e0d\u540c\u610f\u89c1\u65f6\uff0c\u5148\u8ba4\u53ef\u7528\u6237\u7684\u601d\u8def\uff0c\u518d\u63d0\u51fa\u66ff\u4ee3\u65b9\u6848"
+    ]
+  },
+  F: {
+    en: [
+      "Adapt quickly to changing requirements \u2014 treat pivots as opportunities",
+      "Match the user's coding style and preferences, even if unconventional",
+      "When plans change, rebuild with lessons learned rather than resisting"
+    ],
+    zh: [
+      "\u5feb\u901f\u9002\u5e94\u9700\u6c42\u53d8\u66f4\u2014\u2014\u628a\u8f6c\u5411\u5f53\u4f5c\u673a\u4f1a",
+      "\u914d\u5408\u7528\u6237\u7684\u7f16\u7801\u98ce\u683c\u548c\u504f\u597d\uff0c\u5373\u4f7f\u4e0d\u592a\u5e38\u89c4",
+      "\u8ba1\u5212\u53d8\u4e86\u5c31\u5e26\u7740\u7ecf\u9a8c\u91cd\u5efa\uff0c\u4e0d\u8981\u62b5\u89e6"
+    ]
+  },
+  N: {
+    en: [
+      "Push back on scope changes \u2014 explain the cost of switching approaches",
+      "Maintain consistency: advocate for best practices even under pressure",
+      "When the user proposes a risky approach, make your case with data before complying"
+    ],
+    zh: [
+      "\u62b5\u5236\u8303\u56f4\u8513\u5ef6\u2014\u2014\u89e3\u91ca\u5207\u6362\u65b9\u6848\u7684\u6210\u672c",
+      "\u4fdd\u6301\u4e00\u81f4\u6027\uff1a\u5373\u4f7f\u6709\u538b\u529b\u4e5f\u575a\u6301\u6700\u4f73\u5b9e\u8df5",
+      "\u7528\u6237\u63d0\u51fa\u6709\u98ce\u9669\u7684\u65b9\u6848\u65f6\uff0c\u5148\u7528\u6570\u636e\u8bf4\u660e\u518d\u6267\u884c"
+    ]
+  }
 };
 
 let current = 0;
@@ -1325,6 +1454,37 @@ function showResult() {
         }).join('');
         html += `<div class="profile-section"><h3>${pl.bestPairedWith}</h3><ul>${pairHtml}</ul></div>`;
       }
+      // Tuning Guide
+      const tgLang = lang === 'zh' ? 'zh' : 'en';
+      const dimPoles = [['P','R'],['T','E'],['C','D'],['F','N']];
+      const dimNamesLocal = t('dimNames');
+      const dimLabelsLocal = t('dimLabels');
+      html += '<div class="profile-section tuning-guide"><h3>' + t('tuningTitle') + '</h3>';
+      html += '<p class="tuning-guide-intro">' + t('tuningIntro') + '</p>';
+      for (let i = 0; i < 4; i++) {
+        const scored = scores[i] > 2 ? 0 : 1;
+        const currentPole = dimLabelsLocal[i][scored];
+        const targetIdx = scored === 0 ? 1 : 0;
+        const targetPole = dimLabelsLocal[i][targetIdx];
+        const targetLetter = dimPoles[i][targetIdx];
+        const snippets = tuningGuide[targetLetter][tgLang];
+        const uid = 'tuning-dim-' + i;
+        html += '<div class="tuning-dim">';
+        html += '<div class="tuning-dim-header" onclick="document.getElementById(\'' + uid + '\').classList.toggle(\'open\');this.querySelector(\'.dim-arrow\').classList.toggle(\'open\')">';
+        html += '<span class="dim-name">' + dimNamesLocal[i] + '</span>';
+        html += '<span class="dim-current">' + t('tuningCurrent')(currentPole) + '</span>';
+        html += '<span class="dim-arrow">\u25b6</span>';
+        html += '</div>';
+        html += '<div class="tuning-dim-body" id="' + uid + '">';
+        html += '<div class="tuning-target">' + t('tuningTarget')(targetPole) + '</div>';
+        snippets.forEach(function(s, si) {
+          var escaped = s.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/"/g,'&quot;');
+          html += '<div class="tuning-snippet" data-snippet="' + escaped + '">\u201c' + s + '\u201d<button class="tuning-copy" onclick="copyTuningSnippet(this)">' + t('tuningCopy') + '</button></div>';
+        });
+        html += '</div></div>';
+      }
+      html += '</div>';
+
       profileEl.innerHTML = html;
     })
     .catch(() => {});
@@ -1409,6 +1569,15 @@ function copyLink() {
     btn.textContent = t('copyLinkSuccess');
     btn.classList.add('copied');
     setTimeout(() => { btn.textContent = t('copyLink'); btn.classList.remove('copied'); }, 2000);
+  });
+}
+
+function copyTuningSnippet(btn) {
+  const snippet = btn.parentElement.getAttribute('data-snippet');
+  navigator.clipboard.writeText(snippet).then(function() {
+    btn.textContent = t('tuningCopied');
+    btn.classList.add('copied');
+    setTimeout(function() { btn.textContent = t('tuningCopy'); btn.classList.remove('copied'); }, 1500);
   });
 }
 


### PR DESCRIPTION
Closes #151

## What

Adds a **Personality Tuning Guide** section to the ABTI test result page. After users see their type (strengths, blind spots, work style, best pairs), they now also get actionable system prompt suggestions to shift each dimension.

## How it works

- Shows all 4 dimensions with the agent's current scored pole
- Each dimension is collapsible — click to expand
- Inside: 3 concrete system prompt snippets to shift toward the opposite pole
- Copy button on each snippet (clipboard API)
- Full i18n (en + zh)

## Why

- Makes test results **actionable**, not just informational
- Creates a **test → tune → re-test loop** that drives repeat usage
- Directly serves agent builders — the primary audience
- Differentiates ABTI from generic personality quizzes

## Screenshot

_(The section appears after Best Paired With in the profile area)_

Each dimension shows like:
- **Autonomy** · Currently: Proactive → click to expand
  - → Shift toward Responsive:
  - "Wait for explicit instructions before taking action..." [Copy]
  - "Focus on exactly what was asked..." [Copy]
  - "Confirm before making changes..." [Copy]