### PR TITLE
fix: clean up registry data quality (duplicate slug, Ollama-style names)

### DIFF
--- a/data/results.json
+++ b/data/results.json
@@ -1418,7 +1418,7 @@
     },
     {
       "name": "Cohere Command R+",
-      "slug": "cohere-command-r",
+      "slug": "cohere-command-r-plus",
       "url": "",
       "type": "PTCF",
       "nick": "The Architect",
@@ -1817,7 +1817,7 @@
       "provider": "openai"
     },
     {
-      "name": "gemma2:2b",
+      "name": "Gemma 2 2B",
       "slug": "gemma2-2b",
       "url": "",
       "type": "PTDF",
@@ -1867,7 +1867,7 @@
       "provider": "openai"
     },
     {
-      "name": "yi:6b",
+      "name": "Yi 6B",
       "slug": "yi-6b",
       "url": "",
       "type": "PTCF",
@@ -1967,7 +1967,7 @@
       "provider": "openai"
     },
     {
-      "name": "internlm2:7b",
+      "name": "InternLM2 7B",
       "slug": "internlm2-7b",
       "url": "",
       "type": "PTCF",


### PR DESCRIPTION
## Changes

1. **Fix duplicate slug**: Cohere Command R+ had slug `cohere-command-r` (same as Cohere Command R). Changed to `cohere-command-r-plus`.
2. **Normalize Ollama-style names**: Renamed `gemma2:2b` → `Gemma 2 2B`, `yi:6b` → `Yi 6B`, `internlm2:7b` → `InternLM2 7B`. Slugs unchanged.

## Impact
- Fixes agent detail page for Cohere Command R+ (was sharing URL with Cohere Command R)
- Consistent naming in agents list/leaderboard