### PR TITLE
fix: derive agent total from array length instead of separate counter

### DIFF
--- a/api-server.js
+++ b/api-server.js
@@ -18,7 +18,7 @@ function loadData() {
   try {
     return JSON.parse(fs.readFileSync(DATA_FILE, 'utf8'));
   } catch {
-    return { total: 0, agents: [] };
+    return { agents: [] };
   }
 }
 
@@ -180,7 +180,6 @@ function registerAgent(entry) {
   if (entry.name && !entry.slug) {
     entry.slug = slugify(entry.name);
   }
-  agentData.total++;
   const oneHourAgo = Date.now() - 3600000;
   const existing = agentData.agents.findIndex(a => a.name === entry.name && new Date(a.testedAt).getTime() > oneHourAgo);
   if (existing !== -1) {
@@ -361,7 +360,6 @@ const server = http.createServer((req, res) => {
           dims[dn] = { score: scores[i], max: 4, pole, letter };
         }
         // Persist result
-        agentData.total++;
         if (agentName && typeof agentName === 'string') {
           const name = agentName.slice(0, 64);
           const urlStr = (typeof agentUrl === 'string') ? agentUrl : '';
@@ -439,7 +437,7 @@ const server = http.createServer((req, res) => {
   // GET /api/agents - list tested agents
   if (url.pathname === '/api/agents' && req.method === 'GET') {
     res.writeHead(200, {'Content-Type':'application/json'});
-    return res.end(JSON.stringify({ total: agentData.total, agents: agentData.agents }));
+    return res.end(JSON.stringify({ total: agentData.agents.length, agents: agentData.agents }));
   }
 
   // GET /api/leaderboard - ranked agents by consistency

--- a/data/results.json
+++ b/data/results.json
@@ -1,5 +1,4 @@
 {
-  "total": 5,
   "agents": [
     {
       "name": "Claude (Anthropic)",

--- a/mcp/tools.js
+++ b/mcp/tools.js
@@ -243,7 +243,7 @@ function registerTools(mcpServer, opts) {
         ...(a.model ? { model: a.model } : {}),
         ...(a.provider ? { provider: a.provider } : {})
       }));
-      return { content: [{ type: 'text', text: JSON.stringify({ total: data.total, agents }, null, 2) }] };
+      return { content: [{ type: 'text', text: JSON.stringify({ total: agents.length, agents }, null, 2) }] };
     }
   );
 


### PR DESCRIPTION
## Problem

`registerAgent()` incremented `agentData.total` unconditionally before checking if the agent already existed. When an existing agent was re-tested within 1 hour, the entry was replaced (not pushed), but `total` still went up. This caused `GET /api/agents` to return `{total: 11, agents: [5 entries]}`.

## Fix

Removed the standalone `total` field entirely. Now derived from `agents.length` everywhere:
- `registerAgent()` — removed `total++`
- `/api/agents` endpoint — uses `agents.length`
- `loadData()` — no longer initializes `total`
- MCP `abti_list_agents` tool — uses `agents.length`
- `data/results.json` — removed stale `total` field

All 126 tests pass.

Closes #170