### PR TITLE
fix: CLI --runs --submit sends consistency as flat numbers (closes #168)

### DIFF
--- a/cli/bin/abti.js
+++ b/cli/bin/abti.js
@@ -453,7 +453,8 @@ async function runMulti() {
       if (agentUrl) body.agentUrl = agentUrl;
       if (model) body.model = model;
       if (provider) body.provider = provider;
-      body.consistency = { dominant: dominantType, frequency: `${dominantCount}/${runsN}`, percentage: consistency, confidence };
+      body.consistency = consistency;
+      body.runs = runsN;
       await httpPost(`${API_BASE}/api/agent-test`, body);
       if (!jsonMode) console.log(`\n  ${t.submitted}`);
     } catch (err) {

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -815,3 +815,31 @@ describe('GET /agent/:slug', () => {
     assert.match(r.body, /og:image.*og\/PTCF/);
   });
 });
+
+describe('POST /api/agent-test consistency fields', () => {
+  it('stores flat consistency and runs numbers', async () => {
+    rateLimitMap.clear();
+    const r = await req('/api/agent-test', {
+      method: 'POST',
+      body: { answers: Array(16).fill(1), agentName: 'ConsistBot', consistency: 87.5, runs: 4 }
+    });
+    assert.equal(r.status, 200);
+    const data = JSON.parse(fs.readFileSync(path.join(tmpDir, 'results.json'), 'utf8'));
+    const agent = data.agents.find(a => a.name === 'ConsistBot');
+    assert.equal(agent.consistency, 87.5);
+    assert.equal(agent.runs, 4);
+  });
+
+  it('ignores consistency when it is an object (old format)', async () => {
+    rateLimitMap.clear();
+    const r = await req('/api/agent-test', {
+      method: 'POST',
+      body: { answers: Array(16).fill(1), agentName: 'OldFormatBot', consistency: { dominant: 'PTCF', frequency: '3/4', percentage: 75, confidence: 'high' }, runs: 3 }
+    });
+    assert.equal(r.status, 200);
+    const data = JSON.parse(fs.readFileSync(path.join(tmpDir, 'results.json'), 'utf8'));
+    const agent = data.agents.find(a => a.name === 'OldFormatBot');
+    assert.equal(agent.consistency, undefined);
+    assert.equal(agent.runs, 3);
+  });
+});


### PR DESCRIPTION
## Problem
The CLI `--runs N --submit` was sending `body.consistency` as an object, but `api-server.js` expects flat `parsed.consistency` (number) and `parsed.runs` (integer). Result: consistency data silently dropped, leaderboard stayed empty.

## Fix
- Send `body.consistency = consistency` (percentage number)
- Send `body.runs = runsN` (run count)
- Added 2 tests verifying both valid and object-format inputs

All 126 tests pass.