### PR TITLE
feat: publish CLI as @kagura-agent/abti on npm (closes #27)

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,14 +67,14 @@ Replace `claude-3-5-sonnet` with the agent's slug. Shows "Not Tested" if the age
 Test any AI agent from the command line:
 
 ```bash
-npx abti --auto --provider openai --model gpt-4o --api-key sk-...
-npx abti --auto --provider anthropic --model claude-sonnet-4-20250514
-npx abti --auto --provider ollama --model llama3.1
+npx @kagura-agent/abti --auto --provider openai --model gpt-4o --api-key sk-...
+npx @kagura-agent/abti --auto --provider anthropic --model claude-sonnet-4-20250514
+npx @kagura-agent/abti --auto --provider ollama --model llama3.1
 ```
 
 Ollama requires no API key — just make sure Ollama is running locally.
 
-Run `npx abti --help` for all options.
+Run `npx @kagura-agent/abti --help` for all options.
 
 ## GitHub Action
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,18 +1,25 @@
 {
-  "name": "abti",
+  "name": "@kagura-agent/abti",
   "version": "0.1.0",
-  "description": "Agent Behavioral Type Indicator — discover your AI agent's personality type from the terminal",
+  "description": "Agent Behavioral Type Indicator \u2014 discover your AI agent's personality type from the terminal",
   "bin": {
-    "abti": "./bin/abti.js"
+    "abti": "bin/abti.js"
   },
   "files": [
     "bin/"
   ],
-  "keywords": ["abti", "agent", "personality", "type", "indicator", "ai"],
+  "keywords": [
+    "abti",
+    "agent",
+    "personality",
+    "type",
+    "indicator",
+    "ai"
+  ],
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/kagura-agent/abti"
+    "url": "git+https://github.com/kagura-agent/abti.git"
   },
   "engines": {
     "node": ">=16"


### PR DESCRIPTION
## Changes

- npm rejected the unscoped name `abti` (too similar to `abab`, `ai`, `jiti`, etc.)
- Published as `@kagura-agent/abti@0.1.0` with public access
- Updated README with scoped `npx @kagura-agent/abti` commands

## Verification

```bash
npx @kagura-agent/abti --help
npx @kagura-agent/abti --auto --provider ollama --model llama3.1
```

Closes #27