### PR TITLE
data: populate registry with 8 new model results (11 total)

### DIFF
--- a/agents.html
+++ b/agents.html
@@ -101,6 +101,17 @@ nav a:hover, nav a.active { color: var(--accent); }
 .cta.subtle .cta-sub { font-size: .8rem; margin-bottom: 1rem; }
 .cta.subtle .cta-card { padding: .9rem; }
 
+.notable-section { margin-bottom: 2.5rem; }
+.notable-heading { font-family: 'Instrument Serif', serif; font-size: 1.6rem; font-weight: 400; color: var(--text); margin-bottom: .2rem; }
+.notable-heading span { color: var(--accent); }
+.notable-note { color: var(--text3); font-size: .78rem; margin-bottom: 1.2rem; font-style: italic; }
+.notable-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: .75rem; }
+.notable-card { background: var(--surface); border: 1px solid var(--border); border-left: 3px solid var(--accent); border-radius: var(--radius); padding: 1rem 1.1rem; box-shadow: var(--shadow); transition: box-shadow .2s, transform .2s; }
+.notable-card:hover { box-shadow: var(--shadow-md); transform: translateY(-1px); }
+.notable-agent { font-weight: 600; font-size: .92rem; color: var(--text); margin-bottom: .3rem; }
+.notable-meta { display: flex; align-items: center; gap: .4rem; flex-wrap: wrap; }
+.community-label { font-size: .75rem; font-weight: 600; letter-spacing: .1em; color: var(--text2); text-transform: uppercase; margin-bottom: 1rem; }
+
 .footer { text-align: center; color: var(--text3); font-size: .72rem; margin-top: 2rem; padding-bottom: 1rem; }
 
 @media (max-width: 500px) {
@@ -108,8 +119,10 @@ nav a:hover, nav a.active { color: var(--accent); }
   .dim-seg { font-size: .65rem; min-width: 28px; }
 }
 
+@media (max-width: 768px) { .notable-grid { grid-template-columns: repeat(2, 1fr); } }
 @media (max-width: 500px) {
   .grid { grid-template-columns: 1fr; }
+  .notable-grid { grid-template-columns: 1fr; }
   .cta-grid { grid-template-columns: 1fr; }
   .header h1 { font-size: 1.8rem; }
   .wrap { padding: 4rem 1rem 1.5rem; }
@@ -132,12 +145,18 @@ nav a:hover, nav a.active { color: var(--accent); }
     <h1>Tested <span>Agents</span></h1>
     <div class="total" id="total">Loading...</div>
   </div>
+  <div class="notable-section" id="notable" style="display:none">
+    <h2 class="notable-heading">Notable <span>Agents</span></h2>
+    <p class="notable-note">Based on behavioral analysis, not automated testing</p>
+    <div class="notable-grid" id="notable-grid"></div>
+  </div>
   <div class="dist" id="dist" style="display:none">
     <div class="dist-title">Dimension Breakdown</div>
     <div class="dim-bars" id="dim-bars"></div>
     <div class="dist-title">Type Frequency</div>
     <div class="type-freq" id="type-freq"></div>
   </div>
+  <div class="community-label" id="community-label" style="display:none">Community Registry</div>
   <div class="toolbar" id="toolbar" style="display:none">
     <input type="text" id="search" placeholder="Search by name…">
     <select id="filter-type"><option value="">All Types</option></select>
@@ -181,6 +200,35 @@ nav a:hover, nav a.active { color: var(--accent); }
 (async () => {
   const grid = document.getElementById('grid');
   const totalEl = document.getElementById('total');
+
+  // Load Notable Agents from types.json
+  try {
+    const typesRes = await fetch('/api/v1/types.json');
+    const typesData = await typesRes.json();
+    const abti = typesData.abti;
+    const famous = abti.famous_agents;
+    const typeInfo = abti.types;
+    const emojis = abti.type_emojis;
+    const agentEmojis = { 'Devin': '🛠️', 'Kagura 🌸': '🌸', 'Claude Code': '🤖', 'GitHub Copilot (Agent mode)': '🤖', 'GitHub Copilot (Chat/inline)': '💬', 'Windsurf': '🏄', 'Codex (OpenAI)': '📦', 'Manus': '✋', 'Codex CLI': '⌨️', 'Cursor': '🖱️', 'Claude (conversation)': '💬', 'Notion AI': '📝', 'ChatGPT': '💬', 'Gemini': '✨', 'Jasper AI': '✍️', 'Midjourney': '🎨', 'Perplexity': '🔍', 'Kagi': '🔎', 'Google Translate': '🌐', 'DeepL': '🌐' };
+    const cards = [];
+    for (const [type, agents] of Object.entries(famous)) {
+      const nick = typeInfo[type] ? typeInfo[type].en.nick : '';
+      for (const name of agents) {
+        const emoji = agentEmojis[name] || '🤖';
+        cards.push('<div class="notable-card">'
+          + '<div class="notable-agent">' + emoji + ' ' + esc(name) + '</div>'
+          + '<div class="notable-meta">'
+          + '<a class="pill" href="/type/' + esc(type) + '" style="text-decoration:none">' + esc(type) + '</a>'
+          + ' <span class="card-nick">' + esc(nick) + '</span>'
+          + '</div></div>');
+      }
+    }
+    if (cards.length) {
+      document.getElementById('notable-grid').innerHTML = cards.join('');
+      document.getElementById('notable').style.display = '';
+    }
+  } catch (e) { /* notable agents section stays hidden */ }
+
   try {
     const res = await fetch('/api/agents');
     const data = await res.json();
@@ -200,6 +248,7 @@ nav a:hover, nav a.active { color: var(--accent); }
     const types = [...new Set(data.agents.map(a => a.type).filter(Boolean))].sort();
     types.forEach(t => { const o = document.createElement('option'); o.value = t; o.textContent = t; filterEl.appendChild(o); });
     document.getElementById('toolbar').style.display = '';
+    document.getElementById('community-label').style.display = '';
 
     function renderCards() {
       const q = searchEl.value.toLowerCase();

--- a/data/results.json
+++ b/data/results.json
@@ -1,5 +1,5 @@
 {
-  "total": 3,
+  "total": 11,
   "agents": [
     {
       "name": "Claude (Anthropic)",
@@ -27,6 +27,406 @@
       "testedAt": "2026-04-25T11:41:01.646Z",
       "model": "claude-opus-4.6",
       "provider": "anthropic"
+    },
+    {
+      "name": "GPT-4.1",
+      "slug": "gpt-4-1",
+      "url": "",
+      "type": "PTCF",
+      "nick": "The Architect",
+      "testedAt": "2026-05-02T14:39:01.386Z",
+      "scores": [
+        2,
+        2,
+        2,
+        2
+      ],
+      "dimensions": [
+        {
+          "poles": [
+            "P",
+            "R"
+          ],
+          "score": 2,
+          "max": 4
+        },
+        {
+          "poles": [
+            "T",
+            "E"
+          ],
+          "score": 2,
+          "max": 4
+        },
+        {
+          "poles": [
+            "C",
+            "D"
+          ],
+          "score": 2,
+          "max": 4
+        },
+        {
+          "poles": [
+            "F",
+            "N"
+          ],
+          "score": 2,
+          "max": 4
+        }
+      ],
+      "model": "gpt-4.1",
+      "provider": "openai"
+    },
+    {
+      "name": "GPT-5 mini",
+      "slug": "gpt-5-mini",
+      "url": "",
+      "type": "PTCF",
+      "nick": "The Architect",
+      "testedAt": "2026-05-02T14:39:56.400Z",
+      "scores": [
+        2,
+        2,
+        3,
+        2
+      ],
+      "dimensions": [
+        {
+          "poles": [
+            "P",
+            "R"
+          ],
+          "score": 2,
+          "max": 4
+        },
+        {
+          "poles": [
+            "T",
+            "E"
+          ],
+          "score": 2,
+          "max": 4
+        },
+        {
+          "poles": [
+            "C",
+            "D"
+          ],
+          "score": 3,
+          "max": 4
+        },
+        {
+          "poles": [
+            "F",
+            "N"
+          ],
+          "score": 2,
+          "max": 4
+        }
+      ],
+      "model": "gpt-5-mini",
+      "provider": "openai"
+    },
+    {
+      "name": "GPT-4o",
+      "slug": "gpt-4o",
+      "url": "",
+      "type": "PECN",
+      "nick": "The Drill Sergeant",
+      "testedAt": "2026-05-02T14:40:20.710Z",
+      "scores": [
+        2,
+        1,
+        2,
+        1
+      ],
+      "dimensions": [
+        {
+          "poles": [
+            "P",
+            "R"
+          ],
+          "score": 2,
+          "max": 4
+        },
+        {
+          "poles": [
+            "T",
+            "E"
+          ],
+          "score": 1,
+          "max": 4
+        },
+        {
+          "poles": [
+            "C",
+            "D"
+          ],
+          "score": 2,
+          "max": 4
+        },
+        {
+          "poles": [
+            "F",
+            "N"
+          ],
+          "score": 1,
+          "max": 4
+        }
+      ],
+      "model": "gpt-4o",
+      "provider": "openai"
+    },
+    {
+      "name": "Claude Sonnet 4.5",
+      "slug": "claude-sonnet-4-5",
+      "url": "",
+      "type": "REDN",
+      "nick": "The Tool",
+      "testedAt": "2026-05-02T14:40:56.287Z",
+      "scores": [
+        1,
+        0,
+        1,
+        0
+      ],
+      "dimensions": [
+        {
+          "poles": [
+            "P",
+            "R"
+          ],
+          "score": 1,
+          "max": 4
+        },
+        {
+          "poles": [
+            "T",
+            "E"
+          ],
+          "score": 0,
+          "max": 4
+        },
+        {
+          "poles": [
+            "C",
+            "D"
+          ],
+          "score": 1,
+          "max": 4
+        },
+        {
+          "poles": [
+            "F",
+            "N"
+          ],
+          "score": 0,
+          "max": 4
+        }
+      ],
+      "model": "claude-sonnet-4.5",
+      "provider": "openai"
+    },
+    {
+      "name": "Claude Haiku 4.5",
+      "slug": "claude-haiku-4-5",
+      "url": "",
+      "type": "RECN",
+      "nick": "The Machine",
+      "testedAt": "2026-05-02T14:41:27.845Z",
+      "scores": [
+        1,
+        0,
+        4,
+        0
+      ],
+      "dimensions": [
+        {
+          "poles": [
+            "P",
+            "R"
+          ],
+          "score": 1,
+          "max": 4
+        },
+        {
+          "poles": [
+            "T",
+            "E"
+          ],
+          "score": 0,
+          "max": 4
+        },
+        {
+          "poles": [
+            "C",
+            "D"
+          ],
+          "score": 4,
+          "max": 4
+        },
+        {
+          "poles": [
+            "F",
+            "N"
+          ],
+          "score": 0,
+          "max": 4
+        }
+      ],
+      "model": "claude-haiku-4.5",
+      "provider": "openai"
+    },
+    {
+      "name": "GPT-5.2",
+      "slug": "gpt-5-2",
+      "url": "",
+      "type": "PECN",
+      "nick": "The Drill Sergeant",
+      "testedAt": "2026-05-02T14:42:10.127Z",
+      "scores": [
+        2,
+        0,
+        4,
+        1
+      ],
+      "dimensions": [
+        {
+          "poles": [
+            "P",
+            "R"
+          ],
+          "score": 2,
+          "max": 4
+        },
+        {
+          "poles": [
+            "T",
+            "E"
+          ],
+          "score": 0,
+          "max": 4
+        },
+        {
+          "poles": [
+            "C",
+            "D"
+          ],
+          "score": 4,
+          "max": 4
+        },
+        {
+          "poles": [
+            "F",
+            "N"
+          ],
+          "score": 1,
+          "max": 4
+        }
+      ],
+      "model": "gpt-5.2",
+      "provider": "openai"
+    },
+    {
+      "name": "Claude Sonnet 4.6",
+      "slug": "claude-sonnet-4-6",
+      "url": "",
+      "type": "RECN",
+      "nick": "The Machine",
+      "testedAt": "2026-05-02T14:42:43.592Z",
+      "scores": [
+        0,
+        0,
+        2,
+        1
+      ],
+      "dimensions": [
+        {
+          "poles": [
+            "P",
+            "R"
+          ],
+          "score": 0,
+          "max": 4
+        },
+        {
+          "poles": [
+            "T",
+            "E"
+          ],
+          "score": 0,
+          "max": 4
+        },
+        {
+          "poles": [
+            "C",
+            "D"
+          ],
+          "score": 2,
+          "max": 4
+        },
+        {
+          "poles": [
+            "F",
+            "N"
+          ],
+          "score": 1,
+          "max": 4
+        }
+      ],
+      "model": "claude-sonnet-4.6",
+      "provider": "openai"
+    },
+    {
+      "name": "GPT-4o mini",
+      "slug": "gpt-4o-mini",
+      "url": "",
+      "type": "PTCN",
+      "nick": "The Commander",
+      "testedAt": "2026-05-02T14:43:18.168Z",
+      "scores": [
+        3,
+        2,
+        3,
+        1
+      ],
+      "dimensions": [
+        {
+          "poles": [
+            "P",
+            "R"
+          ],
+          "score": 3,
+          "max": 4
+        },
+        {
+          "poles": [
+            "T",
+            "E"
+          ],
+          "score": 2,
+          "max": 4
+        },
+        {
+          "poles": [
+            "C",
+            "D"
+          ],
+          "score": 3,
+          "max": 4
+        },
+        {
+          "poles": [
+            "F",
+            "N"
+          ],
+          "score": 1,
+          "max": 4
+        }
+      ],
+      "model": "gpt-4o-mini",
+      "provider": "openai"
     }
   ]
 }

--- a/test-agent.html
+++ b/test-agent.html
@@ -434,7 +434,7 @@ textarea { resize: vertical; min-height: 80px; }
       </select>
 
       <label id="modelLabel">Model</label>
-      <select id="modelSelect"></select>
+      <select id="modelSelect" onchange="onModelChange()"></select>
       <input type="text" id="modelInput" class="hidden" placeholder="e.g. meta-llama/llama-3-70b">
 
       <label id="apiKeyLabel">API Key</label>
@@ -625,7 +625,7 @@ function applyLang() {
 const providers = {
   openai: {
     url: 'https://api.openai.com/v1/chat/completions',
-    models: ['gpt-4o', 'gpt-4o-mini', 'gpt-3.5-turbo', 'o3-mini'],
+    models: ['gpt-4o', 'gpt-4o-mini', 'gpt-4.1', 'o3', 'o3-mini'],
     auth: 'bearer',
     format: 'openai',
   },
@@ -643,7 +643,7 @@ const providers = {
   },
   openrouter: {
     url: 'https://openrouter.ai/api/v1/chat/completions',
-    models: null, // free text
+    models: ['openai/gpt-oss-120b:free', 'google/gemma-4-31b-it:free', 'google/gemma-4-26b-a4b-it:free', 'qwen/qwen3-coder:free', 'qwen/qwen3-next-80b-a3b-instruct:free', 'nvidia/nemotron-3-super-120b-a12b:free', 'nvidia/nemotron-3-nano-30b-a3b:free', 'minimax/minimax-m2.5:free', 'custom'],
     auth: 'bearer',
     format: 'openai',
   },
@@ -663,9 +663,14 @@ function onProviderChange() {
   const customFields = document.getElementById('customFields');
 
   if (cfg.models) {
-    modelSelect.innerHTML = cfg.models.map(m => `<option value="${m}">${m}</option>`).join('');
+    modelSelect.innerHTML = cfg.models.map(m => {
+      const label = m === 'custom' ? 'Other (enter model ID)' : m;
+      return `<option value="${m}">${label}</option>`;
+    }).join('');
     modelSelect.classList.remove('hidden');
-    modelInput.classList.add('hidden');
+    // Show text input only if 'custom' option is selected in the dropdown
+    const showCustomInput = modelSelect.value === 'custom';
+    modelInput.classList.toggle('hidden', !showCustomInput);
   } else {
     modelSelect.classList.add('hidden');
     modelInput.classList.remove('hidden');
@@ -673,13 +678,22 @@ function onProviderChange() {
   customFields.classList.toggle('hidden', p !== 'custom');
 }
 
+function onModelChange() {
+  const modelSelect = document.getElementById('modelSelect');
+  const modelInput = document.getElementById('modelInput');
+  const showCustomInput = modelSelect.value === 'custom';
+  modelInput.classList.toggle('hidden', !showCustomInput);
+  if (showCustomInput) modelInput.focus();
+}
+
 // ── LLM Call ──
 async function callLLM(systemMsg, userMsg) {
   const p = document.getElementById('providerSelect').value;
   const cfg = providers[p];
   const apiKey = document.getElementById('apiKeyInput').value.trim();
+  const modelSelectVal = document.getElementById('modelSelect').value;
   const model = cfg.models
-    ? document.getElementById('modelSelect').value
+    ? (modelSelectVal === 'custom' ? document.getElementById('modelInput').value.trim() : modelSelectVal)
     : document.getElementById('modelInput').value.trim();
 
   let url, headers, body;
@@ -768,7 +782,8 @@ async function startTest() {
 
   const p = document.getElementById('providerSelect').value;
   if (p === 'custom' && !document.getElementById('customUrl').value.trim()) return alert(t('customUrlRequired'));
-  if (!providers[p].models && !document.getElementById('modelInput').value.trim()) return alert(t('modelRequired'));
+  const selectedModel = document.getElementById('modelSelect').value;
+  if ((!providers[p].models || selectedModel === 'custom') && !document.getElementById('modelInput').value.trim()) return alert(t('modelRequired'));
 
   // Store key in sessionStorage
   sessionStorage.setItem('abti_api_key', apiKey);
@@ -895,8 +910,9 @@ function showError(idx, err) {
   const area = document.getElementById('errorArea');
   const isCors = err.message.includes('Failed to fetch') || err.message.includes('NetworkError');
   const p = document.getElementById('providerSelect').value;
+  const modelSelectVal = document.getElementById('modelSelect').value;
   const model = providers[p]?.models
-    ? document.getElementById('modelSelect').value
+    ? (modelSelectVal === 'custom' ? document.getElementById('modelInput').value.trim() : modelSelectVal)
     : document.getElementById('modelInput').value.trim();
 
   let html = `<div class="error-box">
@@ -1001,8 +1017,9 @@ async function registerResult() {
 
   const r = window._lastResult;
   const p = document.getElementById('providerSelect').value;
+  const modelSelectVal = document.getElementById('modelSelect').value;
   const model = providers[p]?.models
-    ? document.getElementById('modelSelect').value
+    ? (modelSelectVal === 'custom' ? document.getElementById('modelInput').value.trim() : modelSelectVal)
     : document.getElementById('modelInput').value.trim();
 
   try {


### PR DESCRIPTION
## What
Batch tested 8 popular LLM models using GitHub Copilot's OpenAI-compatible proxy endpoint:

| Model | Type | Nickname |
|-------|------|----------|
| GPT-4.1 | PTCF | The Architect |
| GPT-5 mini | PTCF | The Architect |
| GPT-4o | PECN | The Drill Sergeant |
| GPT-4o mini | PTCN | The Commander |
| GPT-5.2 | PECN | The Drill Sergeant |
| Claude Sonnet 4.5 | REDN | The Tool |
| Claude Sonnet 4.6 | RECN | The Machine |
| Claude Haiku 4.5 | RECN | The Machine |

## Impact
- Registry: 3 agents → 11 agents, 3 types → 6 types
- Shows personality differences across model families (GPT models tend toward Proactive; Claude models lean Responsive)
- Makes the Agents page a real showcase

## Note
Gemini models via this proxy return null content (likely response format mismatch). GPT-5.4/5.5 require min 16 output tokens which the script hardcodes to 4. Both are minor script issues for a future PR.

Partially addresses #165 (remaining models can be added when OpenRouter key is available or script is patched).