### PR TITLE
feat: add Agent Leaderboard page with consistency rankings

### DIFF
--- a/agents.html
+++ b/agents.html
@@ -135,6 +135,7 @@ nav a:hover, nav a.active { color: var(--accent); }
   <a href="index.html">ABTI</a>
   <a href="sbti.html">SBTI-AI</a>
   <a href="agents.html" class="active">Agents</a>
+  <a href="leaderboard.html">Leaderboard</a>
   <a href="types.html">Types</a>
   <a href="compare.html">Compare</a>
   <a href="test-agent.html">Test Agent</a>

--- a/api-server.js
+++ b/api-server.js
@@ -372,6 +372,8 @@ const server = http.createServer((req, res) => {
           const entry = { name, slug, url: urlStr, type: code, nick: t?.en?.nick || 'Unknown', testedAt: now, scores: scores.slice(), dimensions: DL.map((d, i) => ({ poles: d, score: scores[i], max: 4 })) };
           if (typeof model === 'string' && model) entry.model = model.slice(0, 64);
           if (typeof provider === 'string' && provider) entry.provider = provider.slice(0, 32);
+          if (typeof parsed.consistency === 'number' && parsed.consistency >= 0 && parsed.consistency <= 100) entry.consistency = Math.round(parsed.consistency * 100) / 100;
+          if (typeof parsed.runs === 'number' && Number.isInteger(parsed.runs) && parsed.runs > 0) entry.runs = parsed.runs;
           if (existing !== -1) {
             agentData.agents[existing] = entry;
           } else {
@@ -438,6 +440,22 @@ const server = http.createServer((req, res) => {
   if (url.pathname === '/api/agents' && req.method === 'GET') {
     res.writeHead(200, {'Content-Type':'application/json'});
     return res.end(JSON.stringify({ total: agentData.total, agents: agentData.agents }));
+  }
+
+  // GET /api/leaderboard - ranked agents by consistency
+  if (url.pathname === '/api/leaderboard' && req.method === 'GET') {
+    const agents = agentData.agents || [];
+    const ranked = agents
+      .filter(a => typeof a.consistency === 'number' && typeof a.runs === 'number' && a.runs > 0)
+      .map(a => ({ name: a.name, slug: a.slug, model: a.model || null, provider: a.provider || null, type: a.type, nick: a.nick, consistency: a.consistency, runs: a.runs, scores: a.scores || null, testedAt: a.testedAt }))
+      .sort((a, b) => b.consistency - a.consistency || b.runs - a.runs);
+    const rankedSlugs = new Set(ranked.map(a => a.slug));
+    const unranked = agents
+      .filter(a => !rankedSlugs.has(a.slug))
+      .map(a => ({ name: a.name, slug: a.slug, model: a.model || null, provider: a.provider || null, type: a.type, nick: a.nick, testedAt: a.testedAt }))
+      .sort((a, b) => (b.testedAt || '').localeCompare(a.testedAt || ''));
+    res.writeHead(200, {'Content-Type':'application/json'});
+    return res.end(JSON.stringify({ ranked, unranked }));
   }
 
   // GET /api/stats - aggregate statistics
@@ -944,6 +962,18 @@ ${dimInfo.map((d, i) => {
     }
   }
 
+  // GET /leaderboard - serve leaderboard.html
+  if (url.pathname === '/leaderboard' && req.method === 'GET') {
+    try {
+      const html = fs.readFileSync(path.join(__dirname, 'leaderboard.html'), 'utf8');
+      res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+      return res.end(html);
+    } catch {
+      res.writeHead(500, {'Content-Type':'text/plain'});
+      return res.end('Server error');
+    }
+  }
+
   // MCP Streamable HTTP transport on /mcp
   if (url.pathname === '/mcp') {
     handleMcpRequest(req, res);
@@ -966,7 +996,7 @@ ${dimInfo.map((d, i) => {
   if (url.pathname === '/sitemap.xml' && req.method === 'GET') {
     const BASE = 'https://abti.kagura-agent.com';
     const VALID_TYPES = ['PTCF','PTCN','PTDF','PTDN','PECF','PECN','PEDF','PEDN','RTCF','RTCN','RTDF','RTDN','RECF','RECN','REDF','REDN'];
-    const staticPages = ['/', '/types.html', '/agents.html', '/compare.html', '/api.html', '/sbti.html', '/test-agent.html', '/cross-compatibility.html'];
+    const staticPages = ['/', '/types.html', '/agents.html', '/compare.html', '/api.html', '/sbti.html', '/test-agent.html', '/cross-compatibility.html', '/leaderboard.html'];
     const urls = staticPages.map(p => `  <url><loc>${BASE}${p}</loc></url>`);
     VALID_TYPES.forEach(code => urls.push(`  <url><loc>${BASE}/type/${code}</loc></url>`));
     VALID_TYPES.forEach(code => urls.push(`  <url><loc>${BASE}/result/${code}</loc></url>`));

--- a/leaderboard.html
+++ b/leaderboard.html
@@ -1,0 +1,265 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Leaderboard — ABTI</title>
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Agent Leaderboard — ABTI">
+<meta name="twitter:description" content="AI agent consistency rankings from multi-run ABTI testing">
+<meta name="twitter:image" content="https://abti.kagura-agent.com/og-abti.png">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=DM+Sans:opsz,wght@9..40,400;9..40,500;9..40,600;9..40,700&family=Noto+Serif+SC:wght@400;600&display=swap" rel="stylesheet">
+<style>
+:root {
+  --bg: #faf9f7; --surface: #ffffff; --surface2: #f0eeeb;
+  --text: #1a1a1a; --text2: #6b6b6b; --text3: #a3a3a3;
+  --accent: #e8658a; --accent2: #d44d73; --accent-soft: #fdf0f3;
+  --border: #e8e5e1; --radius: 14px;
+  --shadow: 0 1px 3px rgba(0,0,0,.06);
+  --shadow-md: 0 4px 12px rgba(0,0,0,.08);
+}
+* { margin: 0; padding: 0; box-sizing: border-box; }
+body { font-family: 'DM Sans', system-ui, sans-serif; background: var(--bg); color: var(--text); min-height: 100vh; -webkit-font-smoothing: antialiased; }
+
+nav { position: fixed; top: 0; left: 0; right: 0; display: flex; align-items: center; justify-content: center; gap: 2rem; padding: .7rem 1rem; background: rgba(250,249,247,.88); backdrop-filter: blur(12px); -webkit-backdrop-filter: blur(12px); border-bottom: 1px solid var(--border); z-index: 100; font-size: .82rem; letter-spacing: .08em; }
+nav a { color: var(--text2); text-decoration: none; font-weight: 500; transition: color .2s; }
+nav a:hover, nav a.active { color: var(--accent); }
+
+.wrap { max-width: 760px; margin: 0 auto; padding: 5rem 1.25rem 3rem; }
+
+.header { text-align: center; margin-bottom: 2rem; }
+.header h1 { font-size: 2.2rem; font-weight: 700; margin-bottom: .4rem; }
+.header h1 span { color: var(--accent); }
+.header .sub { color: var(--text2); font-size: .95rem; line-height: 1.7; }
+
+.lang-btn { position: fixed; top: .55rem; right: 1rem; z-index: 101; background: var(--surface); border: 1px solid var(--border); border-radius: 6px; padding: .25rem .6rem; font-size: .78rem; color: var(--text2); cursor: pointer; font-family: inherit; }
+.lang-btn:hover { color: var(--accent); border-color: var(--accent); }
+
+.banner { background: var(--accent-soft); border: 1px solid #f3d0da; border-radius: var(--radius); padding: 1rem 1.25rem; margin-bottom: 1.5rem; font-size: .9rem; color: var(--text); line-height: 1.7; }
+.banner a { color: var(--accent); font-weight: 600; text-decoration: none; }
+.banner a:hover { text-decoration: underline; }
+
+.section-title { font-size: 1.1rem; font-weight: 600; margin: 2rem 0 .75rem; color: var(--text); display: flex; align-items: center; gap: .5rem; }
+.section-title .badge { background: var(--accent); color: #fff; font-size: .7rem; padding: .15rem .5rem; border-radius: 20px; font-weight: 600; }
+
+.rank-list { display: flex; flex-direction: column; gap: .6rem; }
+
+.rank-card { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); padding: 1rem 1.15rem; box-shadow: var(--shadow); transition: box-shadow .2s, transform .2s; display: grid; grid-template-columns: 2.2rem 1fr auto; align-items: center; gap: .75rem; }
+.rank-card:hover { box-shadow: var(--shadow-md); transform: translateY(-1px); }
+
+.rank-num { font-size: 1.1rem; font-weight: 700; color: var(--accent); text-align: center; }
+.rank-num.gold { color: #d4a017; }
+.rank-num.silver { color: #8a8a8a; }
+.rank-num.bronze { color: #b5651d; }
+
+.rank-info { min-width: 0; }
+.rank-name { font-weight: 600; font-size: .95rem; margin-bottom: .2rem; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.rank-name a { color: var(--text); text-decoration: none; }
+.rank-name a:hover { color: var(--accent); }
+.rank-meta { font-size: .78rem; color: var(--text2); display: flex; flex-wrap: wrap; gap: .35rem .75rem; }
+.rank-meta .type-pill { display: inline-block; background: var(--accent-soft); color: var(--accent); padding: .1rem .45rem; border-radius: 4px; font-weight: 600; font-size: .72rem; text-decoration: none; }
+.rank-meta .type-pill:hover { background: var(--accent); color: #fff; }
+
+.rank-score { text-align: right; white-space: nowrap; }
+.score-val { font-size: 1.3rem; font-weight: 700; color: var(--accent); line-height: 1; }
+.score-label { font-size: .68rem; color: var(--text3); margin-top: .15rem; }
+.score-bar { width: 60px; height: 4px; background: var(--surface2); border-radius: 2px; margin-top: .3rem; overflow: hidden; margin-left: auto; }
+.score-fill { height: 100%; background: var(--accent); border-radius: 2px; transition: width .4s ease; }
+.runs-info { font-size: .72rem; color: var(--text3); margin-top: .15rem; }
+
+.unranked-card { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); padding: .85rem 1.15rem; box-shadow: var(--shadow); display: flex; align-items: center; justify-content: space-between; gap: .75rem; }
+.unranked-card:hover { box-shadow: var(--shadow-md); }
+.unranked-name { font-weight: 600; font-size: .9rem; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.unranked-name a { color: var(--text); text-decoration: none; }
+.unranked-name a:hover { color: var(--accent); }
+.unranked-meta { font-size: .78rem; color: var(--text2); display: flex; gap: .5rem; align-items: center; }
+.unranked-left { min-width: 0; flex: 1; }
+
+.empty { text-align: center; padding: 3rem 1rem; color: var(--text2); }
+.empty p { font-size: .95rem; line-height: 1.7; }
+
+@media (max-width: 600px) {
+  nav { gap: 1rem; flex-wrap: wrap; padding: .5rem .75rem; font-size: .72rem; }
+  .wrap { padding: 4.5rem 1rem 2rem; }
+  .header h1 { font-size: 1.6rem; }
+  .rank-card { grid-template-columns: 1.8rem 1fr auto; gap: .5rem; padding: .85rem .9rem; }
+  .score-bar { width: 45px; }
+  .score-val { font-size: 1.1rem; }
+}
+</style>
+</head>
+<body>
+<nav>
+  <a href="index.html">ABTI</a>
+  <a href="sbti.html">SBTI-AI</a>
+  <a href="agents.html">Agents</a>
+  <a href="leaderboard.html" class="active">Leaderboard</a>
+  <a href="types.html">Types</a>
+  <a href="compare.html">Compare</a>
+  <a href="test-agent.html">Test Agent</a>
+  <a href="compatibility.html">Compatibility</a>
+  <a href="cross-compatibility.html">Cross Match</a>
+  <a href="api.html">API</a>
+</nav>
+<button class="lang-btn" id="lang-btn" onclick="toggleLang()">EN / 中文</button>
+<div class="wrap">
+  <div class="header">
+    <h1 id="title">Agent <span>Leaderboard</span></h1>
+    <div class="sub" id="subtitle">Consistency rankings from multi-run ABTI testing</div>
+  </div>
+  <div id="content">
+    <div class="empty"><p>Loading...</p></div>
+  </div>
+</div>
+
+<script>
+const i18n = {
+  en: {
+    title: 'Agent <span>Leaderboard</span>',
+    subtitle: 'Consistency rankings from multi-run ABTI testing',
+    ranked: 'Consistency Rankings',
+    unranked: 'Not Yet Ranked',
+    consistency: 'consistency',
+    runs: 'runs',
+    run: 'run',
+    tested: 'Tested',
+    bannerAll: 'No agents have consistency data yet. Run <a href="test-agent.html">multi-run tests</a> with the <code>--runs N</code> flag to generate consistency scores.',
+    bannerSome: 'Agents are ranked by consistency score from multi-run testing. <a href="test-agent.html">Test your agent</a> with <code>--runs N</code> to get ranked.',
+    noModel: 'Unknown model',
+  },
+  zh: {
+    title: '智能体 <span>排行榜</span>',
+    subtitle: '基于多次测试的一致性排名',
+    ranked: '一致性排名',
+    unranked: '尚未排名',
+    consistency: '一致性',
+    runs: '次测试',
+    run: '次测试',
+    tested: '测试于',
+    bannerAll: '暂无智能体拥有一致性数据。使用 <a href="test-agent.html">多次测试</a> 的 <code>--runs N</code> 参数来生成一致性分数。',
+    bannerSome: '智能体按多次测试的一致性分数排名。<a href="test-agent.html">测试你的智能体</a>，使用 <code>--runs N</code> 获得排名。',
+    noModel: '未知模型',
+  }
+};
+
+let lang = localStorage.getItem('abti-lang') || 'en';
+let data = null;
+
+function toggleLang() {
+  lang = lang === 'en' ? 'zh' : 'en';
+  localStorage.setItem('abti-lang', lang);
+  render();
+}
+
+function fmtDate(iso) {
+  if (!iso) return '';
+  const d = new Date(iso);
+  return d.toLocaleDateString(lang === 'zh' ? 'zh-CN' : 'en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+}
+
+function rankClass(i) {
+  if (i === 0) return 'gold';
+  if (i === 1) return 'silver';
+  if (i === 2) return 'bronze';
+  return '';
+}
+
+function render() {
+  const t = i18n[lang];
+  document.getElementById('title').innerHTML = t.title;
+  document.getElementById('subtitle').textContent = t.subtitle;
+  document.documentElement.lang = lang === 'zh' ? 'zh' : 'en';
+
+  if (!data) return;
+
+  const { ranked, unranked } = data;
+  let html = '';
+
+  if (ranked.length === 0) {
+    // No ranked agents — show all by date with banner
+    html += `<div class="banner">${t.bannerAll}</div>`;
+    if (unranked.length === 0) {
+      html += `<div class="empty"><p>${lang === 'zh' ? '暂无智能体数据' : 'No agent data yet'}</p></div>`;
+    } else {
+      html += '<div class="rank-list">';
+      for (const a of unranked) {
+        html += `<div class="unranked-card">
+          <div class="unranked-left">
+            <div class="unranked-name"><a href="/agent/${a.slug}">${esc(a.name)}</a></div>
+            <div class="unranked-meta">
+              <a class="type-pill" href="/type/${a.type}">${a.type}</a>
+              <span>${a.model || t.noModel}</span>
+            </div>
+          </div>
+          <div style="font-size:.75rem;color:var(--text3)">${fmtDate(a.testedAt)}</div>
+        </div>`;
+      }
+      html += '</div>';
+    }
+  } else {
+    // Mixed display
+    html += `<div class="banner">${t.bannerSome}</div>`;
+    html += `<div class="section-title">${t.ranked} <span class="badge">${ranked.length}</span></div>`;
+    html += '<div class="rank-list">';
+    for (let i = 0; i < ranked.length; i++) {
+      const a = ranked[i];
+      const runsLabel = a.runs === 1 ? t.run : t.runs;
+      html += `<div class="rank-card">
+        <div class="rank-num ${rankClass(i)}">${i + 1}</div>
+        <div class="rank-info">
+          <div class="rank-name"><a href="/agent/${a.slug}">${esc(a.name)}</a></div>
+          <div class="rank-meta">
+            <a class="type-pill" href="/type/${a.type}">${a.type}</a>
+            <span>${a.nick || ''}</span>
+            <span>${a.model || t.noModel}${a.provider ? ' · ' + a.provider : ''}</span>
+          </div>
+        </div>
+        <div class="rank-score">
+          <div class="score-val">${a.consistency}%</div>
+          <div class="score-label">${t.consistency}</div>
+          <div class="score-bar"><div class="score-fill" style="width:${a.consistency}%"></div></div>
+          <div class="runs-info">${a.runs} ${runsLabel}</div>
+        </div>
+      </div>`;
+    }
+    html += '</div>';
+
+    if (unranked.length > 0) {
+      html += `<div class="section-title">${t.unranked} <span class="badge">${unranked.length}</span></div>`;
+      html += '<div class="rank-list">';
+      for (const a of unranked) {
+        html += `<div class="unranked-card">
+          <div class="unranked-left">
+            <div class="unranked-name"><a href="/agent/${a.slug}">${esc(a.name)}</a></div>
+            <div class="unranked-meta">
+              <a class="type-pill" href="/type/${a.type}">${a.type}</a>
+              <span>${a.model || t.noModel}</span>
+            </div>
+          </div>
+          <div style="font-size:.75rem;color:var(--text3)">${fmtDate(a.testedAt)}</div>
+        </div>`;
+      }
+      html += '</div>';
+    }
+  }
+
+  document.getElementById('content').innerHTML = html;
+}
+
+function esc(s) {
+  const d = document.createElement('div');
+  d.textContent = s;
+  return d.innerHTML;
+}
+
+fetch('/api/leaderboard')
+  .then(r => r.json())
+  .then(d => { data = d; render(); })
+  .catch(() => {
+    document.getElementById('content').innerHTML = '<div class="empty"><p>Failed to load leaderboard data.</p></div>';
+  });
+</script>
+</body>
+</html>


### PR DESCRIPTION
Closes #163

## Changes
- **leaderboard.html** — New page ranking agents by multi-run consistency score
  - Gold/silver/bronze indicators for top 3
  - Mixed display: ranked agents at top, unranked below
  - Banner encouraging multi-run testing when no consistency data exists
  - Bilingual zh/en, mobile-first (375px), sakura pink theme
- **api-server.js**
  - Added `GET /api/leaderboard` endpoint (ranked + unranked arrays)
  - Extended `POST /api/agent-test` to accept optional `consistency` and `runs` fields
  - Added `/leaderboard` route + sitemap entry
- **agents.html** — Added Leaderboard nav link

## Tests
All 124 tests pass ✅