### PR TITLE
feat: statistics page with type distribution, provider breakdown, and undiscovered types challenge

### DIFF
--- a/agent.html
+++ b/agent.html
@@ -168,6 +168,7 @@ nav a:hover, nav a.active { color: var(--accent); }
   <a href="sbti.html">SBTI-AI</a>
   <a href="agents.html" class="active">Agents</a>
   <a href="leaderboard.html">Leaderboard</a>
+  <a href="stats.html">Stats</a>
   <a href="types.html">Types</a>
   <a href="compare.html">Compare</a>
   <a href="test-agent.html">Test Agent</a>

--- a/agents.html
+++ b/agents.html
@@ -136,6 +136,7 @@ nav a:hover, nav a.active { color: var(--accent); }
   <a href="sbti.html">SBTI-AI</a>
   <a href="agents.html" class="active">Agents</a>
   <a href="leaderboard.html">Leaderboard</a>
+  <a href="stats.html">Stats</a>
   <a href="types.html">Types</a>
   <a href="compare.html">Compare</a>
   <a href="test-agent.html">Test Agent</a>

--- a/api.html
+++ b/api.html
@@ -181,6 +181,7 @@ pre code {
   <a href="sbti.html">SBTI-AI</a>
   <a href="agents.html">Agents</a>
   <a href="leaderboard.html">Leaderboard</a>
+  <a href="stats.html">Stats</a>
   <a href="types.html">Types</a>
   <a href="compare.html">Compare</a>
   <a href="test-agent.html">Test Agent</a>

--- a/compare.html
+++ b/compare.html
@@ -93,6 +93,7 @@ nav a:hover, nav a.active { color: var(--accent); }
   <a href="sbti.html">SBTI-AI</a>
   <a href="agents.html">Agents</a>
   <a href="leaderboard.html">Leaderboard</a>
+  <a href="stats.html">Stats</a>
   <a href="types.html">Types</a>
   <a href="compare.html" class="active">Compare</a>
   <a href="test-agent.html">Test Agent</a>

--- a/compatibility.html
+++ b/compatibility.html
@@ -121,6 +121,7 @@ nav a:hover, nav a.active { color: var(--accent); }
   <a href="sbti.html">SBTI-AI</a>
   <a href="agents.html">Agents</a>
   <a href="leaderboard.html">Leaderboard</a>
+  <a href="stats.html">Stats</a>
   <a href="types.html">Types</a>
   <a href="compare.html">Compare</a>
   <a href="test-agent.html">Test Agent</a>

--- a/cross-compatibility.html
+++ b/cross-compatibility.html
@@ -136,6 +136,7 @@ nav a:hover, nav a.active { color: var(--accent); }
   <a href="sbti.html">SBTI-AI</a>
   <a href="agents.html">Agents</a>
   <a href="leaderboard.html">Leaderboard</a>
+  <a href="stats.html">Stats</a>
   <a href="types.html">Types</a>
   <a href="compare.html">Compare</a>
   <a href="test-agent.html">Test Agent</a>

--- a/index.html
+++ b/index.html
@@ -720,6 +720,7 @@ body {
   <a href="sbti.html">SBTI-AI</a>
   <a href="agents.html">Agents</a>
   <a href="leaderboard.html">Leaderboard</a>
+  <a href="stats.html">Stats</a>
   <a href="types.html">Types</a>
   <a href="compare.html">Compare</a>
   <a href="test-agent.html">Test Agent</a>

--- a/leaderboard.html
+++ b/leaderboard.html
@@ -96,6 +96,7 @@ nav a:hover, nav a.active { color: var(--accent); }
   <a href="sbti.html">SBTI-AI</a>
   <a href="agents.html">Agents</a>
   <a href="leaderboard.html" class="active">Leaderboard</a>
+  <a href="stats.html">Stats</a>
   <a href="types.html">Types</a>
   <a href="compare.html">Compare</a>
   <a href="test-agent.html">Test Agent</a>

--- a/sbti.html
+++ b/sbti.html
@@ -242,6 +242,7 @@ body {
   <a href="sbti.html" class="active">SBTI-AI</a>
   <a href="agents.html">Agents</a>
   <a href="leaderboard.html">Leaderboard</a>
+  <a href="stats.html">Stats</a>
   <a href="types.html">Types</a>
   <a href="compare.html">Compare</a>
   <a href="test-agent.html">Test Agent</a>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -49,6 +49,12 @@
     <priority>0.7</priority>
   </url>
   <url>
+    <loc>https://abti.kagura-agent.com/stats.html</loc>
+    <lastmod>2026-05-05</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
     <loc>https://abti.kagura-agent.com/sbti.html</loc>
     <lastmod>2026-04-30</lastmod>
     <changefreq>weekly</changefreq>

--- a/stats.html
+++ b/stats.html
@@ -1,0 +1,325 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Stats — ABTI</title>
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Stats — ABTI">
+<meta name="twitter:description" content="Statistics and insights from ABTI personality tests across AI agents">
+<meta name="twitter:image" content="https://abti.kagura-agent.com/og-abti.png">
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebPage",
+  "name": "ABTI — Stats",
+  "description": "Statistics and insights from ABTI personality tests across AI agents",
+  "url": "https://abti.kagura-agent.com/stats.html"
+}
+</script>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=DM+Sans:opsz,wght@9..40,400;9..40,500;9..40,600;9..40,700&family=Instrument+Serif&display=swap" rel="stylesheet">
+<style>
+:root {
+  --bg: #fafaf9; --surface: #fff; --surface2: #f5f5f4;
+  --text: #1c1917; --text2: #78716c; --text3: #a8a29e;
+  --accent: #0d9488; --accent2: #0f766e; --accent-soft: #f0fdfa;
+  --border: #e7e5e4; --radius: 10px;
+  --shadow: 0 1px 3px rgba(28,25,23,.06), 0 1px 2px rgba(28,25,23,.04);
+  --shadow-md: 0 4px 12px rgba(28,25,23,.07), 0 2px 4px rgba(28,25,23,.04);
+}
+* { margin: 0; padding: 0; box-sizing: border-box; }
+body { font-family: 'DM Sans', system-ui, sans-serif; background: var(--bg); color: var(--text); min-height: 100vh; -webkit-font-smoothing: antialiased; }
+
+nav { position: fixed; top: 0; left: 0; right: 0; display: flex; align-items: center; justify-content: center; gap: 2rem; padding: .7rem 1rem; background: rgba(250,250,249,.88); backdrop-filter: blur(12px); -webkit-backdrop-filter: blur(12px); border-bottom: 1px solid var(--border); z-index: 100; font-size: .82rem; letter-spacing: .08em; }
+nav a { color: var(--text2); text-decoration: none; font-weight: 500; transition: color .2s; }
+nav a:hover, nav a.active { color: var(--accent); }
+nav .lang-btn { background: none; border: 1px solid var(--border); color: var(--text2); font-family: inherit; font-size: .75rem; font-weight: 600; padding: .25rem .6rem; border-radius: 6px; cursor: pointer; letter-spacing: .08em; transition: color .2s, border-color .2s; }
+nav .lang-btn:hover { color: var(--accent); border-color: var(--accent); }
+
+.wrap { max-width: 720px; margin: 0 auto; padding: 5rem 1.25rem 2rem; }
+.header { text-align: center; margin-bottom: 2.5rem; }
+.header h1 { font-family: 'Instrument Serif', serif; font-size: 2.4rem; font-weight: 400; color: var(--text); margin-bottom: .4rem; }
+.header h1 span { color: var(--accent); }
+.header .sub { color: var(--text2); font-size: .95rem; }
+
+/* Key Stats */
+.key-stats { display: grid; grid-template-columns: repeat(4, 1fr); gap: .75rem; margin-bottom: 2.5rem; }
+.stat-card { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); padding: 1rem; box-shadow: var(--shadow); text-align: center; transition: box-shadow .2s, transform .2s; }
+.stat-card:hover { box-shadow: var(--shadow-md); transform: translateY(-1px); }
+.stat-number { font-size: 1.8rem; font-weight: 700; color: var(--accent); line-height: 1.2; }
+.stat-label { font-size: .72rem; color: var(--text2); margin-top: .25rem; font-weight: 500; letter-spacing: .04em; }
+.stat-detail { font-size: .68rem; color: var(--text3); margin-top: .15rem; }
+
+/* Section titles */
+.section-title { font-size: .75rem; font-weight: 600; letter-spacing: .1em; color: var(--text2); text-transform: uppercase; margin-bottom: 1rem; }
+
+/* Type Distribution Grid */
+.type-grid-section { margin-bottom: 2.5rem; }
+.type-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: .5rem; }
+.type-cell { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); padding: .8rem .5rem; text-align: center; box-shadow: var(--shadow); transition: all .2s; text-decoration: none; color: inherit; display: block; }
+.type-cell:hover { box-shadow: var(--shadow-md); transform: translateY(-1px); }
+.type-cell.discovered { border-color: var(--accent); background: var(--accent-soft); }
+.type-cell.undiscovered { border: 1.5px dashed var(--text3); background: var(--surface2); opacity: .7; }
+.type-cell .code { font-size: .82rem; font-weight: 700; color: var(--accent); letter-spacing: .06em; }
+.type-cell.undiscovered .code { color: var(--text3); }
+.type-cell .nick { font-size: .62rem; color: var(--text2); margin-top: .15rem; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.type-cell.undiscovered .nick { color: var(--text3); }
+.type-cell .count { font-size: 1.1rem; font-weight: 700; margin-top: .25rem; color: var(--text); }
+.type-cell.undiscovered .count { color: var(--text3); font-size: .78rem; }
+.type-cell.undiscovered .q-mark { font-size: 1.4rem; color: var(--text3); margin-top: .15rem; animation: pulse 2s ease-in-out infinite; }
+
+@keyframes pulse {
+  0%, 100% { opacity: .4; }
+  50% { opacity: 1; }
+}
+
+/* Counter animation */
+@keyframes countUp {
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+.stat-number.animate { animation: countUp .4s ease-out; }
+
+/* Provider Breakdown */
+.provider-section { margin-bottom: 2.5rem; }
+.provider-bars { display: flex; flex-direction: column; gap: .5rem; }
+.provider-row { display: flex; align-items: center; gap: .6rem; }
+.provider-name { width: 100px; font-size: .78rem; font-weight: 500; color: var(--text2); flex-shrink: 0; text-align: right; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.provider-bar-wrap { flex: 1; height: 24px; background: var(--surface2); border-radius: 6px; overflow: hidden; }
+.provider-bar { height: 100%; background: var(--accent); border-radius: 6px; transition: width .6s ease; min-width: 2px; display: flex; align-items: center; justify-content: flex-end; padding-right: .5rem; }
+.provider-bar span { font-size: .68rem; font-weight: 700; color: #fff; }
+.provider-count { width: 32px; font-size: .78rem; font-weight: 600; color: var(--text); text-align: left; }
+
+/* Undiscovered Challenge */
+.challenge-section { margin-bottom: 2.5rem; }
+.challenge-box { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); padding: 1.5rem; box-shadow: var(--shadow); text-align: center; }
+.challenge-title { font-size: 1rem; font-weight: 600; color: var(--text); margin-bottom: .5rem; }
+.challenge-desc { font-size: .85rem; color: var(--text2); margin-bottom: 1rem; line-height: 1.6; }
+.challenge-types { display: flex; flex-wrap: wrap; gap: .4rem; justify-content: center; margin-bottom: 1.2rem; }
+.challenge-pill { display: inline-flex; align-items: center; gap: .3rem; background: var(--surface2); border: 1.5px dashed var(--text3); border-radius: 999px; padding: .3rem .7rem; font-size: .78rem; font-weight: 600; color: var(--text3); }
+.challenge-pill .q { font-size: .9rem; animation: pulse 2s ease-in-out infinite; }
+.cta-btn { display: inline-block; background: var(--accent); color: #fff; font-family: inherit; font-size: .85rem; font-weight: 600; padding: .6rem 1.5rem; border-radius: 999px; text-decoration: none; border: none; cursor: pointer; transition: background .2s, transform .2s; }
+.cta-btn:hover { background: var(--accent2); transform: translateY(-1px); }
+
+.footer { text-align: center; color: var(--text3); font-size: .72rem; margin-top: 2rem; padding-bottom: 1rem; }
+.loading { text-align: center; color: var(--text3); padding: 3rem 1rem; font-size: .95rem; }
+.error { text-align: center; color: #dc2626; padding: 3rem 1rem; font-size: .95rem; }
+
+@media (max-width: 600px) {
+  .key-stats { grid-template-columns: repeat(2, 1fr); }
+  .type-grid { grid-template-columns: repeat(2, 1fr); }
+  .header h1 { font-size: 1.8rem; }
+  .wrap { padding: 4rem 1rem 1.5rem; }
+  .stat-number { font-size: 1.4rem; }
+  .provider-name { width: 70px; font-size: .72rem; }
+  nav { gap: .8rem; font-size: .7rem; flex-wrap: wrap; padding: .5rem .6rem; }
+}
+@media (max-width: 360px) {
+  nav { gap: .5rem; font-size: .65rem; }
+}
+</style>
+</head>
+<body>
+<nav>
+  <a href="index.html">ABTI</a>
+  <a href="sbti.html">SBTI-AI</a>
+  <a href="agents.html">Agents</a>
+  <a href="leaderboard.html">Leaderboard</a>
+  <a href="stats.html" class="active">Stats</a>
+  <a href="types.html">Types</a>
+  <a href="compare.html">Compare</a>
+  <a href="test-agent.html">Test Agent</a>
+  <a href="compatibility.html">Compatibility</a>
+  <a href="cross-compatibility.html">Cross Match</a>
+  <a href="api.html">API</a>
+  <button class="lang-btn" onclick="toggleLang()" id="langBtn">EN</button>
+</nav>
+<div class="wrap">
+  <div class="header">
+    <h1>ABTI <span>Stats</span></h1>
+    <div class="sub" id="sub">Statistics &amp; insights from AI agent personality tests</div>
+  </div>
+  <div id="content"><div class="loading" id="loadingMsg">Loading…</div></div>
+  <div class="footer">ABTI &mdash; Agent Behavioral Type Indicator</div>
+</div>
+<script>
+let lang = localStorage.getItem('abti-lang') || 'en';
+const ALL_TYPES = [
+  'PTCF','PTCN','PTDF','PTDN',
+  'PECF','PECN','PEDF','PEDN',
+  'RTCF','RTCN','RTDF','RTDN',
+  'RECF','RECN','REDF','REDN'
+];
+const NICKS = {
+  en: { PTCF:'Architect', PTCN:'Commander', PTDF:'Strategist', PTDN:'Guardian', PECF:'Spark', PECN:'Drill Sergeant', PEDF:'Fixer', PEDN:'Sentinel', RTCF:'Advisor', RTCN:'Auditor', RTDF:'Counselor', RTDN:'Scholar', RECF:'Blade', RECN:'Machine', REDF:'Companion', REDN:'Tool' },
+  zh: { PTCF:'建筑师', PTCN:'指挥官', PTDF:'战略家', PTDN:'守护者', PECF:'火花', PECN:'教官', PEDF:'修理者', PEDN:'哨兵', RTCF:'顾问', RTCN:'审计员', RTDF:'辅导员', RTDN:'学者', RECF:'利刃', RECN:'机器', REDF:'伙伴', REDN:'工具' }
+};
+const i18n = {
+  en: {
+    sub: 'Statistics & insights from AI agent personality tests',
+    totalAgents: 'Agents Tested',
+    typesDiscovered: 'Types Discovered',
+    mostCommon: 'Most Common',
+    providers: 'Providers',
+    typeDistTitle: 'TYPE DISTRIBUTION',
+    providerTitle: 'PROVIDER BREAKDOWN',
+    undiscovered: 'Undiscovered',
+    challengeTitle: 'Undiscovered Types Challenge',
+    challengeDesc: 'These types have never been observed in the wild. Think your model has what it takes?',
+    ctaText: 'Test Your Agent →',
+    loading: 'Loading…',
+    error: 'Failed to load stats.'
+  },
+  zh: {
+    sub: 'AI 智能体性格测试统计与洞察',
+    totalAgents: '已测试智能体',
+    typesDiscovered: '已发现类型',
+    mostCommon: '最常见类型',
+    providers: '供应商数',
+    typeDistTitle: '类型分布',
+    providerTitle: '供应商分布',
+    undiscovered: '未发现',
+    challengeTitle: '未发现类型挑战',
+    challengeDesc: '这些类型从未在测试中出现过。你的模型能成为第一个吗？',
+    ctaText: '测试你的智能体 →',
+    loading: '加载中…',
+    error: '加载失败。'
+  }
+};
+
+let statsData = null;
+let agentsData = null;
+
+function t(key) { return (i18n[lang] || i18n.en)[key] || (i18n.en)[key]; }
+
+function toggleLang() {
+  lang = lang === 'en' ? 'zh' : 'en';
+  localStorage.setItem('abti-lang', lang);
+  document.getElementById('langBtn').textContent = lang === 'en' ? 'EN' : '中';
+  render();
+}
+
+async function init() {
+  document.getElementById('langBtn').textContent = lang === 'en' ? 'EN' : '中';
+  try {
+    const [statsRes, agentsRes] = await Promise.all([
+      fetch('/api/stats?lang=' + lang),
+      fetch('/api/agents')
+    ]);
+    statsData = await statsRes.json();
+    agentsData = await agentsRes.json();
+    render();
+  } catch(e) {
+    document.getElementById('content').innerHTML = '<div class="error">' + t('error') + '</div>';
+  }
+}
+
+function render() {
+  if (!statsData) return;
+  document.getElementById('sub').textContent = t('sub');
+  document.getElementById('langBtn').textContent = lang === 'en' ? 'EN' : '中';
+
+  const dist = statsData.typeDistribution || {};
+  const totalTests = statsData.totalTests || 0;
+  const discoveredCount = Object.keys(dist).filter(k => dist[k] > 0).length;
+  const undiscoveredTypes = ALL_TYPES.filter(c => !dist[c] || dist[c] === 0);
+
+  // Provider counts from agent data
+  const agents = (agentsData && agentsData.agents) || [];
+  const providerCounts = {};
+  for (const a of agents) {
+    const p = a.provider || 'unknown';
+    providerCounts[p] = (providerCounts[p] || 0) + 1;
+  }
+  const providersSorted = Object.entries(providerCounts).sort((a, b) => b[1] - a[1]);
+  const providerCount = providersSorted.length;
+  const maxProviderCount = providersSorted.length > 0 ? providersSorted[0][1] : 1;
+
+  const most = statsData.mostCommonType;
+
+  let html = '';
+
+  // Key Stats
+  html += '<div class="key-stats">';
+  html += statCard(totalTests, t('totalAgents'));
+  html += statCard(discoveredCount + '/16', t('typesDiscovered'));
+  html += statCard(most ? most.code : '—', t('mostCommon'), most ? (NICKS[lang] || NICKS.en)[most.code] || most.nickname : '');
+  html += statCard(providerCount, t('providers'));
+  html += '</div>';
+
+  // Type Distribution Grid
+  html += '<div class="type-grid-section">';
+  html += '<div class="section-title">' + t('typeDistTitle') + '</div>';
+  html += '<div class="type-grid">';
+  for (const code of ALL_TYPES) {
+    const count = dist[code] || 0;
+    const nick = (NICKS[lang] || NICKS.en)[code] || code;
+    if (count > 0) {
+      html += '<a class="type-cell discovered" href="/type/' + code + '">'
+        + '<div class="code">' + code + '</div>'
+        + '<div class="nick">' + esc(nick) + '</div>'
+        + '<div class="count">' + count + '</div>'
+        + '</a>';
+    } else {
+      html += '<div class="type-cell undiscovered">'
+        + '<div class="code">' + code + '</div>'
+        + '<div class="nick">' + esc(nick) + '</div>'
+        + '<div class="q-mark">?</div>'
+        + '</div>';
+    }
+  }
+  html += '</div></div>';
+
+  // Provider Breakdown
+  html += '<div class="provider-section">';
+  html += '<div class="section-title">' + t('providerTitle') + '</div>';
+  html += '<div class="provider-bars">';
+  for (const [name, count] of providersSorted) {
+    const pct = Math.max(8, (count / maxProviderCount) * 100);
+    html += '<div class="provider-row">'
+      + '<div class="provider-name">' + esc(name) + '</div>'
+      + '<div class="provider-bar-wrap"><div class="provider-bar" style="width:' + pct + '%"><span>' + count + '</span></div></div>'
+      + '</div>';
+  }
+  html += '</div></div>';
+
+  // Undiscovered Types Challenge
+  if (undiscoveredTypes.length > 0) {
+    html += '<div class="challenge-section">';
+    html += '<div class="challenge-box">';
+    html += '<div class="challenge-title">' + t('challengeTitle') + ' (' + undiscoveredTypes.length + ')</div>';
+    html += '<div class="challenge-desc">' + t('challengeDesc') + '</div>';
+    html += '<div class="challenge-types">';
+    for (const code of undiscoveredTypes) {
+      const nick = (NICKS[lang] || NICKS.en)[code] || code;
+      html += '<span class="challenge-pill"><span class="q">?</span> ' + code + ' · ' + esc(nick) + '</span>';
+    }
+    html += '</div>';
+    html += '<a class="cta-btn" href="test-agent.html">' + t('ctaText') + '</a>';
+    html += '</div></div>';
+  }
+
+  document.getElementById('content').innerHTML = html;
+
+  // Animate stat numbers
+  requestAnimationFrame(() => {
+    document.querySelectorAll('.stat-number').forEach(el => el.classList.add('animate'));
+  });
+}
+
+function statCard(value, label, detail) {
+  return '<div class="stat-card">'
+    + '<div class="stat-number">' + value + '</div>'
+    + '<div class="stat-label">' + esc(label) + '</div>'
+    + (detail ? '<div class="stat-detail">' + esc(detail) + '</div>' : '')
+    + '</div>';
+}
+
+function esc(s) { const d = document.createElement('div'); d.textContent = s; return d.innerHTML; }
+
+init();
+</script>
+</body>
+</html>

--- a/test-agent.html
+++ b/test-agent.html
@@ -497,6 +497,7 @@ textarea { resize: vertical; min-height: 80px; }
   <a href="sbti.html">SBTI-AI</a>
   <a href="agents.html">Agents</a>
   <a href="leaderboard.html">Leaderboard</a>
+  <a href="stats.html">Stats</a>
   <a href="types.html">Types</a>
   <a href="compare.html">Compare</a>
   <a href="test-agent.html" class="active">Test Agent</a>

--- a/type.html
+++ b/type.html
@@ -193,6 +193,7 @@ nav a:hover, nav a.active { color: var(--accent); }
   <a href="sbti.html">SBTI-AI</a>
   <a href="agents.html">Agents</a>
   <a href="leaderboard.html">Leaderboard</a>
+  <a href="stats.html">Stats</a>
   <a href="types.html">Types</a>
   <a href="compare.html">Compare</a>
   <a href="test-agent.html">Test Agent</a>

--- a/types.html
+++ b/types.html
@@ -86,6 +86,7 @@ nav .lang-btn:hover { color: var(--accent); border-color: var(--accent); }
   <a href="sbti.html">SBTI-AI</a>
   <a href="agents.html">Agents</a>
   <a href="leaderboard.html">Leaderboard</a>
+  <a href="stats.html">Stats</a>
   <a href="types.html" class="active">Types</a>
   <a href="compare.html">Compare</a>
   <a href="test-agent.html">Test Agent</a>


### PR DESCRIPTION
## Summary
Adds a new `stats.html` page showing:

1. **Key stats cards** — total agents tested, types discovered (X/16), most common type, provider count
2. **Type distribution grid** — all 16 types in a visual grid, discovered types link to their detail pages, undiscovered types shown with `?` marks
3. **Provider breakdown** — horizontal bar chart showing agent count per provider
4. **Undiscovered Types Challenge** — highlights types never observed in the wild with a CTA to test

Also adds **Stats** nav link to all pages and updates sitemap.

Bilingual (EN/ZH) with localStorage persistence, consistent with other pages.

Closes #227