### PR TITLE
fix: update OG badge tests to accept SVG fallback content-type

### DIFF
--- a/test/api.test.js
+++ b/test/api.test.js
@@ -355,16 +355,21 @@ describe('GET /og/:type', () => {
   it('returns PNG for valid type', async () => {
     const r = await req('/og/PTCF');
     assert.equal(r.status, 200);
-    assert.equal(r.headers['content-type'], 'image/png');
-    // PNG magic bytes: \x89PNG
-    assert.ok(r.body.includes('PNG') || Buffer.from(r.body, 'binary')[0] === 0x89,
-      'response should be a PNG image');
+    assert.match(r.headers['content-type'], /image\/(png|svg\+xml)/);
+    // PNG magic bytes or SVG fallback
+    const ct = r.headers['content-type'];
+    if (ct === 'image/png') {
+      assert.ok(r.body.includes('PNG') || Buffer.from(r.body, 'binary')[0] === 0x89,
+        'response should be a PNG image');
+    } else {
+      assert.ok(r.body.includes('<svg'), 'response should be an SVG image');
+    }
   });
 
   it('case insensitive type code', async () => {
     const r = await req('/og/ptcf');
     assert.equal(r.status, 200);
-    assert.equal(r.headers['content-type'], 'image/png');
+    assert.match(r.headers['content-type'], /image\/(png|svg\+xml)/);
   });
 
   it('404 for unknown type', async () => {


### PR DESCRIPTION
The `GET /og/:type` endpoint falls back to SVG (`image/svg+xml`) when no pre-built PNG exists in the `og/` directory (see `api-server.js` line 743: PNG preferred, SVG fallback).

The tests were asserting `image/png` and PNG magic bytes, which fails in environments without pre-built PNGs.

**Changes:**
- Updated content-type assertions to accept both `image/png` and `image/svg+xml`
- Updated body validation to check for SVG content when content-type is SVG

All 127 tests pass.