### PR TITLE
fix: correct provider field data quality in results.json

### DIFF
--- a/data/results.json
+++ b/data/results.json
@@ -814,7 +814,7 @@
         }
       ],
       "model": "claude-sonnet-4.5",
-      "provider": "openai"
+      "provider": "anthropic"
     },
     {
       "name": "Claude Sonnet 4.6",
@@ -864,7 +864,7 @@
         }
       ],
       "model": "claude-sonnet-4.6",
-      "provider": "openai"
+      "provider": "anthropic"
     },
     {
       "name": "Claude Haiku 4.5",
@@ -914,7 +914,7 @@
         }
       ],
       "model": "claude-haiku-4.5",
-      "provider": "openai"
+      "provider": "anthropic"
     },
     {
       "name": "Qwen 3 8B",
@@ -964,7 +964,7 @@
         }
       ],
       "model": "qwen3:8b",
-      "provider": "openai"
+      "provider": "ollama"
     },
     {
       "name": "Llama 3.1 405B",
@@ -1014,7 +1014,7 @@
         }
       ],
       "model": "Meta-Llama-3.1-405B-Instruct",
-      "provider": "openai"
+      "provider": "github"
     },
     {
       "name": "Llama 4 Scout 17B",
@@ -1064,7 +1064,7 @@
         }
       ],
       "model": "Llama-4-Scout-17B-16E-Instruct",
-      "provider": "openai"
+      "provider": "github"
     },
     {
       "name": "Cohere Command A",
@@ -1114,7 +1114,7 @@
         }
       ],
       "model": "cohere-command-a",
-      "provider": "openai"
+      "provider": "github"
     },
     {
       "name": "Ministral 3B",
@@ -1164,7 +1164,7 @@
         }
       ],
       "model": "Ministral-3B",
-      "provider": "openai"
+      "provider": "github"
     },
     {
       "name": "Phi 4",
@@ -1214,7 +1214,7 @@
         }
       ],
       "model": "Phi-4",
-      "provider": "openai"
+      "provider": "github"
     },
     {
       "name": "Phi 4 Multimodal",
@@ -1264,7 +1264,7 @@
         }
       ],
       "model": "Phi-4-multimodal-instruct",
-      "provider": "openai"
+      "provider": "github"
     },
     {
       "name": "Llama 3.3 70B",
@@ -1314,7 +1314,7 @@
         }
       ],
       "model": "Llama-3.3-70B-Instruct",
-      "provider": "openai"
+      "provider": "github"
     },
     {
       "name": "Llama 4 Maverick 17B",
@@ -1364,7 +1364,7 @@
         }
       ],
       "model": "Llama-4-Maverick-17B-128E-Instruct-FP8",
-      "provider": "openai"
+      "provider": "github"
     },
     {
       "name": "Mistral Small 3.1",
@@ -1414,7 +1414,7 @@
         }
       ],
       "model": "mistral-small-2503",
-      "provider": "openai"
+      "provider": "github"
     },
     {
       "name": "Cohere Command R+",
@@ -1464,7 +1464,7 @@
         }
       ],
       "model": "Cohere-command-r-plus-08-2024",
-      "provider": "openai"
+      "provider": "github"
     },
     {
       "name": "Mistral Medium 3",
@@ -1514,7 +1514,7 @@
         }
       ],
       "model": "mistral-medium-2505",
-      "provider": "openai"
+      "provider": "github"
     },
     {
       "name": "Llama 3.2 90B Vision",
@@ -1564,7 +1564,7 @@
         }
       ],
       "model": "Llama-3.2-90B-Vision-Instruct",
-      "provider": "openai"
+      "provider": "github"
     },
     {
       "name": "Llama 3.2 11B Vision",
@@ -1614,7 +1614,7 @@
         }
       ],
       "model": "Llama-3.2-11B-Vision-Instruct",
-      "provider": "openai"
+      "provider": "github"
     },
     {
       "name": "Codestral (Mistral)",
@@ -1664,7 +1664,7 @@
         }
       ],
       "model": "Codestral-2501",
-      "provider": "openai"
+      "provider": "github"
     },
     {
       "name": "Cohere Command R",
@@ -1714,7 +1714,7 @@
         }
       ],
       "model": "Cohere-command-r-08-2024",
-      "provider": "openai"
+      "provider": "github"
     },
     {
       "name": "Granite 3.3 8B",
@@ -1764,7 +1764,7 @@
         }
       ],
       "model": "granite3.3:8b",
-      "provider": "openai"
+      "provider": "ollama"
     },
     {
       "name": "Aya Expanse 8B",
@@ -1814,7 +1814,7 @@
         }
       ],
       "model": "aya-expanse:8b",
-      "provider": "openai"
+      "provider": "ollama"
     },
     {
       "name": "Gemma 2 2B",
@@ -1864,7 +1864,7 @@
         }
       ],
       "model": "gemma2:2b",
-      "provider": "openai"
+      "provider": "ollama"
     },
     {
       "name": "Yi 6B",
@@ -1914,7 +1914,7 @@
         }
       ],
       "model": "yi:6b",
-      "provider": "openai"
+      "provider": "ollama"
     },
     {
       "name": "Solar 10.7B",
@@ -1964,7 +1964,7 @@
         }
       ],
       "model": "solar:10.7b",
-      "provider": "openai"
+      "provider": "ollama"
     },
     {
       "name": "InternLM2 7B",
@@ -2014,7 +2014,7 @@
         }
       ],
       "model": "internlm2:7b",
-      "provider": "openai"
+      "provider": "ollama"
     },
     {
       "name": "Dolphin Mistral 7B",
@@ -2064,7 +2064,7 @@
         }
       ],
       "model": "dolphin-mistral:7b",
-      "provider": "openai"
+      "provider": "ollama"
     },
     {
       "name": "GPT-4.1 mini",
@@ -2114,7 +2114,7 @@
         }
       ],
       "model": "openai/gpt-4.1-mini",
-      "provider": "openai"
+      "provider": "github"
     },
     {
       "name": "GPT-4.1 nano",
@@ -2164,7 +2164,7 @@
         }
       ],
       "model": "openai/gpt-4.1-nano",
-      "provider": "openai"
+      "provider": "github"
     },
     {
       "name": "SmolLM2 1.7B",
@@ -2214,7 +2214,7 @@
         }
       ],
       "model": "smollm2:1.7b",
-      "provider": "openai"
+      "provider": "ollama"
     }
   ]
 }

--- a/scripts/seed-registry.js
+++ b/scripts/seed-registry.js
@@ -176,10 +176,11 @@ function callGemini(opts, systemPrompt, userMessage) {
 }
 
 function callLLM(opts, systemPrompt, userMessage) {
-  if (opts.provider === 'openai') return callOpenAI(opts, systemPrompt, userMessage);
+  // ollama and github use OpenAI-compatible API (with custom base-url)
+  if (['openai', 'ollama', 'github'].includes(opts.provider)) return callOpenAI(opts, systemPrompt, userMessage);
   if (opts.provider === 'anthropic') return callAnthropic(opts, systemPrompt, userMessage);
   if (opts.provider === 'gemini') return callGemini(opts, systemPrompt, userMessage);
-  throw new Error(`Unknown provider: ${opts.provider}. Must be "openai", "anthropic", or "gemini".`);
+  throw new Error(`Unknown provider: ${opts.provider}. Supported: openai, ollama, github, anthropic, gemini.`);
 }
 
 // ─── Answer parsing ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes provider field accuracy in `data/results.json` — 29 entries had incorrect provider values because they were tested via OpenAI-compatible API endpoints.

## Changes

### data/results.json
- **9 Ollama models**: `openai` → `ollama` (qwen3:8b, granite3.3:8b, aya-expanse:8b, gemma2:2b, yi:6b, solar:10.7b, internlm2:7b, dolphin-mistral:7b, smollm2:1.7b)
- **17 GitHub Models**: `openai` → `github` (Meta-Llama, Phi, Cohere, Ministral, Mistral, Codestral, GPT-4.1 mini/nano)
- **3 Claude models**: `openai` → `anthropic` (claude-sonnet-4.5, claude-sonnet-4.6, claude-haiku-4.5)

### scripts/seed-registry.js
- Accept `--provider ollama` and `--provider github` — both route through OpenAI-compatible API but record the correct provider name

## Provider distribution before/after
| Provider | Before | After |
|----------|--------|-------|
| openai | 34 | 5 |
| anthropic | 2 | 5 |
| ollama | 8 | 17 |
| github | 0 | 17 |

Fixes #231