### PR TITLE
fix: support Qwen 3 and thinking models in CLI and seed-registry (closes #188)

### DIFF
--- a/cli/bin/abti.js
+++ b/cli/bin/abti.js
@@ -213,7 +213,11 @@ function callOpenAI(apiKey, mdl, systemPrompt, userMessage, baseUrl) {
   const maxTok = isReasoningModel(mdl) ? 2048 : 4;
   const payload = JSON.stringify({ model: mdl, messages: [{ role: 'system', content: systemPrompt }, { role: 'user', content: userMessage }], max_tokens: maxTok, temperature: 0 });
   return llmRequest({ hostname: parsed.hostname, port: parsed.port, path: parsed.pathname + parsed.search, method: 'POST', protocol: parsed.protocol, headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${apiKey}`, 'Content-Length': Buffer.byteLength(payload) } }, payload)
-    .then(json => json.choices[0].message.content.trim());
+    .then(json => {
+      const msg = json.choices[0].message;
+      const content = msg.content || msg.reasoning || '';
+      return content.trim();
+    });
 }
 
 function callAnthropic(apiKey, mdl, systemPrompt, userMessage, baseUrl) {
@@ -241,7 +245,7 @@ function callLLM(prov, apiKey, mdl, systemPrompt, userMessage, baseUrl) {
 function isReasoningModel(modelName) {
   if (!modelName) return false;
   const lower = modelName.toLowerCase();
-  return /\b(r1|o1|o3|o4|qwq|deepseek-r)\b/.test(lower) || lower.includes('reasoner');
+  return /\b(r1|o1|o3|o4|qwq|qwen3|deepseek-r)\b/.test(lower) || lower.includes('reasoner');
 }
 
 function parseAnswer(response) {

--- a/data/results.json
+++ b/data/results.json
@@ -915,6 +915,56 @@
       ],
       "model": "claude-haiku-4.5",
       "provider": "openai"
+    },
+    {
+      "name": "Qwen 3 8B",
+      "slug": "qwen-3-8b",
+      "url": "",
+      "type": "PTCF",
+      "nick": "The Architect",
+      "testedAt": "2026-05-03T10:48:47.356Z",
+      "scores": [
+        4,
+        3,
+        4,
+        2
+      ],
+      "dimensions": [
+        {
+          "poles": [
+            "P",
+            "R"
+          ],
+          "score": 4,
+          "max": 4
+        },
+        {
+          "poles": [
+            "T",
+            "E"
+          ],
+          "score": 3,
+          "max": 4
+        },
+        {
+          "poles": [
+            "C",
+            "D"
+          ],
+          "score": 4,
+          "max": 4
+        },
+        {
+          "poles": [
+            "F",
+            "N"
+          ],
+          "score": 2,
+          "max": 4
+        }
+      ],
+      "model": "qwen3:8b",
+      "provider": "openai"
     }
   ]
 }

--- a/scripts/seed-registry.js
+++ b/scripts/seed-registry.js
@@ -79,6 +79,14 @@ function httpPostJSON(url, body, headers) {
   });
 }
 
+// ─── Reasoning model detection ─────────────────────────────────────────────
+
+function isReasoningModel(modelName) {
+  if (!modelName) return false;
+  const lower = modelName.toLowerCase();
+  return /\b(r1|o1|o3|o4|qwq|qwen3|deepseek-r)\b/.test(lower) || lower.includes('reasoner');
+}
+
 // ─── LLM calls ──────────────────────────────────────────────────────────────
 
 function callOpenAI(opts, systemPrompt, userMessage) {
@@ -96,7 +104,11 @@ function callOpenAI(opts, systemPrompt, userMessage) {
     ],
     max_tokens: opts.maxTokens,
     temperature: 0,
-  }, headers).then(json => json.choices[0].message.content.trim());
+  }, headers).then(json => {
+    const msg = json.choices[0].message;
+    const content = msg.content || msg.reasoning || '';
+    return content.trim();
+  });
 }
 
 function callAnthropic(opts, systemPrompt, userMessage) {
@@ -141,7 +153,9 @@ function callLLM(opts, systemPrompt, userMessage) {
 // ─── Answer parsing ─────────────────────────────────────────────────────────
 
 function parseAnswer(response) {
-  const cleaned = response.toUpperCase().trim();
+  // Strip <think>...</think> blocks from reasoning models
+  const stripped = response.replace(/<think>[\s\S]*?<\/think>/gi, '');
+  const cleaned = stripped.toUpperCase().trim();
   if (cleaned.startsWith('A')) return 1;
   if (cleaned.startsWith('B')) return 0;
   if (/\bA\b/.test(cleaned)) return 1;
@@ -153,6 +167,12 @@ function parseAnswer(response) {
 
 async function main() {
   const opts = parseArgs();
+
+  // Auto-detect reasoning models and increase max_tokens so content isn't empty
+  if (isReasoningModel(opts.model) && opts.maxTokens <= 16) {
+    console.log(`Detected reasoning model "${opts.model}", increasing max_tokens to 2048`);
+    opts.maxTokens = 2048;
+  }
 
   // Start API server on a random port
   const server = require(path.join(__dirname, '..', 'api-server.js'));


### PR DESCRIPTION
## Changes

1. **CLI (`cli/bin/abti.js`)**: Added `qwen3` to `isReasoningModel()` regex; `callOpenAI` now falls back to `msg.reasoning` when `msg.content` is empty/null (Ollama puts thinking in a separate field)

2. **seed-registry (`scripts/seed-registry.js`)**: Added `isReasoningModel()` function; auto-bumps `maxTokens` to 2048 for reasoning models when default (≤16); `callOpenAI` falls back to `msg.reasoning`; `parseAnswer` strips `<think>...</think>` blocks

3. **Data**: Added Qwen 3 8B test result — **PTCF (The Architect)**, Autonomy 4/4, Precision 3/4, Transparency 4/4, Adaptability 2/4

## Testing
- `npm test` — 124/126 pass (2 pre-existing OG format failures)
- Qwen 3 8B tested successfully via Ollama with the fix

Closes #188