### PR TITLE
ops: add systemd unit with orphan-process safety net

### DIFF
--- a/ops/README.md
+++ b/ops/README.md
@@ -1,0 +1,26 @@
+# ABTI Ops Guide
+
+## Install the systemd service
+
+```bash
+sudo cp ops/abti-api.service /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable abti-api
+sudo systemctl start abti-api
+```
+
+## Restart / manage
+
+```bash
+sudo systemctl restart abti-api
+sudo systemctl status abti-api
+sudo journalctl -u abti-api -f
+```
+
+**Always use `systemctl` to start/stop the service. Never use `nohup node api-server.js &`.**
+
+Manual `nohup` creates orphan processes that hold port 3300, causing systemd `EADDRINUSE` crash loops on restart.
+
+## How the safety net works
+
+The service unit includes `ExecStartPre=fuser -k 3300/tcp || true`, which kills any process holding port 3300 before starting. This ensures the service can always bind the port, even if an orphan process was left behind.

--- a/ops/abti-api.service
+++ b/ops/abti-api.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=ABTI API Server
+After=network.target
+
+[Service]
+Type=simple
+User=abti
+WorkingDirectory=/opt/abti
+ExecStartPre=/bin/sh -c 'fuser -k 3300/tcp || true'
+ExecStart=/usr/bin/node api-server.js
+Restart=on-failure
+RestartSec=5
+Environment=NODE_ENV=production
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary

Adds a version-controlled systemd unit file with `ExecStartPre` that kills any process on port 3300 before starting, preventing EADDRINUSE crash loops from orphan nohup processes.

## Changes
- `ops/abti-api.service` — systemd unit with safety net
- `ops/README.md` — ops guide (install, restart, why no nohup)

## How it works
`ExecStartPre=/bin/sh -c 'fuser -k 3300/tcp || true'` ensures the port is free before `ExecStart` runs.

Closes #199