### PR TITLE
fix: auto-reload data when results.json changes (closes #205)

### DIFF
--- a/api-server.js
+++ b/api-server.js
@@ -32,9 +32,46 @@ function resetData() {
   DATA_DIR = process.env.ABTI_DATA_DIR || path.join(__dirname, 'data');
   DATA_FILE = path.join(DATA_DIR, 'results.json');
   agentData = loadData();
+  startWatching();
 }
 
 let agentData = loadData();
+
+// File watcher: auto-reload data when DATA_FILE changes
+let _fileWatcher = null;
+let _debounceTimer = null;
+
+function startWatching() {
+  stopWatching();
+  try {
+    _fileWatcher = fs.watch(DATA_FILE, () => {
+      clearTimeout(_debounceTimer);
+      _debounceTimer = setTimeout(() => {
+        try {
+          agentData = loadData();
+          console.log(`Data reloaded: ${agentData.agents.length} agents`);
+        } catch (err) {
+          console.error('Failed to reload data:', err.message);
+        }
+      }, 500);
+    });
+    _fileWatcher.on('error', (err) => {
+      console.error('File watch error:', err.message);
+    });
+  } catch (err) {
+    console.error('Failed to start file watcher:', err.message);
+  }
+}
+
+function stopWatching() {
+  clearTimeout(_debounceTimer);
+  if (_fileWatcher) {
+    _fileWatcher.close();
+    _fileWatcher = null;
+  }
+}
+
+startWatching();
 
 // Rate limiter for POST /api/agent-test: max 5 per IP per hour
 const rateLimitMap = new Map();
@@ -1384,5 +1421,6 @@ if (require.main === module) {
 }
 module.exports = server;
 module.exports.resetData = resetData;
+module.exports.stopWatching = stopWatching;
 module.exports.rateLimitMap = rateLimitMap;
 module.exports.slugify = slugify;

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "abti",
   "private": true,
   "scripts": {
-    "test": "node --test test/api.test.js test/mcp.test.js test/mcp-http.test.js test/compatibility.test.js",
+    "test": "node --test test/api.test.js test/mcp.test.js test/mcp-http.test.js test/compatibility.test.js test/auto-reload.test.js",
     "generate-og": "node scripts/generate-og-images.js"
   },
   "devDependencies": {

--- a/test/auto-reload.test.js
+++ b/test/auto-reload.test.js
@@ -1,0 +1,71 @@
+const { describe, it, before, after, beforeEach } = require('node:test');
+const assert = require('node:assert/strict');
+const http = require('node:http');
+const os = require('node:os');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'abti-reload-'));
+process.env.ABTI_DATA_DIR = tmpDir;
+
+const server = require('../api-server.js');
+const { resetData, stopWatching } = require('../api-server.js');
+
+let BASE;
+
+function req(urlPath) {
+  return new Promise((resolve, reject) => {
+    const url = new URL(urlPath, BASE);
+    http.get(url, (res) => {
+      let d = '';
+      res.on('data', c => d += c);
+      res.on('end', () => resolve(JSON.parse(d)));
+    }).on('error', reject);
+  });
+}
+
+function sleep(ms) {
+  return new Promise(r => setTimeout(r, ms));
+}
+
+before(() => new Promise((resolve) => {
+  // Ensure data file exists so watcher can attach
+  const dataFile = path.join(tmpDir, 'results.json');
+  fs.writeFileSync(dataFile, JSON.stringify({ agents: [] }));
+  resetData();
+  server.listen(0, '127.0.0.1', () => {
+    BASE = `http://127.0.0.1:${server.address().port}`;
+    resolve();
+  });
+}));
+
+after(() => new Promise((resolve) => {
+  stopWatching();
+  server.close(resolve);
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+}));
+
+describe('auto-reload data on file change', () => {
+  it('should reload agentData when results.json is modified externally', async () => {
+    // Verify initially empty
+    const before = await req('/api/agents');
+    assert.equal(before.total, 0);
+
+    // Write new data directly to file (simulating external edit)
+    const dataFile = path.join(tmpDir, 'results.json');
+    const newData = {
+      agents: [
+        { name: 'TestBot', type: 'PTCF', scores: [3,2,3,3], slug: 'testbot', testedAt: new Date().toISOString() }
+      ]
+    };
+    fs.writeFileSync(dataFile, JSON.stringify(newData));
+
+    // Wait for debounce (500ms) + buffer
+    await sleep(1000);
+
+    // Verify data was reloaded
+    const afterReload = await req('/api/agents');
+    assert.equal(afterReload.total, 1);
+    assert.equal(afterReload.agents[0].name, 'TestBot');
+  });
+});


### PR DESCRIPTION
## Problem

The API server reads `data/results.json` once on startup and caches it in memory. When new model test results are merged and the repo is pulled on VM1, the API continues serving stale data until manually restarted.

Found during routine check: API served 37 agents while the file had 38.

## Solution

Added `fs.watch()` on the data file with 500ms debounce to auto-reload `agentData` when the file changes on disk.

- Debounced (500ms) to handle rapid writes during git operations
- Logs `Data reloaded: N agents` on success
- Handles watch errors gracefully
- `resetData()` now re-attaches the watcher
- Exports `stopWatching()` for clean test teardown
- Added `test/auto-reload.test.js` — 125 pass, 2 fail (pre-existing OG badge issue)

Closes #205