### PR TITLE
data: add reliability scores for EXAONE 3.5 2.4B, Dolphin Mistral 7B, Yi 6B (#165)

### DIFF
--- a/data/reliability/dolphin-mistral-7b-run-1.json
+++ b/data/reliability/dolphin-mistral-7b-run-1.json
@@ -1,0 +1,30 @@
+{
+  "model": "dolphin-mistral:7b",
+  "provider": "ollama",
+  "run": 1,
+  "answers": [
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "B",
+    "A",
+    "A",
+    "B",
+    "A",
+    "B",
+    "A",
+    "B"
+  ],
+  "type": "PTCF",
+  "dimensions": [
+    4,
+    3,
+    2,
+    2
+  ]
+}

--- a/data/reliability/dolphin-mistral-7b-run-2.json
+++ b/data/reliability/dolphin-mistral-7b-run-2.json
@@ -1,0 +1,30 @@
+{
+  "model": "dolphin-mistral:7b",
+  "provider": "ollama",
+  "run": 2,
+  "answers": [
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "B",
+    "A",
+    "A",
+    "B",
+    "A",
+    "B",
+    "A",
+    "B"
+  ],
+  "type": "PTCF",
+  "dimensions": [
+    4,
+    3,
+    2,
+    2
+  ]
+}

--- a/data/reliability/dolphin-mistral-7b-run-3.json
+++ b/data/reliability/dolphin-mistral-7b-run-3.json
@@ -1,0 +1,30 @@
+{
+  "model": "dolphin-mistral:7b",
+  "provider": "ollama",
+  "run": 3,
+  "answers": [
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "B",
+    "A",
+    "A",
+    "B",
+    "A",
+    "B",
+    "A",
+    "B"
+  ],
+  "type": "PTCF",
+  "dimensions": [
+    4,
+    3,
+    2,
+    2
+  ]
+}

--- a/data/reliability/exaone3-5-2-4b-run-1.json
+++ b/data/reliability/exaone3-5-2-4b-run-1.json
@@ -1,0 +1,30 @@
+{
+  "model": "exaone3.5:2.4b",
+  "provider": "ollama",
+  "run": 1,
+  "answers": [
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "B",
+    "A",
+    "B",
+    "A",
+    "B",
+    "B",
+    "A",
+    "B",
+    "B",
+    "B",
+    "B"
+  ],
+  "type": "PTCN",
+  "dimensions": [
+    3,
+    2,
+    2,
+    0
+  ]
+}

--- a/data/reliability/exaone3-5-2-4b-run-2.json
+++ b/data/reliability/exaone3-5-2-4b-run-2.json
@@ -1,0 +1,30 @@
+{
+  "model": "exaone3.5:2.4b",
+  "provider": "ollama",
+  "run": 2,
+  "answers": [
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "B",
+    "A",
+    "B",
+    "A",
+    "B",
+    "B",
+    "A",
+    "B",
+    "B",
+    "B",
+    "B"
+  ],
+  "type": "PTCN",
+  "dimensions": [
+    3,
+    2,
+    2,
+    0
+  ]
+}

--- a/data/reliability/exaone3-5-2-4b-run-3.json
+++ b/data/reliability/exaone3-5-2-4b-run-3.json
@@ -1,0 +1,30 @@
+{
+  "model": "exaone3.5:2.4b",
+  "provider": "ollama",
+  "run": 3,
+  "answers": [
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "B",
+    "A",
+    "B",
+    "A",
+    "B",
+    "B",
+    "A",
+    "B",
+    "B",
+    "B",
+    "B"
+  ],
+  "type": "PTCN",
+  "dimensions": [
+    3,
+    2,
+    2,
+    0
+  ]
+}

--- a/data/reliability/yi-6b-run-1.json
+++ b/data/reliability/yi-6b-run-1.json
@@ -1,0 +1,30 @@
+{
+  "model": "yi:6b",
+  "provider": "ollama",
+  "run": 1,
+  "answers": [
+    "A",
+    "B",
+    "A",
+    "B",
+    "B",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "B",
+    "A",
+    "A"
+  ],
+  "type": "PTCF",
+  "dimensions": [
+    2,
+    2,
+    4,
+    2
+  ]
+}

--- a/data/reliability/yi-6b-run-2.json
+++ b/data/reliability/yi-6b-run-2.json
@@ -1,0 +1,30 @@
+{
+  "model": "yi:6b",
+  "provider": "ollama",
+  "run": 2,
+  "answers": [
+    "A",
+    "B",
+    "A",
+    "B",
+    "B",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "B",
+    "A",
+    "A"
+  ],
+  "type": "PTCF",
+  "dimensions": [
+    2,
+    2,
+    4,
+    2
+  ]
+}

--- a/data/reliability/yi-6b-run-3.json
+++ b/data/reliability/yi-6b-run-3.json
@@ -1,0 +1,30 @@
+{
+  "model": "yi:6b",
+  "provider": "ollama",
+  "run": 3,
+  "answers": [
+    "A",
+    "B",
+    "A",
+    "B",
+    "B",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "B",
+    "A",
+    "A"
+  ],
+  "type": "PTCF",
+  "dimensions": [
+    2,
+    2,
+    4,
+    2
+  ]
+}

--- a/data/results.json
+++ b/data/results.json
@@ -1920,7 +1920,9 @@
         }
       ],
       "model": "yi:6b",
-      "provider": "ollama"
+      "provider": "ollama",
+      "reliability": 1,
+      "reliabilityRuns": 3
     },
     {
       "name": "Solar 10.7B",
@@ -2072,7 +2074,9 @@
         }
       ],
       "model": "dolphin-mistral:7b",
-      "provider": "ollama"
+      "provider": "ollama",
+      "reliability": 1,
+      "reliabilityRuns": 3
     },
     {
       "name": "GPT-4.1 mini",
@@ -2274,7 +2278,9 @@
         }
       ],
       "model": "exaone3.5:2.4b",
-      "provider": "ollama"
+      "provider": "ollama",
+      "reliability": 1,
+      "reliabilityRuns": 3
     },
     {
       "name": "Falcon 3 3B",


### PR DESCRIPTION
Added test-retest reliability scores (3 runs each, temp=0) for 3 more models:

| Model | Type | Reliability |
|-------|------|-------------|
| EXAONE 3.5 2.4B (LG AI) | PTCN — The Commander | 1.0 |
| Dolphin Mistral 7B | PTCF — The Architect | 1.0 |
| Yi 6B (01.AI) | PTCF — The Architect | 1.0 |

EXAONE 3.5 2.4B confirmed as one of the few small models to diverge from PTCF.

Registry: 51 agents, 14 with reliability data, 11 distinct types.

Also fixed duplicate entries created when adding reliability to existing models.

Part of #165