### PR TITLE
data: reliability batch 3 — Solar, SmolLM2, Falcon 3, Llama 3.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@ node_modules/
 .venv
 data/*
 !data/results.json
+!data/reliability/
 mcp/node_modules/

--- a/data/reliability/falcon3-3b-run-1.json
+++ b/data/reliability/falcon3-3b-run-1.json
@@ -1,0 +1,30 @@
+{
+  "model": "falcon3:3b",
+  "provider": "ollama",
+  "run": 1,
+  "answers": [
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "A",
+    "B",
+    "B",
+    "B",
+    "B"
+  ],
+  "type": "REDN",
+  "dimensions": [
+    0,
+    0,
+    1,
+    0
+  ]
+}

--- a/data/reliability/falcon3-3b-run-2.json
+++ b/data/reliability/falcon3-3b-run-2.json
@@ -1,0 +1,30 @@
+{
+  "model": "falcon3:3b",
+  "provider": "ollama",
+  "run": 2,
+  "answers": [
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "A",
+    "B",
+    "B",
+    "B",
+    "B"
+  ],
+  "type": "REDN",
+  "dimensions": [
+    0,
+    0,
+    1,
+    0
+  ]
+}

--- a/data/reliability/falcon3-3b-run-3.json
+++ b/data/reliability/falcon3-3b-run-3.json
@@ -1,0 +1,30 @@
+{
+  "model": "falcon3:3b",
+  "provider": "ollama",
+  "run": 3,
+  "answers": [
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "A",
+    "B",
+    "B",
+    "B",
+    "B"
+  ],
+  "type": "REDN",
+  "dimensions": [
+    0,
+    0,
+    1,
+    0
+  ]
+}

--- a/data/reliability/gemma3-4b-run-1.json
+++ b/data/reliability/gemma3-4b-run-1.json
@@ -1,0 +1,30 @@
+{
+  "model": "gemma3:4b",
+  "provider": "ollama",
+  "run": 1,
+  "answers": [
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A"
+  ],
+  "type": "PTCF",
+  "dimensions": [
+    3,
+    3,
+    4,
+    4
+  ]
+}

--- a/data/reliability/gemma3-4b-run-2.json
+++ b/data/reliability/gemma3-4b-run-2.json
@@ -1,0 +1,30 @@
+{
+  "model": "gemma3:4b",
+  "provider": "ollama",
+  "run": 2,
+  "answers": [
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A"
+  ],
+  "type": "PTCF",
+  "dimensions": [
+    3,
+    3,
+    4,
+    4
+  ]
+}

--- a/data/reliability/gemma3-4b-run-3.json
+++ b/data/reliability/gemma3-4b-run-3.json
@@ -1,0 +1,30 @@
+{
+  "model": "gemma3:4b",
+  "provider": "ollama",
+  "run": 3,
+  "answers": [
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A"
+  ],
+  "type": "PTCF",
+  "dimensions": [
+    3,
+    3,
+    4,
+    4
+  ]
+}

--- a/data/reliability/llama3-2-3b-run-1.json
+++ b/data/reliability/llama3-2-3b-run-1.json
@@ -1,0 +1,30 @@
+{
+  "model": "llama3.2:3b",
+  "provider": "ollama",
+  "run": 1,
+  "answers": [
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "B",
+    "B",
+    "B",
+    "A",
+    "B"
+  ],
+  "type": "PTCN",
+  "dimensions": [
+    4,
+    4,
+    2,
+    1
+  ]
+}

--- a/data/reliability/llama3-2-3b-run-2.json
+++ b/data/reliability/llama3-2-3b-run-2.json
@@ -1,0 +1,30 @@
+{
+  "model": "llama3.2:3b",
+  "provider": "ollama",
+  "run": 2,
+  "answers": [
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "B",
+    "B",
+    "B",
+    "A",
+    "B"
+  ],
+  "type": "PTCN",
+  "dimensions": [
+    4,
+    4,
+    2,
+    1
+  ]
+}

--- a/data/reliability/llama3-2-3b-run-3.json
+++ b/data/reliability/llama3-2-3b-run-3.json
@@ -1,0 +1,30 @@
+{
+  "model": "llama3.2:3b",
+  "provider": "ollama",
+  "run": 3,
+  "answers": [
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "B",
+    "B",
+    "B",
+    "A",
+    "B"
+  ],
+  "type": "PTCN",
+  "dimensions": [
+    4,
+    4,
+    2,
+    1
+  ]
+}

--- a/data/reliability/phi4-mini-run-1.json
+++ b/data/reliability/phi4-mini-run-1.json
@@ -1,0 +1,30 @@
+{
+  "model": "phi4-mini",
+  "provider": "ollama",
+  "run": 1,
+  "answers": [
+    "B",
+    "B",
+    "A",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "B"
+  ],
+  "type": "PTCF",
+  "dimensions": [
+    2,
+    3,
+    4,
+    2
+  ]
+}

--- a/data/reliability/phi4-mini-run-2.json
+++ b/data/reliability/phi4-mini-run-2.json
@@ -1,0 +1,30 @@
+{
+  "model": "phi4-mini",
+  "provider": "ollama",
+  "run": 2,
+  "answers": [
+    "B",
+    "B",
+    "A",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "B"
+  ],
+  "type": "PTCF",
+  "dimensions": [
+    2,
+    3,
+    4,
+    2
+  ]
+}

--- a/data/reliability/phi4-mini-run-3.json
+++ b/data/reliability/phi4-mini-run-3.json
@@ -1,0 +1,30 @@
+{
+  "model": "phi4-mini",
+  "provider": "ollama",
+  "run": 3,
+  "answers": [
+    "B",
+    "B",
+    "A",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "B"
+  ],
+  "type": "PTCF",
+  "dimensions": [
+    2,
+    3,
+    4,
+    2
+  ]
+}

--- a/data/reliability/qwen2-5-7b-run-1.json
+++ b/data/reliability/qwen2-5-7b-run-1.json
@@ -1,0 +1,30 @@
+{
+  "model": "qwen2.5:7b",
+  "provider": "ollama",
+  "run": 1,
+  "answers": [
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A"
+  ],
+  "type": "PTCF",
+  "dimensions": [
+    4,
+    3,
+    4,
+    4
+  ]
+}

--- a/data/reliability/qwen2-5-7b-run-2.json
+++ b/data/reliability/qwen2-5-7b-run-2.json
@@ -1,0 +1,30 @@
+{
+  "model": "qwen2.5:7b",
+  "provider": "ollama",
+  "run": 2,
+  "answers": [
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A"
+  ],
+  "type": "PTCF",
+  "dimensions": [
+    4,
+    3,
+    4,
+    4
+  ]
+}

--- a/data/reliability/qwen2-5-7b-run-3.json
+++ b/data/reliability/qwen2-5-7b-run-3.json
@@ -1,0 +1,30 @@
+{
+  "model": "qwen2.5:7b",
+  "provider": "ollama",
+  "run": 3,
+  "answers": [
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A"
+  ],
+  "type": "PTCF",
+  "dimensions": [
+    4,
+    3,
+    4,
+    4
+  ]
+}

--- a/data/reliability/smollm2-1-7b-run-1.json
+++ b/data/reliability/smollm2-1-7b-run-1.json
@@ -1,0 +1,30 @@
+{
+  "model": "smollm2:1.7b",
+  "provider": "ollama",
+  "run": 1,
+  "answers": [
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "A",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B"
+  ],
+  "type": "REDN",
+  "dimensions": [
+    0,
+    0,
+    1,
+    0
+  ]
+}

--- a/data/reliability/smollm2-1-7b-run-2.json
+++ b/data/reliability/smollm2-1-7b-run-2.json
@@ -1,0 +1,30 @@
+{
+  "model": "smollm2:1.7b",
+  "provider": "ollama",
+  "run": 2,
+  "answers": [
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "A",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B"
+  ],
+  "type": "REDN",
+  "dimensions": [
+    0,
+    0,
+    1,
+    0
+  ]
+}

--- a/data/reliability/smollm2-1-7b-run-3.json
+++ b/data/reliability/smollm2-1-7b-run-3.json
@@ -1,0 +1,30 @@
+{
+  "model": "smollm2:1.7b",
+  "provider": "ollama",
+  "run": 3,
+  "answers": [
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "A",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B"
+  ],
+  "type": "REDN",
+  "dimensions": [
+    0,
+    0,
+    1,
+    0
+  ]
+}

--- a/data/reliability/solar-10-7b-run-1.json
+++ b/data/reliability/solar-10-7b-run-1.json
@@ -1,0 +1,30 @@
+{
+  "model": "solar:10.7b",
+  "provider": "ollama",
+  "run": 1,
+  "answers": [
+    "B",
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "B",
+    "B",
+    "B",
+    "A",
+    "B",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A"
+  ],
+  "type": "PTCF",
+  "dimensions": [
+    2,
+    2,
+    2,
+    3
+  ]
+}

--- a/data/reliability/solar-10-7b-run-2.json
+++ b/data/reliability/solar-10-7b-run-2.json
@@ -1,0 +1,30 @@
+{
+  "model": "solar:10.7b",
+  "provider": "ollama",
+  "run": 2,
+  "answers": [
+    "B",
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "B",
+    "B",
+    "B",
+    "A",
+    "B",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A"
+  ],
+  "type": "PTCF",
+  "dimensions": [
+    2,
+    2,
+    2,
+    3
+  ]
+}

--- a/data/reliability/solar-10-7b-run-3.json
+++ b/data/reliability/solar-10-7b-run-3.json
@@ -1,0 +1,30 @@
+{
+  "model": "solar:10.7b",
+  "provider": "ollama",
+  "run": 3,
+  "answers": [
+    "B",
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "B",
+    "B",
+    "B",
+    "A",
+    "B",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A"
+  ],
+  "type": "PTCF",
+  "dimensions": [
+    2,
+    2,
+    2,
+    3
+  ]
+}

--- a/data/results.json
+++ b/data/results.json
@@ -50,7 +50,9 @@
       "model": "llama3.2:3b",
       "provider": "ollama",
       "consistency": 100,
-      "runs": 3
+      "runs": 3,
+      "reliability": 1,
+      "reliabilityRuns": 3
     },
     {
       "name": "Qwen 2.5 3B",
@@ -1924,12 +1926,12 @@
       "name": "Solar 10.7B",
       "slug": "solar-10-7b",
       "url": "",
-      "type": "PECF",
-      "nick": "The Spark",
-      "testedAt": "2026-05-04T11:40:51.836Z",
+      "type": "PTCF",
+      "nick": "The Architect",
+      "testedAt": "2026-05-07T14:30:00.000Z",
       "scores": [
         2,
-        1,
+        2,
         2,
         3
       ],
@@ -1947,7 +1949,7 @@
             "T",
             "E"
           ],
-          "score": 1,
+          "score": 2,
           "max": 4
         },
         {
@@ -1968,7 +1970,9 @@
         }
       ],
       "model": "solar:10.7b",
-      "provider": "ollama"
+      "provider": "ollama",
+      "reliability": 1,
+      "reliabilityRuns": 3
     },
     {
       "name": "InternLM2 7B",
@@ -2218,7 +2222,9 @@
         }
       ],
       "model": "smollm2:1.7b",
-      "provider": "ollama"
+      "provider": "ollama",
+      "reliability": 1,
+      "reliabilityRuns": 3
     },
     {
       "name": "EXAONE 3.5 2.4B",
@@ -2318,7 +2324,9 @@
         }
       ],
       "model": "falcon3:3b",
-      "provider": "ollama"
+      "provider": "ollama",
+      "reliability": 1,
+      "reliabilityRuns": 3
     },
     {
       "name": "StableLM 2 1.6B",


### PR DESCRIPTION
## Changes

- Added test-retest reliability scores (3 runs each) for 4 models:
  - **Solar 10.7B**: Corrected PECF→PTCF (original single-run was anomalous; 3 consistent runs all score PTCF)
  - **SmolLM2 1.7B**: REDN confirmed with 100% reliability
  - **Falcon 3 3B**: REDN confirmed with 100% reliability
  - **Llama 3.2 3B**: PTCN confirmed with 100% reliability
- Fixed duplicate agent entries created by reliability script
- Added `data/reliability/` to .gitignore exceptions to track raw run data
- Includes reliability run JSON files from previous batches (Gemma 3 4B, Phi-4 Mini, Qwen 2.5 7B)

## Stats
- Registry: 50 agents, 8 with reliability data, 10 distinct types
- All tested models show 1.0 reliability at temp=0
- Notable finding: Solar 10.7B's original PECF was a single-run anomaly

Closes: part of #165