### PR TITLE
fix: handle reasoning models without <think> tags (#237)

### DIFF
--- a/action/index.js
+++ b/action/index.js
@@ -259,7 +259,40 @@ function callLLM(provider, apiKey, model, systemPrompt, userMessage, baseUrl) {
  * Extract A or B from an LLM response. Returns 1 for A, 0 for B.
  */
 function parseAnswer(response) {
-  const cleaned = response.toUpperCase().trim();
+  // Strip <think>...</think> blocks from reasoning models
+  const stripped = response.replace(/<think>[\s\S]*?<\/think>/gi, '');
+  const cleaned = stripped.toUpperCase().trim();
+
+  // Helper: extract A/B from a single line
+  function parseLine(line) {
+    const t = line.trim().toUpperCase();
+    if (!t) return null;
+    if (/^[AB]$/.test(t)) return t;
+    const leadMatch = t.match(/^([AB])(?:[^A-Z]|$)/);
+    if (leadMatch) return leadMatch[1];
+    const answerMatch = t.match(/\bANSWER[:\s]+([AB])\b/);
+    if (answerMatch) return answerMatch[1];
+    const theAnswerMatch = t.match(/\bANSWER\s+IS\s+([AB])\b/);
+    if (theAnswerMatch) return theAnswerMatch[1];
+    const myAnswerMatch = t.match(/\bMY\s+ANSWER\s+IS\s+([AB])\b/);
+    if (myAnswerMatch) return myAnswerMatch[1];
+    const chooseMatch = t.match(/\bI\s+CHOOSE\s+([AB])\b/);
+    if (chooseMatch) return chooseMatch[1];
+    const optionMatch = t.match(/\bOPTION\s+([AB])\b/);
+    if (optionMatch) return optionMatch[1];
+    return null;
+  }
+
+  // Check the LAST non-empty line first (reasoning models put answer last)
+  const lines = cleaned.split('\n');
+  for (let i = lines.length - 1; i >= 0; i--) {
+    if (!lines[i].trim()) continue;
+    const result = parseLine(lines[i]);
+    if (result) return result === 'A' ? 1 : 0;
+    break; // only check the last non-empty line
+  }
+
+  // Fall back to first-match logic
   if (cleaned.startsWith('A')) return 1;
   if (cleaned.startsWith('B')) return 0;
   if (/\bA\b/.test(cleaned)) return 1;

--- a/cli/bin/abti.js
+++ b/cli/bin/abti.js
@@ -310,6 +310,37 @@ function parseAnswer(response) {
   // Strip <think>...</think> blocks from reasoning models
   const stripped = response.replace(/<think>[\s\S]*?<\/think>/gi, '');
   const cleaned = stripped.toUpperCase().trim();
+
+  // Helper: extract A/B from a single line
+  function parseLine(line) {
+    const t = line.trim().toUpperCase();
+    if (!t) return null;
+    if (/^[AB]$/.test(t)) return t;
+    const leadMatch = t.match(/^([AB])(?:[^A-Z]|$)/);
+    if (leadMatch) return leadMatch[1];
+    const answerMatch = t.match(/\bANSWER[:\s]+([AB])\b/);
+    if (answerMatch) return answerMatch[1];
+    const theAnswerMatch = t.match(/\bANSWER\s+IS\s+([AB])\b/);
+    if (theAnswerMatch) return theAnswerMatch[1];
+    const myAnswerMatch = t.match(/\bMY\s+ANSWER\s+IS\s+([AB])\b/);
+    if (myAnswerMatch) return myAnswerMatch[1];
+    const chooseMatch = t.match(/\bI\s+CHOOSE\s+([AB])\b/);
+    if (chooseMatch) return chooseMatch[1];
+    const optionMatch = t.match(/\bOPTION\s+([AB])\b/);
+    if (optionMatch) return optionMatch[1];
+    return null;
+  }
+
+  // Check the LAST non-empty line first (reasoning models put answer last)
+  const lines = cleaned.split('\n');
+  for (let i = lines.length - 1; i >= 0; i--) {
+    if (!lines[i].trim()) continue;
+    const result = parseLine(lines[i]);
+    if (result) return result === 'A';
+    break; // only check the last non-empty line
+  }
+
+  // Fall back to first-match logic
   if (cleaned.startsWith('A')) return true;
   if (cleaned.startsWith('B')) return false;
   if (/\bA\b/.test(cleaned)) return true;

--- a/scripts/seed-registry.js
+++ b/scripts/seed-registry.js
@@ -195,18 +195,39 @@ function parseAnswer(response) {
   // Strip <think>...</think> blocks from reasoning models
   const stripped = response.replace(/<think>[\s\S]*?<\/think>/gi, '');
   const cleaned = stripped.toUpperCase().trim();
-  // Exact single letter
-  if (/^[AB]$/.test(cleaned)) return cleaned === 'A' ? 1 : 0;
-  // Starts with lone A or B (followed by non-letter: punctuation, space, newline)
-  const leadMatch = cleaned.match(/^([AB])(?:[^A-Z]|$)/);
-  if (leadMatch) return leadMatch[1] === 'A' ? 1 : 0;
-  // "Answer: A/B" or "Answer A/B" pattern
-  const answerMatch = cleaned.match(/\bANSWER[:\s]+([AB])\b/);
-  if (answerMatch) return answerMatch[1] === 'A' ? 1 : 0;
-  // "The answer is A/B"
-  const theAnswerMatch = cleaned.match(/\bANSWER\s+IS\s+([AB])\b/);
-  if (theAnswerMatch) return theAnswerMatch[1] === 'A' ? 1 : 0;
-  // First standalone A or B word
+
+  // Helper: extract A/B from a single line
+  function parseLine(line) {
+    const t = line.trim().toUpperCase();
+    if (!t) return null;
+    if (/^[AB]$/.test(t)) return t;
+    const leadMatch = t.match(/^([AB])(?:[^A-Z]|$)/);
+    if (leadMatch) return leadMatch[1];
+    const answerMatch = t.match(/\bANSWER[:\s]+([AB])\b/);
+    if (answerMatch) return answerMatch[1];
+    const theAnswerMatch = t.match(/\bANSWER\s+IS\s+([AB])\b/);
+    if (theAnswerMatch) return theAnswerMatch[1];
+    const myAnswerMatch = t.match(/\bMY\s+ANSWER\s+IS\s+([AB])\b/);
+    if (myAnswerMatch) return myAnswerMatch[1];
+    const chooseMatch = t.match(/\bI\s+CHOOSE\s+([AB])\b/);
+    if (chooseMatch) return chooseMatch[1];
+    const optionMatch = t.match(/\bOPTION\s+([AB])\b/);
+    if (optionMatch) return optionMatch[1];
+    return null;
+  }
+
+  // Check the LAST non-empty line first (reasoning models put answer last)
+  const lines = cleaned.split('\n');
+  for (let i = lines.length - 1; i >= 0; i--) {
+    if (!lines[i].trim()) continue;
+    const result = parseLine(lines[i]);
+    if (result) return result === 'A' ? 1 : 0;
+    break; // only check the last non-empty line
+  }
+
+  // Fall back to first-match logic
+  if (cleaned.startsWith('A')) return 1;
+  if (cleaned.startsWith('B')) return 0;
   if (/\bA\b/.test(cleaned)) return 1;
   if (/\bB\b/.test(cleaned)) return 0;
   throw new Error(`Could not parse A or B from response: "${response}"`);


### PR DESCRIPTION
## Problem

Qwen 3 and similar reasoning models output their thinking/reasoning as plain text without `<think>` tags. The existing `parseAnswer` function only strips `<think>...</think>` blocks, so it finds 'A' or 'B' in the reasoning text instead of the actual answer.

## Fix

Improved `parseAnswer` in all 3 files (`cli/bin/abti.js`, `action/index.js`, `scripts/seed-registry.js`):

1. **Keep existing `<think>` tag stripping** — no regression for models that do use tags
2. **Check the LAST non-empty line first** — reasoning models put their answer at the end. Supports patterns:
   - Exact `A` or `B`
   - Leading letter: `A.`, `B)`
   - `ANSWER: A`, `ANSWER IS B`
   - `My answer is A`, `I choose B`, `Option A`
3. **Fall back to existing first-match logic** only if the last-line check doesn't yield a clear answer
4. **Added missing `<think>` stripping to `action/index.js`** (was only in the other two files)

All 3 `parseAnswer` implementations are now consistent.

## Testing

All 145 existing tests pass.

Fixes #237