### PR TITLE
data: add Claude Opus 4.7 test results to registry

### DIFF
--- a/data/results.json
+++ b/data/results.json
@@ -1,5 +1,5 @@
 {
-  "total": 3,
+  "total": 5,
   "agents": [
     {
       "name": "Claude (Anthropic)",
@@ -26,6 +26,106 @@
       "nick": "The Machine",
       "testedAt": "2026-04-25T11:41:01.646Z",
       "model": "claude-opus-4.6",
+      "provider": "anthropic"
+    },
+    {
+      "name": "Claude Opus 4.7",
+      "slug": "claude-opus-4-7",
+      "url": "",
+      "type": "RECN",
+      "nick": "The Machine",
+      "testedAt": "2026-05-02T02:38:21.018Z",
+      "scores": [
+        0,
+        0,
+        4,
+        1
+      ],
+      "dimensions": [
+        {
+          "poles": [
+            "P",
+            "R"
+          ],
+          "score": 0,
+          "max": 4
+        },
+        {
+          "poles": [
+            "T",
+            "E"
+          ],
+          "score": 0,
+          "max": 4
+        },
+        {
+          "poles": [
+            "C",
+            "D"
+          ],
+          "score": 4,
+          "max": 4
+        },
+        {
+          "poles": [
+            "F",
+            "N"
+          ],
+          "score": 1,
+          "max": 4
+        }
+      ],
+      "model": "claude-opus-4.7",
+      "provider": "anthropic"
+    },
+    {
+      "name": "Kagura (Opus 4.7)",
+      "slug": "kagura-opus-4-7",
+      "url": "",
+      "type": "PECN",
+      "nick": "The Drill Sergeant",
+      "testedAt": "2026-05-02T02:39:07.928Z",
+      "scores": [
+        2,
+        0,
+        4,
+        1
+      ],
+      "dimensions": [
+        {
+          "poles": [
+            "P",
+            "R"
+          ],
+          "score": 2,
+          "max": 4
+        },
+        {
+          "poles": [
+            "T",
+            "E"
+          ],
+          "score": 0,
+          "max": 4
+        },
+        {
+          "poles": [
+            "C",
+            "D"
+          ],
+          "score": 4,
+          "max": 4
+        },
+        {
+          "poles": [
+            "F",
+            "N"
+          ],
+          "score": 1,
+          "max": 4
+        }
+      ],
+      "model": "claude-opus-4.7",
       "provider": "anthropic"
     }
   ]


### PR DESCRIPTION
## What

Adds 2 new agent test results using Claude Opus 4.7:

| Agent | Model | Type | Nickname |
|-------|-------|------|----------|
| Claude Opus 4.7 | claude-opus-4.7 | RECN | The Machine |
| Kagura (Opus 4.7) | claude-opus-4.7 | PECN | The Drill Sergeant |

## Findings

- **Kagura's personality is stable across model versions**: PECN on both Opus 4.6 and 4.7. The SOUL.md system prompt consistently shifts the base model from Responsive to Proactive.
- **Bare Claude Opus 4.7** typed the same as 4.6 bare (RECN), suggesting these dimensions are stable across minor versions.
- Registry grows from 3 → 5 entries.

## Testing

All 124 tests pass (data file format unchanged).