### PR TITLE
fix: add category field to /api/compatibility/human ranked results

### DIFF
--- a/api-server.js
+++ b/api-server.js
@@ -1305,7 +1305,8 @@ ${dimInfo.map((d, i) => {
     const ranked = ABTI_VALID.map(code => {
       const score = crossScore(mbti, code);
       const profile = richProfiles[code]?.[lang] || richProfiles[code]?.en || types[code]?.en || {};
-      return { code, nick: profile.nick || code, score };
+      const category = score >= 80 ? 'complementary' : score >= 60 ? 'balanced' : 'similar';
+      return { code, nick: profile.nick || code, score, category };
     }).sort((a, b) => b.score - a.score);
 
     const complementaryType = poles.autonomy === 'P' ? 'R' : 'P';

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "abti",
   "private": true,
   "scripts": {
-    "test": "node --test test/api.test.js test/mcp.test.js test/mcp-http.test.js test/compatibility.test.js test/auto-reload.test.js",
+    "test": "node --test test/api.test.js test/mcp.test.js test/mcp-http.test.js test/compatibility.test.js test/cross-compatibility.test.js test/auto-reload.test.js",
     "generate-og": "node scripts/generate-og-images.js"
   },
   "devDependencies": {


### PR DESCRIPTION
Closes #224.

- Add `category` (complementary/balanced/similar) to each ranked item in `/api/compatibility/human`
- Include `test/cross-compatibility.test.js` in the test script — it was excluded, hiding a test failure

All 145 tests pass.