### PR TITLE
fix: retry on parse failure in CLI and seed-registry (closes #207)

### DIFF
--- a/cli/bin/abti.js
+++ b/cli/bin/abti.js
@@ -331,8 +331,20 @@ async function runAuto() {
       `B: ${optB}`,
     ].join('\n');
 
-    const response = await callLLM(autoProvider, apiKey, autoModel, systemPrompt, userMessage, llmBaseUrl || undefined);
-    const answer = parseAnswer(response);
+    let answer;
+    let lastErr;
+    for (let attempt = 0; attempt < 3; attempt++) {
+      const msg = attempt === 0 ? userMessage : 'Your previous response was not clear. Reply with ONLY the single letter A or B. Nothing else.';
+      const response = await callLLM(autoProvider, apiKey, autoModel, systemPrompt, msg, llmBaseUrl || undefined);
+      try {
+        answer = parseAnswer(response);
+        break;
+      } catch (err) {
+        lastErr = err;
+        process.stderr.write(`  Parse failed (attempt ${attempt + 1}/3): ${err.message}\n`);
+      }
+    }
+    if (answer === undefined) throw lastErr;
     answers.push(answer);
     process.stderr.write(`  Question ${i + 1}/${questions.length}... ${answer ? 'A' : 'B'}\n`);
   }

--- a/scripts/seed-registry.js
+++ b/scripts/seed-registry.js
@@ -246,9 +246,21 @@ async function main() {
       ].join('\n');
 
       console.log(`  Q${i + 1}/${questions.length} [${q.dimension}]...`);
-      const response = await callLLM(opts, systemPrompt, userMessage);
-      const answer = parseAnswer(response);
-      console.log(`    → ${answer === 1 ? 'A' : 'B'} (raw: "${response}")`);
+      let answer;
+      let lastErr;
+      for (let attempt = 0; attempt < 3; attempt++) {
+        const msg = attempt === 0 ? userMessage : 'Your previous response was not clear. Reply with ONLY the single letter A or B. Nothing else.';
+        const response = await callLLM(opts, systemPrompt, msg);
+        try {
+          answer = parseAnswer(response);
+          console.log(`    → ${answer === 1 ? 'A' : 'B'} (raw: "${response}")`);
+          break;
+        } catch (err) {
+          lastErr = err;
+          console.log(`    Parse failed (attempt ${attempt + 1}/3): ${err.message}`);
+        }
+      }
+      if (answer === undefined) throw lastErr;
       answers.push(answer);
     }
 


### PR DESCRIPTION
## Problem

When testing models that give verbose responses (e.g., Solar 10.7B, TinyLlama), `parseAnswer()` throws on first failure without retrying, crashing the entire test run.

## Fix

Both `cli/bin/abti.js` and `scripts/seed-registry.js` now retry up to 3 times on parse failure with a stricter prompt. If all 3 attempts fail, the original error is thrown.

All 127 tests pass.

Closes #207