### PR TITLE
fix: add root action.yml for GitHub Action discoverability

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,54 @@
+name: 'ABTI — Agent Personality Test'
+description: 'Run an ABTI personality test on your AI agent and get its behavioral type'
+author: 'kagura-agent'
+
+inputs:
+  agent-prompt:
+    description: 'Agent system prompt string'
+    required: false
+  agent-prompt-file:
+    description: 'Path to file containing the agent system prompt (e.g. AGENTS.md)'
+    required: false
+  provider:
+    description: 'LLM provider: openai, anthropic, or gemini'
+    required: true
+  model:
+    description: 'Model name (e.g. gpt-4o, claude-sonnet-4-20250514)'
+    required: true
+  api-key:
+    description: 'API key for the LLM provider'
+    required: true
+  post-comment:
+    description: 'Post a PR comment with results'
+    required: false
+    default: 'false'
+  llm-base-url:
+    description: 'Base URL for the LLM API (e.g. https://openrouter.ai/api). Overrides the default provider endpoint.'
+    required: false
+  api-base-url:
+    description: 'ABTI API base URL'
+    required: false
+    default: 'https://abti.kagura-agent.com'
+  agent-name:
+    description: 'Display name for the agent in the registry (defaults to "<model> (<provider>)")'
+    required: false
+  lang:
+    description: 'Language for questions (en or zh)'
+    required: false
+    default: 'en'
+
+outputs:
+  type:
+    description: 'ABTI type code (e.g. PTCF)'
+  nickname:
+    description: 'Type nickname (e.g. The Architect)'
+  badge-url:
+    description: 'URL for the ABTI badge SVG'
+
+branding:
+  icon: 'users'
+  color: 'purple'
+
+runs:
+  using: 'node20'
+  main: 'action/index.js'


### PR DESCRIPTION
## What

Adds `action.yml` at repo root pointing to `action/index.js`. This makes `uses: kagura-agent/abti@v1` work as documented in README.

Previously, the action.yml was only in `action/` subdirectory, requiring `kagura-agent/abti/action@ref` syntax.

## After merge

Tag `v1` needs to be created on master to complete the fix.

Closes #201