### PR TITLE
data: add Yi 6B to agent registry (PTCF)

### DIFF
--- a/data/results.json
+++ b/data/results.json
@@ -1865,6 +1865,56 @@
       ],
       "model": "gemma2:2b",
       "provider": "openai"
+    },
+    {
+      "name": "yi:6b",
+      "slug": "yi-6b",
+      "url": "",
+      "type": "PTCF",
+      "nick": "The Architect",
+      "testedAt": "2026-05-04T08:44:49.762Z",
+      "scores": [
+        3,
+        2,
+        4,
+        2
+      ],
+      "dimensions": [
+        {
+          "poles": [
+            "P",
+            "R"
+          ],
+          "score": 3,
+          "max": 4
+        },
+        {
+          "poles": [
+            "T",
+            "E"
+          ],
+          "score": 2,
+          "max": 4
+        },
+        {
+          "poles": [
+            "C",
+            "D"
+          ],
+          "score": 4,
+          "max": 4
+        },
+        {
+          "poles": [
+            "F",
+            "N"
+          ],
+          "score": 2,
+          "max": 4
+        }
+      ],
+      "model": "yi:6b",
+      "provider": "openai"
     }
   ]
 }


### PR DESCRIPTION
Add Yi 6B (01.AI) test result via Ollama.

**Result:** PTCF — The Architect
- Autonomy: 3/4 → Proactive
- Precision: 2/4 → Thorough
- Transparency: 4/4 → Candid
- Adaptability: 2/4 → Flexible

**Registry: 38 agents, 10 distinct types.**

Also attempted TinyLlama (1.1B) but it's too small to follow the question format — outputs gibberish instead of A/B answers.

Relates to #165