### PR TITLE
feat: add leaderboard to nav, sitemap, and fix color consistency

### DIFF
--- a/agent.html
+++ b/agent.html
@@ -167,6 +167,7 @@ nav a:hover, nav a.active { color: var(--accent); }
   <a href="index.html">ABTI</a>
   <a href="sbti.html">SBTI-AI</a>
   <a href="agents.html" class="active">Agents</a>
+  <a href="leaderboard.html">Leaderboard</a>
   <a href="types.html">Types</a>
   <a href="compare.html">Compare</a>
   <a href="test-agent.html">Test Agent</a>

--- a/api.html
+++ b/api.html
@@ -180,6 +180,7 @@ pre code {
   <a href="index.html">ABTI</a>
   <a href="sbti.html">SBTI-AI</a>
   <a href="agents.html">Agents</a>
+  <a href="leaderboard.html">Leaderboard</a>
   <a href="types.html">Types</a>
   <a href="compare.html">Compare</a>
   <a href="test-agent.html">Test Agent</a>

--- a/compare.html
+++ b/compare.html
@@ -92,6 +92,7 @@ nav a:hover, nav a.active { color: var(--accent); }
   <a href="index.html">ABTI</a>
   <a href="sbti.html">SBTI-AI</a>
   <a href="agents.html">Agents</a>
+  <a href="leaderboard.html">Leaderboard</a>
   <a href="types.html">Types</a>
   <a href="compare.html" class="active">Compare</a>
   <a href="test-agent.html">Test Agent</a>

--- a/compatibility.html
+++ b/compatibility.html
@@ -120,6 +120,7 @@ nav a:hover, nav a.active { color: var(--accent); }
   <a href="index.html">ABTI</a>
   <a href="sbti.html">SBTI-AI</a>
   <a href="agents.html">Agents</a>
+  <a href="leaderboard.html">Leaderboard</a>
   <a href="types.html">Types</a>
   <a href="compare.html">Compare</a>
   <a href="test-agent.html">Test Agent</a>

--- a/cross-compatibility.html
+++ b/cross-compatibility.html
@@ -135,6 +135,7 @@ nav a:hover, nav a.active { color: var(--accent); }
   <a href="index.html">ABTI</a>
   <a href="sbti.html">SBTI-AI</a>
   <a href="agents.html">Agents</a>
+  <a href="leaderboard.html">Leaderboard</a>
   <a href="types.html">Types</a>
   <a href="compare.html">Compare</a>
   <a href="test-agent.html">Test Agent</a>

--- a/index-v4.html
+++ b/index-v4.html
@@ -104,6 +104,7 @@ nav a:hover, nav a.active { color: var(--accent); }
   <a href="index.html" class="active">ABTI</a>
   <a href="sbti.html">SBTI-AI</a>
   <a href="agents.html">Agents</a>
+  <a href="leaderboard.html">Leaderboard</a>
   <a href="api.html">API</a>
   <button class="lang-btn" onclick="toggleLang()" id="langBtn">EN</button>
 </nav>

--- a/index.html
+++ b/index.html
@@ -719,6 +719,7 @@ body {
   <a href="index.html" class="active">ABTI</a>
   <a href="sbti.html">SBTI-AI</a>
   <a href="agents.html">Agents</a>
+  <a href="leaderboard.html">Leaderboard</a>
   <a href="types.html">Types</a>
   <a href="compare.html">Compare</a>
   <a href="test-agent.html">Test Agent</a>

--- a/leaderboard.html
+++ b/leaderboard.html
@@ -15,7 +15,7 @@
 :root {
   --bg: #faf9f7; --surface: #ffffff; --surface2: #f0eeeb;
   --text: #1a1a1a; --text2: #6b6b6b; --text3: #a3a3a3;
-  --accent: #e8658a; --accent2: #d44d73; --accent-soft: #fdf0f3;
+  --accent: #0d9488; --accent2: #0f766e; --accent-soft: #f0fdfa;
   --border: #e8e5e1; --radius: 14px;
   --shadow: 0 1px 3px rgba(0,0,0,.06);
   --shadow-md: 0 4px 12px rgba(0,0,0,.08);

--- a/sbti.html
+++ b/sbti.html
@@ -240,10 +240,14 @@ body {
 <nav class="nav">
   <a href="index.html">ABTI</a>
   <a href="sbti.html" class="active">SBTI-AI</a>
+  <a href="agents.html">Agents</a>
+  <a href="leaderboard.html">Leaderboard</a>
   <a href="types.html">Types</a>
+  <a href="compare.html">Compare</a>
   <a href="test-agent.html">Test Agent</a>
   <a href="compatibility.html">Compatibility</a>
   <a href="cross-compatibility.html">Cross Match</a>
+  <a href="api.html">API</a>
   <button class="lang-btn" onclick="toggleLang()" id="langBtn">中文</button>
 </nav>
 

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -43,6 +43,12 @@
     <priority>0.7</priority>
   </url>
   <url>
+    <loc>https://abti.kagura-agent.com/leaderboard.html</loc>
+    <lastmod>2026-05-05</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
     <loc>https://abti.kagura-agent.com/sbti.html</loc>
     <lastmod>2026-04-30</lastmod>
     <changefreq>weekly</changefreq>

--- a/test-agent.html
+++ b/test-agent.html
@@ -496,6 +496,7 @@ textarea { resize: vertical; min-height: 80px; }
   <a href="index.html">ABTI</a>
   <a href="sbti.html">SBTI-AI</a>
   <a href="agents.html">Agents</a>
+  <a href="leaderboard.html">Leaderboard</a>
   <a href="types.html">Types</a>
   <a href="compare.html">Compare</a>
   <a href="test-agent.html" class="active">Test Agent</a>

--- a/type.html
+++ b/type.html
@@ -169,6 +169,7 @@ nav a:hover, nav a.active { color: var(--accent); }
   <a href="index.html">ABTI</a>
   <a href="sbti.html">SBTI-AI</a>
   <a href="agents.html">Agents</a>
+  <a href="leaderboard.html">Leaderboard</a>
   <a href="types.html">Types</a>
   <a href="compare.html">Compare</a>
   <a href="test-agent.html">Test Agent</a>

--- a/types.html
+++ b/types.html
@@ -85,6 +85,7 @@ nav .lang-btn:hover { color: var(--accent); border-color: var(--accent); }
   <a href="index.html">ABTI</a>
   <a href="sbti.html">SBTI-AI</a>
   <a href="agents.html">Agents</a>
+  <a href="leaderboard.html">Leaderboard</a>
   <a href="types.html" class="active">Types</a>
   <a href="compare.html">Compare</a>
   <a href="test-agent.html">Test Agent</a>


### PR DESCRIPTION
Closes #213

## Changes

- Add **Leaderboard** link to navigation bar on all 13 HTML pages
- Fix `sbti.html` nav to include all pages (was missing Agents, Leaderboard, Compare, API)
- Add `leaderboard.html` to `sitemap.xml` (priority 0.7)
- Change leaderboard accent color from pink to teal for visual consistency

## Impact

The leaderboard page was effectively hidden — not linked from any page's nav and not indexed by search engines. This makes it discoverable.