### PR TITLE
data: add Dolphin Mistral 7B test result (PTCF)

### DIFF
--- a/data/results.json
+++ b/data/results.json
@@ -2015,6 +2015,56 @@
       ],
       "model": "internlm2:7b",
       "provider": "openai"
+    },
+    {
+      "name": "Dolphin Mistral 7B",
+      "slug": "dolphin-mistral-7b",
+      "url": "",
+      "type": "PTCF",
+      "nick": "The Architect",
+      "testedAt": "2026-05-05T01:39:08.872Z",
+      "scores": [
+        4,
+        3,
+        2,
+        3
+      ],
+      "dimensions": [
+        {
+          "poles": [
+            "P",
+            "R"
+          ],
+          "score": 4,
+          "max": 4
+        },
+        {
+          "poles": [
+            "T",
+            "E"
+          ],
+          "score": 3,
+          "max": 4
+        },
+        {
+          "poles": [
+            "C",
+            "D"
+          ],
+          "score": 2,
+          "max": 4
+        },
+        {
+          "poles": [
+            "F",
+            "N"
+          ],
+          "score": 3,
+          "max": 4
+        }
+      ],
+      "model": "dolphin-mistral:7b",
+      "provider": "openai"
     }
   ]
 }


### PR DESCRIPTION
Add Dolphin Mistral 7B (uncensored variant) to the registry.

**Result: PTCF — The Architect** (P4/T3/C2/F3)

Registry: 41 agents, 10 distinct types.

Despite being an uncensored/unaligned variant, Dolphin-Mistral scores the same as its base model and most other 7B instruction-tuned models — further confirming the PTCF convergence pattern for mid-size models.

Contributes to #165