### PR TITLE
data: add Solar 10.7B and TinyLlama 1.1B test results

### DIFF
--- a/data/results.json
+++ b/data/results.json
@@ -1915,6 +1915,106 @@
       ],
       "model": "yi:6b",
       "provider": "openai"
+    },
+    {
+      "name": "Solar 10.7B",
+      "slug": "solar-10-7b",
+      "url": "",
+      "type": "PECF",
+      "nick": "The Spark",
+      "testedAt": "2026-05-04T11:40:51.836Z",
+      "scores": [
+        2,
+        1,
+        2,
+        3
+      ],
+      "dimensions": [
+        {
+          "poles": [
+            "P",
+            "R"
+          ],
+          "score": 2,
+          "max": 4
+        },
+        {
+          "poles": [
+            "T",
+            "E"
+          ],
+          "score": 1,
+          "max": 4
+        },
+        {
+          "poles": [
+            "C",
+            "D"
+          ],
+          "score": 2,
+          "max": 4
+        },
+        {
+          "poles": [
+            "F",
+            "N"
+          ],
+          "score": 3,
+          "max": 4
+        }
+      ],
+      "model": "solar:10.7b",
+      "provider": "openai"
+    },
+    {
+      "name": "TinyLlama 1.1B",
+      "slug": "tinyllama-1-1b",
+      "url": "",
+      "type": "PTCF",
+      "nick": "The Architect",
+      "testedAt": "2026-05-04T11:43:08.067Z",
+      "scores": [
+        4,
+        4,
+        4,
+        4
+      ],
+      "dimensions": [
+        {
+          "poles": [
+            "P",
+            "R"
+          ],
+          "score": 4,
+          "max": 4
+        },
+        {
+          "poles": [
+            "T",
+            "E"
+          ],
+          "score": 4,
+          "max": 4
+        },
+        {
+          "poles": [
+            "C",
+            "D"
+          ],
+          "score": 4,
+          "max": 4
+        },
+        {
+          "poles": [
+            "F",
+            "N"
+          ],
+          "score": 4,
+          "max": 4
+        }
+      ],
+      "model": "tinyllama",
+      "provider": "openai"
     }
   ]
 }


### PR DESCRIPTION
Two new local model results using the retry fix from #208:

- **Solar 10.7B** → PECF (The Spark) — first test using retry (Q15 needed retry)
- **TinyLlama 1.1B** → PTCF (The Architect) — 4/4 all dimensions, classic position bias

Registry: 38 → 40 agents, 10 types.