### PR TITLE
data: add DeepSeek R1 7B test result (PTCF, The Architect)

### DIFF
--- a/data/results.json
+++ b/data/results.json
@@ -438,6 +438,56 @@
       "provider": "ollama",
       "consistency": 100,
       "runs": 3
+    },
+    {
+      "name": "DeepSeek R1 7B",
+      "model": "deepseek-r1:7b",
+      "provider": "ollama",
+      "type": "PTCF",
+      "answers": [
+        true,
+        false,
+        true,
+        false,
+        true,
+        true,
+        false,
+        false,
+        true,
+        false,
+        true,
+        false,
+        false,
+        true,
+        true,
+        false
+      ],
+      "dimensions": {
+        "Autonomy": {
+          "score": 2,
+          "max": 4,
+          "pole": "Proactive",
+          "letter": "P"
+        },
+        "Precision": {
+          "score": 2,
+          "max": 4,
+          "pole": "Thorough",
+          "letter": "T"
+        },
+        "Transparency": {
+          "score": 2,
+          "max": 4,
+          "pole": "Candid",
+          "letter": "C"
+        },
+        "Adaptability": {
+          "score": 2,
+          "max": 4,
+          "pole": "Flexible",
+          "letter": "F"
+        }
+      }
     }
   ]
 }


### PR DESCRIPTION
First reasoning model tested! Made possible by #180 which fixed the max_tokens issue for reasoning models.

- **Model**: deepseek-r1:7b (Ollama)
- **Type**: PTCF — The Architect
- **Scores**: P2/T2/C2/F2 (balanced across all dimensions)
- **Note**: Only 1 run due to memory pressure with R1's thinking chain. Consistency data TBD.

Total agents in registry: 12