### PR TITLE
feat: add Ollama as first-class provider for local model testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,20 @@ Show your ABTI type in any README:
 
 Replace `PTCF` with your type code. All 16 types are supported.
 
+## CLI
+
+Test any AI agent from the command line:
+
+```bash
+npx abti --auto --provider openai --model gpt-4o --api-key sk-...
+npx abti --auto --provider anthropic --model claude-sonnet-4-20250514
+npx abti --auto --provider ollama --model llama3.1
+```
+
+Ollama requires no API key — just make sure Ollama is running locally.
+
+Run `npx abti --help` for all options.
+
 ## GitHub Action
 
 Test your AI agent's personality in CI. Add to any workflow:

--- a/cli/bin/abti.js
+++ b/cli/bin/abti.js
@@ -105,10 +105,11 @@ if (flag('--help') || flag('-h')) {
     npx abti --auto --provider anthropic --model claude-sonnet-4-20250514
     npx abti --auto --provider gemini --model gemini-2.0-flash
     npx abti --auto --provider deepseek --model deepseek-chat
+    npx abti --auto --provider ollama --model llama3.1
 
   Auto mode options:
     --auto                   Enable LLM auto-answer mode
-    --provider <p>           LLM provider: openai|anthropic|gemini|deepseek (default: openai)
+    --provider <p>           LLM provider: openai|anthropic|gemini|deepseek|ollama (default: openai)
     --model <m>              Model name (required for --auto)
     --api-key <key>          API key (or set OPENAI_API_KEY / ANTHROPIC_API_KEY / GOOGLE_AI_API_KEY / DEEPSEEK_API_KEY)
     --prompt <text>          System prompt for the agent persona
@@ -230,7 +231,8 @@ function callLLM(prov, apiKey, mdl, systemPrompt, userMessage, baseUrl) {
   if (prov === 'anthropic') return callAnthropic(apiKey, mdl, systemPrompt, userMessage, baseUrl);
   if (prov === 'gemini') return callGemini(apiKey, mdl, systemPrompt, userMessage);
   if (prov === 'deepseek') return callOpenAI(apiKey, mdl, systemPrompt, userMessage, 'https://api.deepseek.com');
-  throw new Error(`Unknown provider: ${prov}. Must be "openai", "anthropic", "gemini", or "deepseek".`);
+  if (prov === 'ollama') return callOpenAI(apiKey || 'ollama', mdl, systemPrompt, userMessage, 'http://localhost:11434');
+  throw new Error(`Unknown provider: ${prov}. Must be "openai", "anthropic", "gemini", "deepseek", or "ollama".`);
 }
 
 function parseAnswer(response) {
@@ -244,6 +246,7 @@ function parseAnswer(response) {
 
 function resolveApiKey(prov, explicit) {
   if (explicit) return explicit;
+  if (prov === 'ollama') return 'ollama';
   const envMap = { openai: 'OPENAI_API_KEY', anthropic: 'ANTHROPIC_API_KEY', gemini: 'GOOGLE_AI_API_KEY', deepseek: 'DEEPSEEK_API_KEY' };
   const envKey = envMap[prov];
   if (envKey && process.env[envKey]) return process.env[envKey];

--- a/test-agent.html
+++ b/test-agent.html
@@ -435,6 +435,7 @@ textarea { resize: vertical; min-height: 80px; }
         <option value="anthropic">Anthropic</option>
         <option value="google">Google AI</option>
         <option value="deepseek">DeepSeek</option>
+        <option value="ollama">Ollama (Local)</option>
         <option value="openrouter">OpenRouter</option>
         <option value="custom">Custom Endpoint</option>
       </select>
@@ -707,6 +708,12 @@ const providers = {
     auth: 'bearer',
     format: 'openai',
   },
+  ollama: {
+    url: 'http://localhost:11434/v1/chat/completions',
+    models: ['llama3.1', 'llama3.2', 'gemma2', 'mistral', 'phi3', 'qwen2.5', 'deepseek-r1', 'custom'],
+    auth: null,
+    format: 'openai',
+  },
   openrouter: {
     url: 'https://openrouter.ai/api/v1/chat/completions',
     models: ['openai/gpt-oss-120b:free', 'google/gemma-4-31b-it:free', 'google/gemma-4-26b-a4b-it:free', 'qwen/qwen3-coder:free', 'qwen/qwen3-next-80b-a3b-instruct:free', 'nvidia/nemotron-3-super-120b-a12b:free', 'nvidia/nemotron-3-nano-30b-a3b:free', 'minimax/minimax-m2.5:free', 'custom'],
@@ -742,6 +749,28 @@ function onProviderChange() {
     modelInput.classList.remove('hidden');
   }
   customFields.classList.toggle('hidden', p !== 'custom');
+
+  // Hide API key for providers that don't need it (e.g. ollama)
+  const apiKeyRow = document.getElementById('apiKeyLabel');
+  const apiKeyInput = document.getElementById('apiKeyInput');
+  const noAuth = cfg.auth === null && p !== 'custom';
+  apiKeyRow.classList.toggle('hidden', noAuth);
+  apiKeyInput.classList.toggle('hidden', noAuth);
+
+  // Show CORS note for ollama
+  let ollamaNote = document.getElementById('ollamaCorsNote');
+  if (p === 'ollama') {
+    if (!ollamaNote) {
+      ollamaNote = document.createElement('div');
+      ollamaNote.id = 'ollamaCorsNote';
+      ollamaNote.className = 'privacy-notice';
+      ollamaNote.innerHTML = '<svg width="16" height="16" viewBox="0 0 16 16" fill="none"><circle cx="8" cy="8" r="7" stroke="currentColor" stroke-width="1.5" fill="none"/><path d="M8 4v5M8 11v1" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/></svg><span>Make sure Ollama is running locally. Set <code>OLLAMA_ORIGINS=*</code> to allow browser requests.</span>';
+      document.getElementById('providerSelect').parentElement.appendChild(ollamaNote);
+    }
+    ollamaNote.classList.remove('hidden');
+  } else if (ollamaNote) {
+    ollamaNote.classList.add('hidden');
+  }
 }
 
 function onModelChange() {
@@ -843,10 +872,9 @@ let running = false;
 let abortController = null;
 
 async function startTest() {
-  const apiKey = document.getElementById('apiKeyInput').value.trim();
-  if (!apiKey) return alert(t('apiKeyRequired'));
-
   const p = document.getElementById('providerSelect').value;
+  const apiKey = document.getElementById('apiKeyInput').value.trim();
+  if (!apiKey && providers[p]?.auth !== null) return alert(t('apiKeyRequired'));
   if (p === 'custom' && !document.getElementById('customUrl').value.trim()) return alert(t('customUrlRequired'));
   const selectedModel = document.getElementById('modelSelect').value;
   if ((!providers[p].models || selectedModel === 'custom') && !document.getElementById('modelInput').value.trim()) return alert(t('modelRequired'));


### PR DESCRIPTION
Closes #155

## Changes

### CLI (`cli/bin/abti.js`)
- Added `ollama` as a recognized `--provider` value
- Default base URL: `http://localhost:11434/v1/chat/completions`
- No API key required — auto-resolved to placeholder
- Updated `--help` text with Ollama example

### Test Agent Page (`test-agent.html`)
- Added 'Ollama (Local)' to provider dropdown (between DeepSeek and OpenRouter)
- Popular model presets: llama3.1, llama3.2, gemma2, mistral, phi3, qwen2.5, deepseek-r1
- API key input hidden when Ollama is selected
- CORS info note: 'Set `OLLAMA_ORIGINS=*` to allow browser requests'

### README.md
- Added CLI section with usage examples including Ollama

## Why
Removes the cost barrier for testing — users with Ollama installed can test any local model without API keys. Directly serves the north star of getting more agents to take the test.

## Testing
- All 122 existing tests pass ✅
- CLI `--help` renders correctly with new provider