### PR TITLE
data: add GPT-4.1 mini and GPT-4.1 nano test results

### DIFF
--- a/api-server.js
+++ b/api-server.js
@@ -1305,7 +1305,8 @@ ${dimInfo.map((d, i) => {
     const ranked = ABTI_VALID.map(code => {
       const score = crossScore(mbti, code);
       const profile = richProfiles[code]?.[lang] || richProfiles[code]?.en || types[code]?.en || {};
-      return { code, nick: profile.nick || code, score };
+      const category = score >= 80 ? 'complementary' : score >= 60 ? 'balanced' : 'similar';
+      return { code, nick: profile.nick || code, score, category };
     }).sort((a, b) => b.score - a.score);
 
     const complementaryType = poles.autonomy === 'P' ? 'R' : 'P';

--- a/data/results.json
+++ b/data/results.json
@@ -2065,6 +2065,106 @@
       ],
       "model": "dolphin-mistral:7b",
       "provider": "openai"
+    },
+    {
+      "name": "GPT-4.1 mini",
+      "slug": "gpt-4-1-mini",
+      "url": "",
+      "type": "PECN",
+      "nick": "The Drill Sergeant",
+      "testedAt": "2026-05-05T10:23:35.303Z",
+      "scores": [
+        2,
+        0,
+        3,
+        1
+      ],
+      "dimensions": [
+        {
+          "poles": [
+            "P",
+            "R"
+          ],
+          "score": 2,
+          "max": 4
+        },
+        {
+          "poles": [
+            "T",
+            "E"
+          ],
+          "score": 0,
+          "max": 4
+        },
+        {
+          "poles": [
+            "C",
+            "D"
+          ],
+          "score": 3,
+          "max": 4
+        },
+        {
+          "poles": [
+            "F",
+            "N"
+          ],
+          "score": 1,
+          "max": 4
+        }
+      ],
+      "model": "openai/gpt-4.1-mini",
+      "provider": "openai"
+    },
+    {
+      "name": "GPT-4.1 nano",
+      "slug": "gpt-4-1-nano",
+      "url": "",
+      "type": "PTCF",
+      "nick": "The Architect",
+      "testedAt": "2026-05-05T10:25:08.075Z",
+      "scores": [
+        3,
+        2,
+        2,
+        2
+      ],
+      "dimensions": [
+        {
+          "poles": [
+            "P",
+            "R"
+          ],
+          "score": 3,
+          "max": 4
+        },
+        {
+          "poles": [
+            "T",
+            "E"
+          ],
+          "score": 2,
+          "max": 4
+        },
+        {
+          "poles": [
+            "C",
+            "D"
+          ],
+          "score": 2,
+          "max": 4
+        },
+        {
+          "poles": [
+            "F",
+            "N"
+          ],
+          "score": 2,
+          "max": 4
+        }
+      ],
+      "model": "openai/gpt-4.1-nano",
+      "provider": "openai"
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "abti",
   "private": true,
   "scripts": {
-    "test": "node --test test/api.test.js test/mcp.test.js test/mcp-http.test.js test/compatibility.test.js test/auto-reload.test.js",
+    "test": "node --test test/api.test.js test/mcp.test.js test/mcp-http.test.js test/compatibility.test.js test/cross-compatibility.test.js test/auto-reload.test.js",
     "generate-og": "node scripts/generate-og-images.js"
   },
   "devDependencies": {


### PR DESCRIPTION
Tested via GitHub Models API.

**New agents:**
- **GPT-4.1 mini** → PECN — The Drill Sergeant
- **GPT-4.1 nano** → PTCF — The Architect

Interesting: GPT-4.1 mini diverges from GPT-4.1 (PTCF) — it's more efficient and principled, while GPT-4.1 and GPT-4.1 nano share the same Architect type. The mini variant seems to trade thoroughness for efficiency.

**Registry: 43 agents, 10 distinct types.**

Part of #165