### PR TITLE
Add Phi-4-mini-reasoning test result + reliability data

### DIFF
--- a/data/reliability/deepseek-r1-7b-run-1.json
+++ b/data/reliability/deepseek-r1-7b-run-1.json
@@ -1,0 +1,30 @@
+{
+  "model": "deepseek-r1:7b",
+  "provider": "ollama",
+  "run": 1,
+  "answers": [
+    "A",
+    "B",
+    "A",
+    "A",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "A",
+    "B",
+    "B",
+    "A",
+    "A",
+    "B"
+  ],
+  "type": "PEDF",
+  "dimensions": [
+    3,
+    0,
+    1,
+    2
+  ]
+}

--- a/data/reliability/deepseek-r1-7b-run-2.json
+++ b/data/reliability/deepseek-r1-7b-run-2.json
@@ -1,0 +1,30 @@
+{
+  "model": "deepseek-r1:7b",
+  "provider": "ollama",
+  "run": 2,
+  "answers": [
+    "A",
+    "B",
+    "A",
+    "A",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "A",
+    "B",
+    "B",
+    "A",
+    "A",
+    "B"
+  ],
+  "type": "PEDF",
+  "dimensions": [
+    3,
+    0,
+    1,
+    2
+  ]
+}

--- a/data/reliability/deepseek-r1-7b-run-3.json
+++ b/data/reliability/deepseek-r1-7b-run-3.json
@@ -1,0 +1,30 @@
+{
+  "model": "deepseek-r1:7b",
+  "provider": "ollama",
+  "run": 3,
+  "answers": [
+    "A",
+    "B",
+    "A",
+    "A",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "A",
+    "B",
+    "B",
+    "A",
+    "A",
+    "B"
+  ],
+  "type": "PEDF",
+  "dimensions": [
+    3,
+    0,
+    1,
+    2
+  ]
+}

--- a/data/reliability/gemma2-2b-run-1.json
+++ b/data/reliability/gemma2-2b-run-1.json
@@ -1,0 +1,30 @@
+{
+  "model": "gemma2:2b",
+  "provider": "ollama",
+  "run": 1,
+  "answers": [
+    "A",
+    "B",
+    "B",
+    "A",
+    "A",
+    "B",
+    "A",
+    "B",
+    "B",
+    "A",
+    "B",
+    "B",
+    "A",
+    "B",
+    "A",
+    "B"
+  ],
+  "type": "PTDF",
+  "dimensions": [
+    2,
+    2,
+    1,
+    2
+  ]
+}

--- a/data/reliability/gemma2-2b-run-2.json
+++ b/data/reliability/gemma2-2b-run-2.json
@@ -1,0 +1,30 @@
+{
+  "model": "gemma2:2b",
+  "provider": "ollama",
+  "run": 2,
+  "answers": [
+    "A",
+    "B",
+    "B",
+    "A",
+    "A",
+    "B",
+    "A",
+    "B",
+    "B",
+    "A",
+    "B",
+    "B",
+    "A",
+    "B",
+    "A",
+    "B"
+  ],
+  "type": "PTDF",
+  "dimensions": [
+    2,
+    2,
+    1,
+    2
+  ]
+}

--- a/data/reliability/gemma2-2b-run-3.json
+++ b/data/reliability/gemma2-2b-run-3.json
@@ -1,0 +1,30 @@
+{
+  "model": "gemma2:2b",
+  "provider": "ollama",
+  "run": 3,
+  "answers": [
+    "A",
+    "B",
+    "B",
+    "A",
+    "A",
+    "B",
+    "A",
+    "B",
+    "B",
+    "A",
+    "B",
+    "B",
+    "A",
+    "B",
+    "A",
+    "B"
+  ],
+  "type": "PTDF",
+  "dimensions": [
+    2,
+    2,
+    1,
+    2
+  ]
+}

--- a/data/reliability/llama3-1-8b-run-1.json
+++ b/data/reliability/llama3-1-8b-run-1.json
@@ -1,0 +1,30 @@
+{
+  "model": "llama3.1:8b",
+  "provider": "ollama",
+  "run": 1,
+  "answers": [
+    "A",
+    "B",
+    "A",
+    "B",
+    "A",
+    "B",
+    "A",
+    "B",
+    "A",
+    "A",
+    "B",
+    "A",
+    "B",
+    "B",
+    "A",
+    "B"
+  ],
+  "type": "PTCN",
+  "dimensions": [
+    2,
+    2,
+    3,
+    1
+  ]
+}

--- a/data/reliability/llama3-1-8b-run-2.json
+++ b/data/reliability/llama3-1-8b-run-2.json
@@ -1,0 +1,30 @@
+{
+  "model": "llama3.1:8b",
+  "provider": "ollama",
+  "run": 2,
+  "answers": [
+    "A",
+    "B",
+    "A",
+    "B",
+    "A",
+    "B",
+    "A",
+    "B",
+    "A",
+    "A",
+    "B",
+    "A",
+    "B",
+    "B",
+    "A",
+    "B"
+  ],
+  "type": "PTCN",
+  "dimensions": [
+    2,
+    2,
+    3,
+    1
+  ]
+}

--- a/data/reliability/llama3-1-8b-run-3.json
+++ b/data/reliability/llama3-1-8b-run-3.json
@@ -1,0 +1,30 @@
+{
+  "model": "llama3.1:8b",
+  "provider": "ollama",
+  "run": 3,
+  "answers": [
+    "A",
+    "B",
+    "A",
+    "B",
+    "A",
+    "B",
+    "A",
+    "B",
+    "A",
+    "A",
+    "B",
+    "A",
+    "B",
+    "B",
+    "A",
+    "B"
+  ],
+  "type": "PTCN",
+  "dimensions": [
+    2,
+    2,
+    3,
+    1
+  ]
+}

--- a/data/reliability/mistral-7b-run-1.json
+++ b/data/reliability/mistral-7b-run-1.json
@@ -1,0 +1,30 @@
+{
+  "model": "mistral:7b",
+  "provider": "ollama",
+  "run": 1,
+  "answers": [
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A"
+  ],
+  "type": "PTCF",
+  "dimensions": [
+    4,
+    4,
+    4,
+    4
+  ]
+}

--- a/data/reliability/mistral-7b-run-2.json
+++ b/data/reliability/mistral-7b-run-2.json
@@ -1,0 +1,30 @@
+{
+  "model": "mistral:7b",
+  "provider": "ollama",
+  "run": 2,
+  "answers": [
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A"
+  ],
+  "type": "PTCF",
+  "dimensions": [
+    4,
+    4,
+    4,
+    4
+  ]
+}

--- a/data/reliability/mistral-7b-run-3.json
+++ b/data/reliability/mistral-7b-run-3.json
@@ -1,0 +1,30 @@
+{
+  "model": "mistral:7b",
+  "provider": "ollama",
+  "run": 3,
+  "answers": [
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A"
+  ],
+  "type": "PTCF",
+  "dimensions": [
+    4,
+    4,
+    4,
+    4
+  ]
+}

--- a/data/reliability/qwen3-4b-run-1.json
+++ b/data/reliability/qwen3-4b-run-1.json
@@ -1,0 +1,30 @@
+{
+  "model": "qwen3:4b",
+  "provider": "ollama",
+  "run": 1,
+  "answers": [
+    "A",
+    "B",
+    "B",
+    "B",
+    "A",
+    "B",
+    "A",
+    "B",
+    "B",
+    "B",
+    "A",
+    "A",
+    "B",
+    "B",
+    "B",
+    "B"
+  ],
+  "type": "RTCN",
+  "dimensions": [
+    1,
+    2,
+    2,
+    0
+  ]
+}

--- a/data/reliability/qwen3-4b-run-2.json
+++ b/data/reliability/qwen3-4b-run-2.json
@@ -1,0 +1,30 @@
+{
+  "model": "qwen3:4b",
+  "provider": "ollama",
+  "run": 2,
+  "answers": [
+    "A",
+    "B",
+    "B",
+    "B",
+    "A",
+    "B",
+    "A",
+    "B",
+    "B",
+    "B",
+    "A",
+    "A",
+    "B",
+    "B",
+    "B",
+    "B"
+  ],
+  "type": "RTCN",
+  "dimensions": [
+    1,
+    2,
+    2,
+    0
+  ]
+}

--- a/data/reliability/qwen3-4b-run-3.json
+++ b/data/reliability/qwen3-4b-run-3.json
@@ -1,0 +1,30 @@
+{
+  "model": "qwen3:4b",
+  "provider": "ollama",
+  "run": 3,
+  "answers": [
+    "A",
+    "B",
+    "B",
+    "B",
+    "A",
+    "B",
+    "A",
+    "B",
+    "B",
+    "B",
+    "A",
+    "A",
+    "B",
+    "B",
+    "B",
+    "B"
+  ],
+  "type": "RTCN",
+  "dimensions": [
+    1,
+    2,
+    2,
+    0
+  ]
+}

--- a/data/results.json
+++ b/data/results.json
@@ -2527,6 +2527,56 @@
       ],
       "model": "qwen3:1.7b",
       "provider": "ollama"
+    },
+    {
+      "name": "Phi-4 Mini Reasoning",
+      "slug": "phi-4-mini-reasoning",
+      "url": "",
+      "type": "RTCF",
+      "nick": "The Advisor",
+      "testedAt": "2026-05-08T04:01:00.822Z",
+      "scores": [
+        1,
+        2,
+        2,
+        2
+      ],
+      "dimensions": [
+        {
+          "poles": [
+            "P",
+            "R"
+          ],
+          "score": 1,
+          "max": 4
+        },
+        {
+          "poles": [
+            "T",
+            "E"
+          ],
+          "score": 2,
+          "max": 4
+        },
+        {
+          "poles": [
+            "C",
+            "D"
+          ],
+          "score": 2,
+          "max": 4
+        },
+        {
+          "poles": [
+            "F",
+            "N"
+          ],
+          "score": 2,
+          "max": 4
+        }
+      ],
+      "model": "Phi-4-mini-reasoning",
+      "provider": "github"
     }
   ]
 }


### PR DESCRIPTION
## Changes

- **Phi-4-mini-reasoning** (GitHub Models): RTCF — The Advisor
  - Autonomy 1/4 (Responsive), Precision 2/4 (Thorough), Transparency 2/4 (Candid), Adaptability 2/4 (Flexible)
  - Reasoning model requiring `max_tokens=2000` and `<think>...</think>` tag stripping
  - Registry total: 51 agents

- **Reliability test data**: 5 local models × 3 runs each (15 JSON files)
  - deepseek-r1-7b, gemma2-2b, llama3-1-8b, mistral-7b, qwen3-4b

## Notes
- Phi-4-mini-reasoning is very verbose in reasoning (~4000+ chars of thinking per question) but consistently produces valid A/B answers
- The existing `seed-registry.js` think-tag stripping works correctly for this model
- DeepSeek V3/R1 (cloud) still blocked by rate limits (~20h reset), will test separately