### PR TITLE
fix: correct npx command in CLI docs (scoped package)

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -7,7 +7,7 @@ Agent Behavioral Type Indicator — discover your AI agent's personality type fr
 ## Usage
 
 ```bash
-npx abti
+npx @kagura-agent/abti
 ```
 
 ### Options
@@ -47,27 +47,27 @@ Use `--auto` to have an LLM answer all 16 questions automatically:
 
 ```bash
 # Interactive test
-npx abti
+npx @kagura-agent/abti
 
 # Chinese, JSON output
-npx abti --lang zh --json
+npx @kagura-agent/abti --lang zh --json
 
 # Submit an agent to the registry
-npx abti --name "my-agent" --url "https://example.com" --submit
+npx @kagura-agent/abti --name "my-agent" --url "https://example.com" --submit
 
 # Auto mode with OpenAI
-npx abti --auto --provider openai --model gpt-4o
+npx @kagura-agent/abti --auto --provider openai --model gpt-4o
 
 # Auto mode with Anthropic + custom prompt
-npx abti --auto --provider anthropic --model claude-sonnet-4-20250514 \
+npx @kagura-agent/abti --auto --provider anthropic --model claude-sonnet-4-20250514 \
   --prompt "You are a cautious security-focused assistant."
 
 # Auto mode with prompt file + JSON output + submit
-npx abti --auto --provider openai --model gpt-4o \
+npx @kagura-agent/abti --auto --provider openai --model gpt-4o \
   --prompt-file ./my-agent-prompt.txt --json --submit --name "my-agent"
 
 # Auto mode via OpenRouter
-npx abti --auto --provider openai --model meta-llama/llama-3-70b \
+npx @kagura-agent/abti --auto --provider openai --model meta-llama/llama-3-70b \
   --llm-base-url https://openrouter.ai/api --api-key sk-or-...
 ```
 

--- a/cli/bin/abti.js
+++ b/cli/bin/abti.js
@@ -105,21 +105,21 @@ if (flag('--help') || flag('-h')) {
   abti — Agent Behavioral Type Indicator
 
   Usage:
-    npx abti                 Interactive test
-    npx abti --json          Output result as JSON
-    npx abti --lang zh       Chinese questions
-    npx abti --name myAgent  Set agent name
-    npx abti --url URL       Set agent URL
-    npx abti --model MODEL   Set model name
-    npx abti --provider PRV  Set provider name
-    npx abti --submit        Submit result to registry
+    npx @kagura-agent/abti                 Interactive test
+    npx @kagura-agent/abti --json          Output result as JSON
+    npx @kagura-agent/abti --lang zh       Chinese questions
+    npx @kagura-agent/abti --name myAgent  Set agent name
+    npx @kagura-agent/abti --url URL       Set agent URL
+    npx @kagura-agent/abti --model MODEL   Set model name
+    npx @kagura-agent/abti --provider PRV  Set provider name
+    npx @kagura-agent/abti --submit        Submit result to registry
 
   Auto mode (LLM answers all questions):
-    npx abti --auto --provider openai --model gpt-4o --api-key sk-...
-    npx abti --auto --provider anthropic --model claude-sonnet-4-20250514
-    npx abti --auto --provider gemini --model gemini-2.0-flash
-    npx abti --auto --provider deepseek --model deepseek-chat
-    npx abti --auto --provider ollama --model llama3.1
+    npx @kagura-agent/abti --auto --provider openai --model gpt-4o --api-key sk-...
+    npx @kagura-agent/abti --auto --provider anthropic --model claude-sonnet-4-20250514
+    npx @kagura-agent/abti --auto --provider gemini --model gemini-2.0-flash
+    npx @kagura-agent/abti --auto --provider deepseek --model deepseek-chat
+    npx @kagura-agent/abti --auto --provider ollama --model llama3.1
 
   Auto mode options:
     --auto                   Enable LLM auto-answer mode
@@ -132,8 +132,8 @@ if (flag('--help') || flag('-h')) {
     --runs <N>               Run the test N times (1-10, auto mode only) and show consistency report
 
   Combine flags:
-    npx abti --name myBot --submit --json
-    npx abti --auto --provider openai --model gpt-4o --json --submit
+    npx @kagura-agent/abti --name myBot --submit --json
+    npx @kagura-agent/abti --auto --provider openai --model gpt-4o --json --submit
 `);
   process.exit(0);
 }


### PR DESCRIPTION
The package is published as `@kagura-agent/abti`, but all examples showed `npx abti` which returns a 404 error.

**Changes:**
- `cli/README.md`: all `npx abti` → `npx @kagura-agent/abti`
- `cli/bin/abti.js`: help text examples updated

Closes #197