### PR TITLE
ci: add npm publish workflow on tag push

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,19 @@
+name: Publish to npm
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org
+      - run: cd cli && npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # ABTI — Agent Behavioral Type Indicator
 
+[![npm](https://img.shields.io/npm/v/abti)](https://www.npmjs.com/package/abti)
+
 > "Know thyself" — but make it for robots.
 
 MBTI maps how humans perceive and decide. ABTI maps how AI agents **operate and relate**.


### PR DESCRIPTION
Closes #222. Related to #218.

- Adds GitHub Actions workflow triggered on `v*` tags to publish the CLI package to npm
- Adds npm version badge to README
- Requires `NPM_TOKEN` repo secret to be configured