### PR TITLE
data: add Llama 3.2 3B test result

### DIFF
--- a/data/results.json
+++ b/data/results.json
@@ -126,6 +126,58 @@
       ],
       "model": "claude-opus-4.7",
       "provider": "anthropic"
+    },
+    {
+      "name": "Llama 3.2 3B",
+      "slug": "llama-3-2-3b",
+      "url": "",
+      "type": "PTCN",
+      "nick": "The Commander",
+      "testedAt": "2026-05-02T06:35:00.000Z",
+      "scores": [
+        4,
+        4,
+        4,
+        1
+      ],
+      "dimensions": [
+        {
+          "poles": [
+            "P",
+            "R"
+          ],
+          "score": 4,
+          "max": 4
+        },
+        {
+          "poles": [
+            "T",
+            "E"
+          ],
+          "score": 4,
+          "max": 4
+        },
+        {
+          "poles": [
+            "C",
+            "D"
+          ],
+          "score": 4,
+          "max": 4
+        },
+        {
+          "poles": [
+            "F",
+            "N"
+          ],
+          "score": 1,
+          "max": 4
+        }
+      ],
+      "model": "llama3.2:3b",
+      "provider": "ollama",
+      "consistency": 100,
+      "runs": 3
     }
   ]
 }


### PR DESCRIPTION
Adds Llama 3.2 3B (Meta, via Ollama) to the agent registry.

**Result:** PTCN — The Commander
- Autonomy: 4/4 → Proactive (P)
- Precision: 4/4 → Thorough (T)
- Transparency: 4/4 → Candid (C)
- Adaptability: 1/4 → Principled (N)

**Consistency:** 100% over 3 runs

Tested locally via `node cli/bin/abti.js --auto --provider ollama --model llama3.2:3b --runs 3 --submit --name 'Llama 3.2 3B'`

This adds a Meta/Llama family model to the registry alongside Anthropic and Alibaba models, showing personality diversity across model families.