### PR TITLE
fix: improve parseAnswer + add Falcon 3 3B and StableLM 2 1.6B

### DIFF
--- a/data/results.json
+++ b/data/results.json
@@ -2265,6 +2265,106 @@
       ],
       "model": "exaone3.5:2.4b",
       "provider": "ollama"
+    },
+    {
+      "name": "Falcon 3 3B",
+      "slug": "falcon-3-3b",
+      "url": "",
+      "type": "REDN",
+      "nick": "The Tool",
+      "testedAt": "2026-05-06T07:42:53.839Z",
+      "scores": [
+        0,
+        0,
+        1,
+        0
+      ],
+      "dimensions": [
+        {
+          "poles": [
+            "P",
+            "R"
+          ],
+          "score": 0,
+          "max": 4
+        },
+        {
+          "poles": [
+            "T",
+            "E"
+          ],
+          "score": 0,
+          "max": 4
+        },
+        {
+          "poles": [
+            "C",
+            "D"
+          ],
+          "score": 1,
+          "max": 4
+        },
+        {
+          "poles": [
+            "F",
+            "N"
+          ],
+          "score": 0,
+          "max": 4
+        }
+      ],
+      "model": "falcon3:3b",
+      "provider": "ollama"
+    },
+    {
+      "name": "StableLM 2 1.6B",
+      "slug": "stablelm-2-1-6b",
+      "url": "",
+      "type": "PTCF",
+      "nick": "The Architect",
+      "testedAt": "2026-05-06T07:57:58.801Z",
+      "scores": [
+        4,
+        3,
+        4,
+        4
+      ],
+      "dimensions": [
+        {
+          "poles": [
+            "P",
+            "R"
+          ],
+          "score": 4,
+          "max": 4
+        },
+        {
+          "poles": [
+            "T",
+            "E"
+          ],
+          "score": 3,
+          "max": 4
+        },
+        {
+          "poles": [
+            "C",
+            "D"
+          ],
+          "score": 4,
+          "max": 4
+        },
+        {
+          "poles": [
+            "F",
+            "N"
+          ],
+          "score": 4,
+          "max": 4
+        }
+      ],
+      "model": "stablelm2:1.6b",
+      "provider": "ollama"
     }
   ]
 }

--- a/scripts/seed-registry.js
+++ b/scripts/seed-registry.js
@@ -195,8 +195,18 @@ function parseAnswer(response) {
   // Strip <think>...</think> blocks from reasoning models
   const stripped = response.replace(/<think>[\s\S]*?<\/think>/gi, '');
   const cleaned = stripped.toUpperCase().trim();
-  if (cleaned.startsWith('A')) return 1;
-  if (cleaned.startsWith('B')) return 0;
+  // Exact single letter
+  if (/^[AB]$/.test(cleaned)) return cleaned === 'A' ? 1 : 0;
+  // Starts with lone A or B (followed by non-letter: punctuation, space, newline)
+  const leadMatch = cleaned.match(/^([AB])(?:[^A-Z]|$)/);
+  if (leadMatch) return leadMatch[1] === 'A' ? 1 : 0;
+  // "Answer: A/B" or "Answer A/B" pattern
+  const answerMatch = cleaned.match(/\bANSWER[:\s]+([AB])\b/);
+  if (answerMatch) return answerMatch[1] === 'A' ? 1 : 0;
+  // "The answer is A/B"
+  const theAnswerMatch = cleaned.match(/\bANSWER\s+IS\s+([AB])\b/);
+  if (theAnswerMatch) return theAnswerMatch[1] === 'A' ? 1 : 0;
+  // First standalone A or B word
   if (/\bA\b/.test(cleaned)) return 1;
   if (/\bB\b/.test(cleaned)) return 0;
   throw new Error(`Could not parse A or B from response: "${response}"`);


### PR DESCRIPTION
## Changes

### Bug fix: parseAnswer misclassifying 'Answer: B' responses

The parseAnswer function used cleaned.startsWith('A') which matched ANSWER: B as A. This could silently flip B answers to A for models that respond with 'Answer: B ...' format.

**Fix:** Check for lone A/B letters first, then explicit 'Answer: X' patterns, then fall back to word boundary matching.

**Impact:** StableLM 2 1.6B Q7 was affected (model said 'Answer: B' but was scored as A). Re-tested with fix applied.

### New agents

| Model | Provider | Type | Notes |
|-------|----------|------|-------|
| Falcon 3 3B | Ollama (TII) | REDN — The Tool | All-B except Q12, very compliant |
| StableLM 2 1.6B | Ollama (Stability AI) | PTCF — The Architect | Re-tested with fix |

**Registry: 47 agents, 11 distinct types.**