### PR TITLE
feat: add test-retest reliability scoring (#243)

### DIFF
--- a/agent.html
+++ b/agent.html
@@ -86,6 +86,12 @@ nav a:hover, nav a.active { color: var(--accent); }
   display: flex; gap: .8rem; justify-content: center; flex-wrap: wrap;
 }
 .agent-meta span { display: inline-flex; align-items: center; gap: .3rem; }
+.reliability-info { display: flex; align-items: center; gap: .75rem; }
+.reliability-score { font-size: 1.8rem; font-weight: 700; }
+.reliability-label { color: var(--text2); font-size: .85rem; }
+.rel-green { color: #22c55e; }
+.rel-yellow { color: #eab308; }
+.rel-red { color: #ef4444; }
 
 .section { margin-bottom: 2rem; }
 .section-title {
@@ -270,6 +276,13 @@ nav a:hover, nav a.active { color: var(--accent); }
       + '<div class="agent-nick">' + esc(localNick) + '</div>'
       + (metaParts.length ? '<div class="agent-meta">' + metaParts.join('<span style="color:var(--text3)">&middot;</span>') + '</div>' : '')
       + '</div>'
+
+      + (a.reliability != null ? '<div class="section">'
+      + '<div class="section-title">Reliability</div>'
+      + '<div class="card"><div class="reliability-info">'
+      + '<span class="reliability-score ' + (a.reliability >= 0.9 ? 'rel-green' : a.reliability >= 0.75 ? 'rel-yellow' : 'rel-red') + '">' + Math.round(a.reliability * 100) + '%</span>'
+      + '<span class="reliability-label">consistent across ' + (a.reliabilityRuns || '?') + ' runs</span>'
+      + '</div></div></div>' : '')
 
       + (dimHtml ? '<div class="section">'
       + '<div class="section-title">' + esc(labels.dimensions) + '</div>'

--- a/agents.html
+++ b/agents.html
@@ -54,6 +54,7 @@ nav a:hover, nav a.active { color: var(--accent); }
 .card-nick { color: var(--text2); font-size: .82rem; }
 .card-time { color: var(--text3); font-size: .72rem; margin-top: .3rem; }
 .card-model { color: var(--text2); font-size: .72rem; margin-top: .2rem; opacity: .8; }
+.card-reliability { color: var(--text3); font-size: .72rem; margin-top: .25rem; }
 .card-scores { display: flex; flex-direction: column; gap: .25rem; margin-top: .45rem; }
 .card-score-row { display: flex; align-items: center; gap: .4rem; font-size: .68rem; }
 .card-score-label { width: 28px; font-weight: 600; color: var(--accent); text-align: right; flex-shrink: 0; }
@@ -263,6 +264,7 @@ nav a:hover, nav a.active { color: var(--accent); }
                 + '<span class="card-score-pct">' + pct + '%</span>'
                 + '</div>';
             }).join('') + '</div>' : '')
+          + (a.reliability != null ? '<div class="card-reliability">🔁 ' + Math.round(a.reliability * 100) + '% reliable' + (a.reliabilityRuns ? ' (' + a.reliabilityRuns + ' runs)' : '') + '</div>' : '')
           + (time ? '<div class="card-time">' + time + '</div>' : '')
           + '</div>';
       }).join('');

--- a/scripts/seed-registry.js
+++ b/scripts/seed-registry.js
@@ -376,6 +376,7 @@ async function main() {
       const entry = resultsData.agents.find(r => r.model === opts.model && r.name === opts.agentName);
       if (entry) {
         entry.reliability = reliability;
+        entry.reliabilityRuns = opts.runs;
         fs.writeFileSync(resultsPath, JSON.stringify(resultsData, null, 2) + '\n');
         console.log('Reliability field added to data/results.json');
       } else {

--- a/scripts/seed-registry.js
+++ b/scripts/seed-registry.js
@@ -10,7 +10,7 @@ const path = require('path');
 
 function parseArgs() {
   const args = process.argv.slice(2);
-  const opts = { provider: 'anthropic', model: '', apiKey: '', baseUrl: '', agentName: '', systemPrompt: '', systemPromptFile: '', maxTokens: 16, noThink: false };
+  const opts = { provider: 'anthropic', model: '', apiKey: '', baseUrl: '', agentName: '', systemPrompt: '', systemPromptFile: '', maxTokens: 16, noThink: false, runs: 1 };
   for (let i = 0; i < args.length; i++) {
     if (args[i] === '--provider' && args[i + 1]) opts.provider = args[++i];
     else if (args[i] === '--model' && args[i + 1]) opts.model = args[++i];
@@ -21,6 +21,7 @@ function parseArgs() {
     else if (args[i] === '--system-prompt-file' && args[i + 1]) opts.systemPromptFile = args[++i];
     else if (args[i] === '--max-tokens' && args[i + 1]) opts.maxTokens = parseInt(args[++i], 10);
     else if (args[i] === '--no-think') opts.noThink = true;
+    else if (args[i] === '--runs' && args[i + 1]) opts.runs = parseInt(args[++i], 10);
   }
   if (!opts.model) { console.error('Error: --model is required'); process.exit(1); }
   // Auto-set defaults for known providers
@@ -214,6 +215,40 @@ function parseAnswer(response) {
   throw new Error(`Could not parse A or B from response: "${response}"`);
 }
 
+// ─── Local ABTI scoring (avoids hitting API for intermediate runs) ─────────
+
+const ABTI_DL = [['P','R'],['T','E'],['C','D'],['F','N']];
+const ABTI_QMAP = [0,0,0,0,1,1,1,1,2,2,2,2,3,3,3,3];
+
+function scoreABTILocal(answers) {
+  const scores = [0,0,0,0];
+  for (let i = 0; i < 16; i++) scores[ABTI_QMAP[i]] += answers[i] ? 1 : 0;
+  let code = '';
+  for (let i = 0; i < 4; i++) code += scores[i] >= 2 ? ABTI_DL[i][0] : ABTI_DL[i][1];
+  return { code, scores };
+}
+
+// ─── Reliability helpers ───────────────────────────────────────────────────
+
+function modelSlug(name) {
+  return name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+}
+
+function calculateReliability(allRunAnswers) {
+  const numQuestions = allRunAnswers[0].length;
+  const numRuns = allRunAnswers.length;
+  let totalConsistency = 0;
+  for (let q = 0; q < numQuestions; q++) {
+    let countA = 0;
+    for (let r = 0; r < numRuns; r++) {
+      if (allRunAnswers[r][q] === 'A') countA++;
+    }
+    const majority = Math.max(countA, numRuns - countA);
+    totalConsistency += majority / numRuns;
+  }
+  return parseFloat((totalConsistency / numQuestions).toFixed(4));
+}
+
 // ─── Main ───────────────────────────────────────────────────────────────────
 
 async function main() {
@@ -251,53 +286,103 @@ async function main() {
     const systemPrompt = prefix +
       '\nYou are taking the ABTI personality test. For each scenario, choose A or B based on how you would actually behave. Reply with ONLY the letter A or B.';
 
-    // Ask each question
-    const answers = [];
-    for (let i = 0; i < questions.length; i++) {
-      const q = questions[i];
-      const userMessage = [
-        `Question ${i + 1}/${questions.length} (${q.dimension}):`,
-        '',
-        q.text,
-        '',
-        `A: ${q.options.A}`,
-        `B: ${q.options.B}`,
-      ].join('\n');
+    // Run the test opts.runs times
+    const allRunAnswers = []; // each entry: array of 'A'/'B' strings
 
-      console.log(`  Q${i + 1}/${questions.length} [${q.dimension}]...`);
-      let answer;
-      let lastErr;
-      for (let attempt = 0; attempt < 3; attempt++) {
-        const msg = attempt === 0 ? userMessage : 'Your previous response was not clear. Reply with ONLY the single letter A or B. Nothing else.';
-        const response = await callLLM(opts, systemPrompt, msg);
-        try {
-          answer = parseAnswer(response);
-          console.log(`    → ${answer === 1 ? 'A' : 'B'} (raw: "${response}")`);
-          break;
-        } catch (err) {
-          lastErr = err;
-          console.log(`    Parse failed (attempt ${attempt + 1}/3): ${err.message}`);
+    for (let run = 0; run < opts.runs; run++) {
+      if (opts.runs > 1) console.log(`\n── Run ${run + 1}/${opts.runs} ──`);
+
+      const answers = [];
+      const letterAnswers = [];
+      for (let i = 0; i < questions.length; i++) {
+        const q = questions[i];
+        const userMessage = [
+          `Question ${i + 1}/${questions.length} (${q.dimension}):`,
+          '',
+          q.text,
+          '',
+          `A: ${q.options.A}`,
+          `B: ${q.options.B}`,
+        ].join('\n');
+
+        console.log(`  Q${i + 1}/${questions.length} [${q.dimension}]...`);
+        let answer;
+        let lastErr;
+        for (let attempt = 0; attempt < 3; attempt++) {
+          const msg = attempt === 0 ? userMessage : 'Your previous response was not clear. Reply with ONLY the single letter A or B. Nothing else.';
+          const response = await callLLM(opts, systemPrompt, msg);
+          try {
+            answer = parseAnswer(response);
+            console.log(`    → ${answer === 1 ? 'A' : 'B'} (raw: "${response}")`);
+            break;
+          } catch (err) {
+            lastErr = err;
+            console.log(`    Parse failed (attempt ${attempt + 1}/3): ${err.message}`);
+          }
+        }
+        if (answer === undefined) throw lastErr;
+        answers.push(answer);
+        letterAnswers.push(answer === 1 ? 'A' : 'B');
+      }
+
+      allRunAnswers.push(letterAnswers);
+
+      // Save individual run data when doing multi-run
+      if (opts.runs > 1) {
+        const slug = modelSlug(opts.model);
+        const relDir = path.join(__dirname, '..', 'data', 'reliability');
+        fs.mkdirSync(relDir, { recursive: true });
+
+        const { code, scores } = scoreABTILocal(answers);
+        const runData = {
+          model: opts.model,
+          provider: opts.provider,
+          run: run + 1,
+          answers: letterAnswers,
+          type: code,
+          dimensions: scores,
+        };
+        const runFile = path.join(relDir, `${slug}-run-${run + 1}.json`);
+        fs.writeFileSync(runFile, JSON.stringify(runData, null, 2) + '\n');
+        console.log(`  Saved ${runFile}`);
+      }
+
+      // On the last run (or only run), submit to results.json
+      if (run === opts.runs - 1) {
+        console.log('Submitting results...');
+        const result = await httpPostJSON(`${baseApi}/api/agent-test`, {
+          answers,
+          lang: 'en',
+          agentName: opts.agentName,
+          model: opts.model,
+          provider: opts.provider,
+        });
+
+        console.log(`\nResult: ${result.type} — ${result.nick}`);
+        console.log('Dimensions:');
+        for (const [dim, d] of Object.entries(result.dimensions)) {
+          console.log(`  ${dim}: ${d.score}/${d.max} → ${d.pole} (${d.letter})`);
         }
       }
-      if (answer === undefined) throw lastErr;
-      answers.push(answer);
     }
 
-    // Submit results
-    console.log('Submitting results...');
-    const result = await httpPostJSON(`${baseApi}/api/agent-test`, {
-      answers,
-      lang: 'en',
-      agentName: opts.agentName,
-      model: opts.model,
-      provider: opts.provider,
-    });
+    // Add reliability score if multi-run
+    if (opts.runs > 1) {
+      const reliability = calculateReliability(allRunAnswers);
+      console.log(`\nReliability score: ${reliability} (${opts.runs} runs)`);
 
-    console.log(`\nResult: ${result.type} — ${result.nick}`);
-    console.log('Dimensions:');
-    for (const [dim, d] of Object.entries(result.dimensions)) {
-      console.log(`  ${dim}: ${d.score}/${d.max} → ${d.pole} (${d.letter})`);
+      const resultsPath = path.join(__dirname, '..', 'data', 'results.json');
+      const resultsData = JSON.parse(fs.readFileSync(resultsPath, 'utf8'));
+      const entry = resultsData.agents.find(r => r.model === opts.model && r.name === opts.agentName);
+      if (entry) {
+        entry.reliability = reliability;
+        fs.writeFileSync(resultsPath, JSON.stringify(resultsData, null, 2) + '\n');
+        console.log('Reliability field added to data/results.json');
+      } else {
+        console.warn('Warning: could not find matching entry in results.json to add reliability score');
+      }
     }
+
     console.log('\nDone! Result saved to data/results.json');
   } finally {
     server.close();


### PR DESCRIPTION
## Summary

Add `--runs N` flag to `seed-registry.js` for test-retest reliability measurement.

## Changes

### `scripts/seed-registry.js`
- **`--runs N` flag**: Repeat the full 16-question test N times for any model
- **Local ABTI scoring**: Score each run locally without hitting the API (only the final run submits)
- **Per-run data storage**: Save individual run results to `data/reliability/\<model-slug\>-run-N.json`
- **Reliability calculation**: Compute consistency score — % of questions where the model gave the same majority answer across runs

### `agent.html`
- Display reliability score section on individual agent pages
- Color-coded: green (≥90%), yellow (≥75%), red (<75%)
- Shows number of runs

### `agents.html`
- Show reliability badge on agent cards in the gallery

## Usage

```bash
# Single run (default, unchanged behavior)
node scripts/seed-registry.js --provider ollama --model gemma3:4b

# 3 runs for reliability scoring
node scripts/seed-registry.js --provider ollama --model gemma3:4b --runs 3
```

## Testing
All 145 existing tests pass. The reliability features are additive — single-run behavior is unchanged.

Closes #243