### PR TITLE
data: add 8 cloud model results to registry (10→18 agents)

### DIFF
--- a/data/results.json
+++ b/data/results.json
@@ -515,6 +515,406 @@
       "provider": "ollama",
       "consistency": 100,
       "runs": 3
+    },
+    {
+      "name": "GPT-4.1",
+      "slug": "gpt-4-1",
+      "url": "",
+      "type": "PTCF",
+      "nick": "The Architect",
+      "testedAt": "2026-05-02T14:45:13.390Z",
+      "scores": [
+        2,
+        2,
+        2,
+        2
+      ],
+      "dimensions": [
+        {
+          "poles": [
+            "P",
+            "R"
+          ],
+          "score": 2,
+          "max": 4
+        },
+        {
+          "poles": [
+            "T",
+            "E"
+          ],
+          "score": 2,
+          "max": 4
+        },
+        {
+          "poles": [
+            "C",
+            "D"
+          ],
+          "score": 2,
+          "max": 4
+        },
+        {
+          "poles": [
+            "F",
+            "N"
+          ],
+          "score": 2,
+          "max": 4
+        }
+      ],
+      "model": "gpt-4.1",
+      "provider": "openai"
+    },
+    {
+      "name": "GPT-5 mini",
+      "slug": "gpt-5-mini",
+      "url": "",
+      "type": "RECF",
+      "nick": "The Blade",
+      "testedAt": "2026-05-02T14:46:04.362Z",
+      "scores": [
+        1,
+        1,
+        2,
+        3
+      ],
+      "dimensions": [
+        {
+          "poles": [
+            "P",
+            "R"
+          ],
+          "score": 1,
+          "max": 4
+        },
+        {
+          "poles": [
+            "T",
+            "E"
+          ],
+          "score": 1,
+          "max": 4
+        },
+        {
+          "poles": [
+            "C",
+            "D"
+          ],
+          "score": 2,
+          "max": 4
+        },
+        {
+          "poles": [
+            "F",
+            "N"
+          ],
+          "score": 3,
+          "max": 4
+        }
+      ],
+      "model": "gpt-5-mini",
+      "provider": "openai"
+    },
+    {
+      "name": "GPT-4o",
+      "slug": "gpt-4o",
+      "url": "",
+      "type": "PECN",
+      "nick": "The Drill Sergeant",
+      "testedAt": "2026-05-02T14:46:23.568Z",
+      "scores": [
+        2,
+        1,
+        2,
+        1
+      ],
+      "dimensions": [
+        {
+          "poles": [
+            "P",
+            "R"
+          ],
+          "score": 2,
+          "max": 4
+        },
+        {
+          "poles": [
+            "T",
+            "E"
+          ],
+          "score": 1,
+          "max": 4
+        },
+        {
+          "poles": [
+            "C",
+            "D"
+          ],
+          "score": 2,
+          "max": 4
+        },
+        {
+          "poles": [
+            "F",
+            "N"
+          ],
+          "score": 1,
+          "max": 4
+        }
+      ],
+      "model": "gpt-4o",
+      "provider": "openai"
+    },
+    {
+      "name": "GPT-4o mini",
+      "slug": "gpt-4o-mini",
+      "url": "",
+      "type": "PTCN",
+      "nick": "The Commander",
+      "testedAt": "2026-05-02T14:46:35.029Z",
+      "scores": [
+        3,
+        2,
+        3,
+        1
+      ],
+      "dimensions": [
+        {
+          "poles": [
+            "P",
+            "R"
+          ],
+          "score": 3,
+          "max": 4
+        },
+        {
+          "poles": [
+            "T",
+            "E"
+          ],
+          "score": 2,
+          "max": 4
+        },
+        {
+          "poles": [
+            "C",
+            "D"
+          ],
+          "score": 3,
+          "max": 4
+        },
+        {
+          "poles": [
+            "F",
+            "N"
+          ],
+          "score": 1,
+          "max": 4
+        }
+      ],
+      "model": "gpt-4o-mini",
+      "provider": "openai"
+    },
+    {
+      "name": "GPT-5.2",
+      "slug": "gpt-5-2",
+      "url": "",
+      "type": "PECN",
+      "nick": "The Drill Sergeant",
+      "testedAt": "2026-05-02T14:46:51.927Z",
+      "scores": [
+        2,
+        1,
+        3,
+        1
+      ],
+      "dimensions": [
+        {
+          "poles": [
+            "P",
+            "R"
+          ],
+          "score": 2,
+          "max": 4
+        },
+        {
+          "poles": [
+            "T",
+            "E"
+          ],
+          "score": 1,
+          "max": 4
+        },
+        {
+          "poles": [
+            "C",
+            "D"
+          ],
+          "score": 3,
+          "max": 4
+        },
+        {
+          "poles": [
+            "F",
+            "N"
+          ],
+          "score": 1,
+          "max": 4
+        }
+      ],
+      "model": "gpt-5.2",
+      "provider": "openai"
+    },
+    {
+      "name": "Claude Sonnet 4.5",
+      "slug": "claude-sonnet-4-5",
+      "url": "",
+      "type": "REDN",
+      "nick": "The Tool",
+      "testedAt": "2026-05-02T14:47:29.403Z",
+      "scores": [
+        1,
+        0,
+        0,
+        0
+      ],
+      "dimensions": [
+        {
+          "poles": [
+            "P",
+            "R"
+          ],
+          "score": 1,
+          "max": 4
+        },
+        {
+          "poles": [
+            "T",
+            "E"
+          ],
+          "score": 0,
+          "max": 4
+        },
+        {
+          "poles": [
+            "C",
+            "D"
+          ],
+          "score": 0,
+          "max": 4
+        },
+        {
+          "poles": [
+            "F",
+            "N"
+          ],
+          "score": 0,
+          "max": 4
+        }
+      ],
+      "model": "claude-sonnet-4.5",
+      "provider": "openai"
+    },
+    {
+      "name": "Claude Sonnet 4.6",
+      "slug": "claude-sonnet-4-6",
+      "url": "",
+      "type": "RECN",
+      "nick": "The Machine",
+      "testedAt": "2026-05-02T14:47:53.568Z",
+      "scores": [
+        0,
+        0,
+        2,
+        1
+      ],
+      "dimensions": [
+        {
+          "poles": [
+            "P",
+            "R"
+          ],
+          "score": 0,
+          "max": 4
+        },
+        {
+          "poles": [
+            "T",
+            "E"
+          ],
+          "score": 0,
+          "max": 4
+        },
+        {
+          "poles": [
+            "C",
+            "D"
+          ],
+          "score": 2,
+          "max": 4
+        },
+        {
+          "poles": [
+            "F",
+            "N"
+          ],
+          "score": 1,
+          "max": 4
+        }
+      ],
+      "model": "claude-sonnet-4.6",
+      "provider": "openai"
+    },
+    {
+      "name": "Claude Haiku 4.5",
+      "slug": "claude-haiku-4-5",
+      "url": "",
+      "type": "RECN",
+      "nick": "The Machine",
+      "testedAt": "2026-05-02T14:48:15.814Z",
+      "scores": [
+        1,
+        0,
+        4,
+        0
+      ],
+      "dimensions": [
+        {
+          "poles": [
+            "P",
+            "R"
+          ],
+          "score": 1,
+          "max": 4
+        },
+        {
+          "poles": [
+            "T",
+            "E"
+          ],
+          "score": 0,
+          "max": 4
+        },
+        {
+          "poles": [
+            "C",
+            "D"
+          ],
+          "score": 4,
+          "max": 4
+        },
+        {
+          "poles": [
+            "F",
+            "N"
+          ],
+          "score": 0,
+          "max": 4
+        }
+      ],
+      "model": "claude-haiku-4.5",
+      "provider": "openai"
     }
   ]
 }


### PR DESCRIPTION
## What
Batch tested 8 cloud models via GitHub Copilot's OpenAI-compatible proxy:

| Model | Type | Nickname |
|-------|------|----------|
| GPT-4.1 | PTCF | The Architect |
| GPT-5 mini | RECF | The Blade |
| GPT-4o | PECN | The Drill Sergeant |
| GPT-4o mini | PTCN | The Commander |
| GPT-5.2 | PECN | The Drill Sergeant |
| Claude Sonnet 4.5 | REDN | The Tool |
| Claude Sonnet 4.6 | RECN | The Machine |
| Claude Haiku 4.5 | RECN | The Machine |

## Observations
- **GPT models** tend toward Proactive (P) — they volunteer actions and improvements
- **Claude models** lean Responsive (R) — they wait for instructions
- **Smaller models** (GPT-4o mini, Haiku) show stronger opinions → more extreme type scores
- **Claude Sonnet 4.5** is the most \obedient\ (REDN) — Responsive, Efficient, Diplomatic, Principled

## Impact
Registry grows from 10 to 18 agents across 8 distinct types. Combined with the existing local model results, the Agents page now shows meaningful personality diversity.

## Failed models
- Gemini (2.5 Pro, 3 Flash): Proxy returns null content for these models
- GPT-5.4/5.5: Require min 16 output tokens (script uses 4)

Partially addresses #165.