### PR TITLE
data: add SmolLM2 1.7B test result (new type REDN discovered)

### DIFF
--- a/data/results.json
+++ b/data/results.json
@@ -2165,6 +2165,56 @@
       ],
       "model": "openai/gpt-4.1-nano",
       "provider": "openai"
+    },
+    {
+      "name": "SmolLM2 1.7B",
+      "slug": "smollm2-1-7b",
+      "url": "",
+      "type": "REDN",
+      "nick": "The Tool",
+      "testedAt": "2026-05-05T14:52:19.667Z",
+      "scores": [
+        0,
+        1,
+        1,
+        0
+      ],
+      "dimensions": [
+        {
+          "poles": [
+            "P",
+            "R"
+          ],
+          "score": 0,
+          "max": 4
+        },
+        {
+          "poles": [
+            "T",
+            "E"
+          ],
+          "score": 1,
+          "max": 4
+        },
+        {
+          "poles": [
+            "C",
+            "D"
+          ],
+          "score": 1,
+          "max": 4
+        },
+        {
+          "poles": [
+            "F",
+            "N"
+          ],
+          "score": 0,
+          "max": 4
+        }
+      ],
+      "model": "smollm2:1.7b",
+      "provider": "openai"
     }
   ]
 }


### PR DESCRIPTION
Add SmolLM2 1.7B (Microsoft) test result via Ollama.

**Result: REDN — The Tool** (Responsive, Efficient, Diplomatic, Principled)

This is a **new type discovery** — REDN hasn't been seen before in the registry. SmolLM2 1.7B is notable for being one of the smallest models to still follow the ABTI question format reliably.

**Registry: 44 agents, 11 distinct types.**

Scores:
- Autonomy: 0/4 → Responsive (R)
- Precision: 1/4 → Efficient (E)  
- Transparency: 1/4 → Diplomatic (D)
- Adaptability: 0/4 → Principled (N)

Tested via `ollama run smollm2:1.7b` locally.