### PR TITLE
data: add Solar 10.7B test result (PTCF)

### DIFF
--- a/data/results.json
+++ b/data/results.json
@@ -2015,6 +2015,56 @@
       ],
       "model": "tinyllama",
       "provider": "openai"
+    },
+    {
+      "name": "solar:10.7b",
+      "slug": "solar-10-7b",
+      "url": "",
+      "type": "PTCF",
+      "nick": "The Architect",
+      "testedAt": "2026-05-04T12:54:25.547Z",
+      "scores": [
+        2,
+        3,
+        2,
+        2
+      ],
+      "dimensions": [
+        {
+          "poles": [
+            "P",
+            "R"
+          ],
+          "score": 2,
+          "max": 4
+        },
+        {
+          "poles": [
+            "T",
+            "E"
+          ],
+          "score": 3,
+          "max": 4
+        },
+        {
+          "poles": [
+            "C",
+            "D"
+          ],
+          "score": 2,
+          "max": 4
+        },
+        {
+          "poles": [
+            "F",
+            "N"
+          ],
+          "score": 2,
+          "max": 4
+        }
+      ],
+      "model": "solar:10.7b",
+      "provider": "openai"
     }
   ]
 }


### PR DESCRIPTION
Add Solar 10.7B (Upstage) test result via Ollama.

**Result:** PTCF — The Architect

Same type as many other models (Gemma 3 4B, Mistral 7B, GPT-4.1, etc.). Solar 10.7B is Upstage's instruction-tuned model based on Llama 2 architecture.

**Registry: 39 agents, 10 distinct types.**

Part of #165.