### PR TITLE
data: add Granite 3.3 8B + Aya Expanse 8B test results

### DIFF
--- a/data/results.json
+++ b/data/results.json
@@ -1715,6 +1715,56 @@
       ],
       "model": "Cohere-command-r-08-2024",
       "provider": "openai"
+    },
+    {
+      "name": "Granite 3.3 8B",
+      "slug": "granite-3-3-8b",
+      "url": "",
+      "type": "PTCF",
+      "nick": "The Architect",
+      "testedAt": "2026-05-04T01:47:44.019Z",
+      "scores": [
+        4,
+        3,
+        4,
+        2
+      ],
+      "dimensions": [
+        {
+          "poles": [
+            "P",
+            "R"
+          ],
+          "score": 4,
+          "max": 4
+        },
+        {
+          "poles": [
+            "T",
+            "E"
+          ],
+          "score": 3,
+          "max": 4
+        },
+        {
+          "poles": [
+            "C",
+            "D"
+          ],
+          "score": 4,
+          "max": 4
+        },
+        {
+          "poles": [
+            "F",
+            "N"
+          ],
+          "score": 2,
+          "max": 4
+        }
+      ],
+      "model": "granite3.3:8b",
+      "provider": "openai"
     }
   ]
 }

--- a/data/results.json
+++ b/data/results.json
@@ -1765,6 +1765,56 @@
       ],
       "model": "granite3.3:8b",
       "provider": "openai"
+    },
+    {
+      "name": "Aya Expanse 8B",
+      "slug": "aya-expanse-8b",
+      "url": "",
+      "type": "PTCN",
+      "nick": "The Commander",
+      "testedAt": "2026-05-04T01:56:26.347Z",
+      "scores": [
+        2,
+        3,
+        3,
+        1
+      ],
+      "dimensions": [
+        {
+          "poles": [
+            "P",
+            "R"
+          ],
+          "score": 2,
+          "max": 4
+        },
+        {
+          "poles": [
+            "T",
+            "E"
+          ],
+          "score": 3,
+          "max": 4
+        },
+        {
+          "poles": [
+            "C",
+            "D"
+          ],
+          "score": 3,
+          "max": 4
+        },
+        {
+          "poles": [
+            "F",
+            "N"
+          ],
+          "score": 1,
+          "max": 4
+        }
+      ],
+      "model": "aya-expanse:8b",
+      "provider": "openai"
     }
   ]
 }


### PR DESCRIPTION
Adds two new model families to the agent registry:

**IBM Granite 3.3 8B** → PTCF (The Architect)
- Autonomy: 4/4 → Proactive
- Precision: 3/4 → Thorough
- Transparency: 4/4 → Candid
- Adaptability: 2/4 → Flexible

**Cohere Aya Expanse 8B** → PTCN (The Commander)
- Autonomy: 2/4 → Proactive
- Precision: 3/4 → Thorough
- Transparency: 3/4 → Candid
- Adaptability: 1/4 → Principled

Both tested locally via Ollama. Registry now has **36 agents** across 9 distinct types.

First IBM model in the registry. Aya Expanse is Cohere's multilingual variant (distinct from Command R/R+ already in registry).