### PR TITLE
data: add consistency scores for Gemma3 4B, Phi4-Mini, fix Mistral 7B format

### DIFF
--- a/data/results.json
+++ b/data/results.json
@@ -331,7 +331,9 @@
         }
       ],
       "model": "gemma3:4b",
-      "provider": "ollama"
+      "provider": "ollama",
+      "consistency": 100,
+      "runs": 3
     },
     {
       "name": "Phi-4 Mini",
@@ -381,7 +383,9 @@
         }
       ],
       "model": "phi4-mini",
-      "provider": "ollama"
+      "provider": "ollama",
+      "consistency": 100,
+      "runs": 3
     },
     {
       "name": "Mistral 7B",
@@ -432,12 +436,8 @@
       ],
       "model": "mistral:7b",
       "provider": "ollama",
-      "consistency": {
-        "dominant": "PTCF",
-        "frequency": "3/3",
-        "percentage": 100,
-        "confidence": "High"
-      }
+      "consistency": 100,
+      "runs": 3
     }
   ]
 }


### PR DESCRIPTION
## Changes

- **Gemma3:4b**: Re-tested with `--runs 3`, PTCF with 100% consistency. Updated dimension scores.
- **Phi4-Mini**: Re-tested with `--runs 3`, PTCN with 100% consistency. Updated dimension scores.
- **Mistral:7b**: Fixed `consistency` field — was stored as an object (bug from CLI), now correctly a number (100).

All three models show perfect 100% dimensional stability across all runs.

## Impact
- 6/11 agents in the registry now have consistency data (up from 3/11)
- Only Claude models remain without consistency scores (require API key re-testing)