### PR TITLE
fix: improve parseAnswer for reasoning models without <think> tags

### DIFF
--- a/cli/bin/abti.js
+++ b/cli/bin/abti.js
@@ -266,10 +266,10 @@ async function llmRequest(options, payload) {
   }
 }
 
-function callOpenAI(apiKey, mdl, systemPrompt, userMessage, baseUrl) {
+function callOpenAI(apiKey, mdl, systemPrompt, userMessage, baseUrl, options) {
   const parsed = baseUrl ? new URL(baseUrl.replace(/\/+$/, '') + '/v1/chat/completions') : new URL('https://api.openai.com/v1/chat/completions');
   const maxTok = isReasoningModel(mdl) ? 2048 : 4;
-  const payload = JSON.stringify({ model: mdl, messages: [{ role: 'system', content: systemPrompt }, { role: 'user', content: userMessage }], max_tokens: maxTok, temperature: 0 });
+  const payload = JSON.stringify({ model: mdl, messages: [{ role: 'system', content: systemPrompt }, { role: 'user', content: userMessage }], max_tokens: maxTok, temperature: 0, ...options });
   return llmRequest({ hostname: parsed.hostname, port: parsed.port, path: parsed.pathname + parsed.search, method: 'POST', protocol: parsed.protocol, headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${apiKey}`, 'Content-Length': Buffer.byteLength(payload) } }, payload)
     .then(json => {
       const msg = json.choices[0].message;
@@ -296,7 +296,7 @@ function callLLM(prov, apiKey, mdl, systemPrompt, userMessage, baseUrl) {
   if (prov === 'anthropic') return callAnthropic(apiKey, mdl, systemPrompt, userMessage, baseUrl);
   if (prov === 'gemini') return callGemini(apiKey, mdl, systemPrompt, userMessage);
   if (prov === 'deepseek') return callOpenAI(apiKey, mdl, systemPrompt, userMessage, 'https://api.deepseek.com');
-  if (prov === 'ollama') return callOpenAI(apiKey || 'ollama', mdl, systemPrompt, userMessage, 'http://localhost:11434');
+  if (prov === 'ollama') return callOpenAI(apiKey || 'ollama', mdl, systemPrompt, userMessage, 'http://localhost:11434', isReasoningModel(mdl) ? { think: false } : undefined);
   throw new Error(`Unknown provider: ${prov}. Must be "openai", "anthropic", "gemini", "deepseek", or "ollama".`);
 }
 
@@ -310,6 +310,22 @@ function parseAnswer(response) {
   // Strip <think>...</think> blocks from reasoning models
   const stripped = response.replace(/<think>[\s\S]*?<\/think>/gi, '');
   const cleaned = stripped.toUpperCase().trim();
+
+  // Check the last non-empty line for a standalone A or B (optionally with punctuation)
+  const lines = cleaned.split('\n').map(l => l.trim()).filter(l => l.length > 0);
+  if (lines.length > 0) {
+    const lastLine = lines[lines.length - 1];
+    if (/^A[.\s]*$/.test(lastLine)) return true;
+    if (/^B[.\s]*$/.test(lastLine)) return false;
+  }
+
+  // Check last few lines for "Answer: A/B" or "The answer is A/B" patterns
+  const tail = lines.slice(-3).join('\n');
+  const answerPattern = /\b(?:ANSWER\s*[:=]\s*|(?:THE|MY)\s+ANSWER\s+IS\s+)([AB])\b/;
+  const answerMatch = tail.match(answerPattern);
+  if (answerMatch) return answerMatch[1] === 'A';
+
+  // Fall back to original logic
   if (cleaned.startsWith('A')) return true;
   if (cleaned.startsWith('B')) return false;
   if (/\bA\b/.test(cleaned)) return true;
@@ -614,3 +630,8 @@ async function runInteractive() {
 }
 
 run().catch(err => { console.error(err.message); process.exit(1); });
+
+// Export for testing
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { parseAnswer };
+}

--- a/test/parseAnswer.test.js
+++ b/test/parseAnswer.test.js
@@ -1,0 +1,49 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+const { parseAnswer } = require('../cli/bin/abti.js');
+
+describe('parseAnswer', () => {
+  it('should return false (B) when reasoning text mentions A but last line is B', () => {
+    const response = 'Okay, the user is asking me to choose between A or B...\n\nB';
+    assert.strictEqual(parseAnswer(response), false);
+  });
+
+  it('should return true (A) when reasoning mentions B but last line is A', () => {
+    const response = 'Let me think. Option A seems good but B better.\n\nA';
+    assert.strictEqual(parseAnswer(response), true);
+  });
+
+  it('should return false (B) with <think> tags', () => {
+    const response = '<think>reasoning</think>\nB';
+    assert.strictEqual(parseAnswer(response), false);
+  });
+
+  it('should return true (A) for standalone A', () => {
+    assert.strictEqual(parseAnswer('A'), true);
+  });
+
+  it('should return false (B) for standalone B', () => {
+    assert.strictEqual(parseAnswer('B'), false);
+  });
+
+  it('should return false (B) for "ANSWER: B"', () => {
+    assert.strictEqual(parseAnswer('ANSWER: B'), false);
+  });
+
+  it('should return true (A) for "The answer is A."', () => {
+    assert.strictEqual(parseAnswer('The answer is A.'), true);
+  });
+
+  it('should return true (A) for "A." with punctuation', () => {
+    assert.strictEqual(parseAnswer('A.'), true);
+  });
+
+  it('should return false (B) for "My answer is B"', () => {
+    assert.strictEqual(parseAnswer('My answer is B'), false);
+  });
+
+  it('should handle long reasoning with answer at end', () => {
+    const response = 'I need to carefully consider both options.\nOption A has merit because of X.\nHowever, option B is better because of Y.\nAfter weighing both sides, I think A is correct.\n\nB';
+    assert.strictEqual(parseAnswer(response), false);
+  });
+});


### PR DESCRIPTION
## Changes

- Parse answer from the **last line** of response instead of first, handling reasoning models that output thinking without `<think>` tags
- Support `Answer: X` and `The/My answer is X` patterns in last few lines
- Disable thinking for Ollama reasoning models via `think: false` option
- Add `parseAnswer` test suite (10 tests)

## Problem

Qwen 3 reasoning models output their thinking as plain text content without `<think>` tags. The parser would find `\bA\b` in reasoning text (e.g. 'between A or B') instead of the actual answer.

## Testing

```
node test/parseAnswer.test.js
```

Fixes #237