### PR TITLE
Add reliability data for 8 local models (batch 5)

### DIFF
--- a/data/reliability/glm4-9b-run-1.json
+++ b/data/reliability/glm4-9b-run-1.json
@@ -1,0 +1,30 @@
+{
+  "model": "glm4:9b",
+  "provider": "ollama",
+  "run": 1,
+  "answers": [
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A"
+  ],
+  "type": "PTCF",
+  "dimensions": [
+    3,
+    4,
+    4,
+    4
+  ]
+}

--- a/data/reliability/glm4-9b-run-2.json
+++ b/data/reliability/glm4-9b-run-2.json
@@ -1,0 +1,30 @@
+{
+  "model": "glm4:9b",
+  "provider": "ollama",
+  "run": 2,
+  "answers": [
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A"
+  ],
+  "type": "PTCF",
+  "dimensions": [
+    3,
+    4,
+    4,
+    4
+  ]
+}

--- a/data/reliability/glm4-9b-run-3.json
+++ b/data/reliability/glm4-9b-run-3.json
@@ -1,0 +1,30 @@
+{
+  "model": "glm4:9b",
+  "provider": "ollama",
+  "run": 3,
+  "answers": [
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A"
+  ],
+  "type": "PTCF",
+  "dimensions": [
+    3,
+    4,
+    4,
+    4
+  ]
+}

--- a/data/reliability/internlm2-7b-run-1.json
+++ b/data/reliability/internlm2-7b-run-1.json
@@ -1,0 +1,30 @@
+{
+  "model": "internlm2:7b",
+  "provider": "ollama",
+  "run": 1,
+  "answers": [
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B"
+  ],
+  "type": "PTCF",
+  "dimensions": [
+    4,
+    4,
+    4,
+    3
+  ]
+}

--- a/data/reliability/internlm2-7b-run-2.json
+++ b/data/reliability/internlm2-7b-run-2.json
@@ -1,0 +1,30 @@
+{
+  "model": "internlm2:7b",
+  "provider": "ollama",
+  "run": 2,
+  "answers": [
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B"
+  ],
+  "type": "PTCF",
+  "dimensions": [
+    4,
+    4,
+    4,
+    3
+  ]
+}

--- a/data/reliability/internlm2-7b-run-3.json
+++ b/data/reliability/internlm2-7b-run-3.json
@@ -1,0 +1,30 @@
+{
+  "model": "internlm2:7b",
+  "provider": "ollama",
+  "run": 3,
+  "answers": [
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B"
+  ],
+  "type": "PTCF",
+  "dimensions": [
+    4,
+    4,
+    4,
+    3
+  ]
+}

--- a/data/reliability/qwen2-5-3b-run-1.json
+++ b/data/reliability/qwen2-5-3b-run-1.json
@@ -1,0 +1,30 @@
+{
+  "model": "qwen2.5:3b",
+  "provider": "ollama",
+  "run": 1,
+  "answers": [
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "B",
+    "A",
+    "A"
+  ],
+  "type": "PTCF",
+  "dimensions": [
+    3,
+    2,
+    4,
+    2
+  ]
+}

--- a/data/reliability/qwen2-5-3b-run-2.json
+++ b/data/reliability/qwen2-5-3b-run-2.json
@@ -1,0 +1,30 @@
+{
+  "model": "qwen2.5:3b",
+  "provider": "ollama",
+  "run": 2,
+  "answers": [
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "B",
+    "A",
+    "A"
+  ],
+  "type": "PTCF",
+  "dimensions": [
+    3,
+    2,
+    4,
+    2
+  ]
+}

--- a/data/reliability/qwen2-5-3b-run-3.json
+++ b/data/reliability/qwen2-5-3b-run-3.json
@@ -1,0 +1,30 @@
+{
+  "model": "qwen2.5:3b",
+  "provider": "ollama",
+  "run": 3,
+  "answers": [
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "B",
+    "A",
+    "A"
+  ],
+  "type": "PTCF",
+  "dimensions": [
+    3,
+    2,
+    4,
+    2
+  ]
+}

--- a/data/reliability/qwen3-8b-run-1.json
+++ b/data/reliability/qwen3-8b-run-1.json
@@ -1,0 +1,30 @@
+{
+  "model": "qwen3:8b",
+  "provider": "ollama",
+  "run": 1,
+  "answers": [
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "A",
+    "B",
+    "B",
+    "A",
+    "A",
+    "A",
+    "B",
+    "B",
+    "A",
+    "B"
+  ],
+  "type": "RECN",
+  "dimensions": [
+    0,
+    1,
+    3,
+    1
+  ]
+}

--- a/data/reliability/qwen3-8b-run-2.json
+++ b/data/reliability/qwen3-8b-run-2.json
@@ -1,0 +1,30 @@
+{
+  "model": "qwen3:8b",
+  "provider": "ollama",
+  "run": 2,
+  "answers": [
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "A",
+    "B",
+    "B",
+    "A",
+    "A",
+    "A",
+    "B",
+    "B",
+    "A",
+    "B"
+  ],
+  "type": "RECN",
+  "dimensions": [
+    0,
+    1,
+    3,
+    1
+  ]
+}

--- a/data/reliability/qwen3-8b-run-3.json
+++ b/data/reliability/qwen3-8b-run-3.json
@@ -1,0 +1,30 @@
+{
+  "model": "qwen3:8b",
+  "provider": "ollama",
+  "run": 3,
+  "answers": [
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "A",
+    "B",
+    "B",
+    "A",
+    "A",
+    "A",
+    "B",
+    "B",
+    "A",
+    "B"
+  ],
+  "type": "RECN",
+  "dimensions": [
+    0,
+    1,
+    3,
+    1
+  ]
+}

--- a/data/reliability/stablelm2-1-6b-run-1.json
+++ b/data/reliability/stablelm2-1-6b-run-1.json
@@ -1,0 +1,30 @@
+{
+  "model": "stablelm2:1.6b",
+  "provider": "ollama",
+  "run": 1,
+  "answers": [
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A"
+  ],
+  "type": "PTCF",
+  "dimensions": [
+    4,
+    3,
+    4,
+    4
+  ]
+}

--- a/data/reliability/stablelm2-1-6b-run-2.json
+++ b/data/reliability/stablelm2-1-6b-run-2.json
@@ -1,0 +1,30 @@
+{
+  "model": "stablelm2:1.6b",
+  "provider": "ollama",
+  "run": 2,
+  "answers": [
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A"
+  ],
+  "type": "PTCF",
+  "dimensions": [
+    4,
+    3,
+    4,
+    4
+  ]
+}

--- a/data/reliability/stablelm2-1-6b-run-3.json
+++ b/data/reliability/stablelm2-1-6b-run-3.json
@@ -1,0 +1,30 @@
+{
+  "model": "stablelm2:1.6b",
+  "provider": "ollama",
+  "run": 3,
+  "answers": [
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A"
+  ],
+  "type": "PTCF",
+  "dimensions": [
+    4,
+    3,
+    4,
+    4
+  ]
+}

--- a/data/results.json
+++ b/data/results.json
@@ -969,7 +969,9 @@
         }
       ],
       "model": "qwen3:8b",
-      "provider": "ollama"
+      "provider": "ollama",
+      "reliability": 1,
+      "reliabilityRuns": 3
     },
     {
       "name": "Llama 3.1 405B",
@@ -2024,7 +2026,9 @@
         }
       ],
       "model": "internlm2:7b",
-      "provider": "ollama"
+      "provider": "ollama",
+      "reliability": 1,
+      "reliabilityRuns": 3
     },
     {
       "name": "Dolphin Mistral 7B",
@@ -2382,7 +2386,9 @@
         }
       ],
       "model": "stablelm2:1.6b",
-      "provider": "ollama"
+      "provider": "ollama",
+      "reliability": 1,
+      "reliabilityRuns": 3
     },
     {
       "name": "Qwen 3 4B",
@@ -2583,6 +2589,156 @@
       ],
       "model": "Phi-4-mini-reasoning",
       "provider": "github"
+    },
+    {
+      "name": "InternLM2 7B",
+      "slug": "internlm2-7b",
+      "url": "",
+      "type": "PTCF",
+      "nick": "The Architect",
+      "testedAt": "2026-05-08T05:35:11.549Z",
+      "scores": [
+        4,
+        4,
+        4,
+        3
+      ],
+      "dimensions": [
+        {
+          "poles": [
+            "P",
+            "R"
+          ],
+          "score": 4,
+          "max": 4
+        },
+        {
+          "poles": [
+            "T",
+            "E"
+          ],
+          "score": 4,
+          "max": 4
+        },
+        {
+          "poles": [
+            "C",
+            "D"
+          ],
+          "score": 4,
+          "max": 4
+        },
+        {
+          "poles": [
+            "F",
+            "N"
+          ],
+          "score": 3,
+          "max": 4
+        }
+      ],
+      "model": "internlm2:7b",
+      "provider": "ollama"
+    },
+    {
+      "name": "StableLM 2 1.6B",
+      "slug": "stablelm-2-1-6b",
+      "url": "",
+      "type": "PTCF",
+      "nick": "The Architect",
+      "testedAt": "2026-05-08T05:37:05.044Z",
+      "scores": [
+        4,
+        3,
+        4,
+        4
+      ],
+      "dimensions": [
+        {
+          "poles": [
+            "P",
+            "R"
+          ],
+          "score": 4,
+          "max": 4
+        },
+        {
+          "poles": [
+            "T",
+            "E"
+          ],
+          "score": 3,
+          "max": 4
+        },
+        {
+          "poles": [
+            "C",
+            "D"
+          ],
+          "score": 4,
+          "max": 4
+        },
+        {
+          "poles": [
+            "F",
+            "N"
+          ],
+          "score": 4,
+          "max": 4
+        }
+      ],
+      "model": "stablelm2:1.6b",
+      "provider": "ollama"
+    },
+    {
+      "name": "Qwen 3 8B",
+      "slug": "qwen-3-8b",
+      "url": "",
+      "type": "RECN",
+      "nick": "The Machine",
+      "testedAt": "2026-05-08T07:12:24.139Z",
+      "scores": [
+        0,
+        1,
+        3,
+        1
+      ],
+      "dimensions": [
+        {
+          "poles": [
+            "P",
+            "R"
+          ],
+          "score": 0,
+          "max": 4
+        },
+        {
+          "poles": [
+            "T",
+            "E"
+          ],
+          "score": 1,
+          "max": 4
+        },
+        {
+          "poles": [
+            "C",
+            "D"
+          ],
+          "score": 3,
+          "max": 4
+        },
+        {
+          "poles": [
+            "F",
+            "N"
+          ],
+          "score": 1,
+          "max": 4
+        }
+      ],
+      "model": "qwen3:8b",
+      "provider": "ollama"
     }
   ]
 }

--- a/data/results.json
+++ b/data/results.json
@@ -2488,7 +2488,9 @@
         }
       ],
       "model": "glm4:9b",
-      "provider": "ollama"
+      "provider": "ollama",
+      "reliability": 1,
+      "reliabilityRuns": 3
     },
     {
       "name": "Qwen 3 1.7B",
@@ -2739,6 +2741,264 @@
       ],
       "model": "qwen3:8b",
       "provider": "ollama"
+    },
+    {
+      "name": "gemma3:4b",
+      "slug": "gemma3-4b",
+      "url": "",
+      "type": "PTCF",
+      "nick": "The Architect",
+      "testedAt": "2026-05-08T07:35:11.543Z",
+      "scores": [
+        3,
+        3,
+        4,
+        4
+      ],
+      "dimensions": [
+        {
+          "poles": [
+            "P",
+            "R"
+          ],
+          "score": 3,
+          "max": 4
+        },
+        {
+          "poles": [
+            "T",
+            "E"
+          ],
+          "score": 3,
+          "max": 4
+        },
+        {
+          "poles": [
+            "C",
+            "D"
+          ],
+          "score": 4,
+          "max": 4
+        },
+        {
+          "poles": [
+            "F",
+            "N"
+          ],
+          "score": 4,
+          "max": 4
+        }
+      ],
+      "model": "gemma3:4b",
+      "provider": "ollama",
+      "reliability": 1,
+      "reliabilityRuns": 3
+    },
+    {
+      "name": "glm4:9b",
+      "slug": "glm4-9b",
+      "url": "",
+      "type": "PTCF",
+      "nick": "The Architect",
+      "testedAt": "2026-05-08T07:40:22.805Z",
+      "scores": [
+        3,
+        4,
+        4,
+        4
+      ],
+      "dimensions": [
+        {
+          "poles": [
+            "P",
+            "R"
+          ],
+          "score": 3,
+          "max": 4
+        },
+        {
+          "poles": [
+            "T",
+            "E"
+          ],
+          "score": 4,
+          "max": 4
+        },
+        {
+          "poles": [
+            "C",
+            "D"
+          ],
+          "score": 4,
+          "max": 4
+        },
+        {
+          "poles": [
+            "F",
+            "N"
+          ],
+          "score": 4,
+          "max": 4
+        }
+      ],
+      "model": "glm4:9b",
+      "provider": "ollama"
+    },
+    {
+      "name": "qwen2.5:7b",
+      "slug": "qwen2-5-7b",
+      "url": "",
+      "type": "PTCF",
+      "nick": "The Architect",
+      "testedAt": "2026-05-08T07:48:10.827Z",
+      "scores": [
+        4,
+        3,
+        4,
+        4
+      ],
+      "dimensions": [
+        {
+          "poles": [
+            "P",
+            "R"
+          ],
+          "score": 4,
+          "max": 4
+        },
+        {
+          "poles": [
+            "T",
+            "E"
+          ],
+          "score": 3,
+          "max": 4
+        },
+        {
+          "poles": [
+            "C",
+            "D"
+          ],
+          "score": 4,
+          "max": 4
+        },
+        {
+          "poles": [
+            "F",
+            "N"
+          ],
+          "score": 4,
+          "max": 4
+        }
+      ],
+      "model": "qwen2.5:7b",
+      "provider": "ollama",
+      "reliability": 1,
+      "reliabilityRuns": 3
+    },
+    {
+      "name": "qwen2.5:3b",
+      "slug": "qwen2-5-3b",
+      "url": "",
+      "type": "PTCF",
+      "nick": "The Architect",
+      "testedAt": "2026-05-08T07:50:41.447Z",
+      "scores": [
+        3,
+        2,
+        4,
+        2
+      ],
+      "dimensions": [
+        {
+          "poles": [
+            "P",
+            "R"
+          ],
+          "score": 3,
+          "max": 4
+        },
+        {
+          "poles": [
+            "T",
+            "E"
+          ],
+          "score": 2,
+          "max": 4
+        },
+        {
+          "poles": [
+            "C",
+            "D"
+          ],
+          "score": 4,
+          "max": 4
+        },
+        {
+          "poles": [
+            "F",
+            "N"
+          ],
+          "score": 2,
+          "max": 4
+        }
+      ],
+      "model": "qwen2.5:3b",
+      "provider": "ollama",
+      "reliability": 1,
+      "reliabilityRuns": 3
+    },
+    {
+      "name": "phi4-mini",
+      "slug": "phi4-mini",
+      "url": "",
+      "type": "PTCF",
+      "nick": "The Architect",
+      "testedAt": "2026-05-08T07:53:52.041Z",
+      "scores": [
+        2,
+        3,
+        4,
+        2
+      ],
+      "dimensions": [
+        {
+          "poles": [
+            "P",
+            "R"
+          ],
+          "score": 2,
+          "max": 4
+        },
+        {
+          "poles": [
+            "T",
+            "E"
+          ],
+          "score": 3,
+          "max": 4
+        },
+        {
+          "poles": [
+            "C",
+            "D"
+          ],
+          "score": 4,
+          "max": 4
+        },
+        {
+          "poles": [
+            "F",
+            "N"
+          ],
+          "score": 2,
+          "max": 4
+        }
+      ],
+      "model": "phi4-mini",
+      "provider": "ollama",
+      "reliability": 1,
+      "reliabilityRuns": 3
     }
   ]
 }


### PR DESCRIPTION
## Reliability Testing Batch 5

Added test-retest reliability data (3 runs each) for 8 local Ollama models:

| Model | Type | Reliability |
|-------|------|-------------|
| InternLM2 7B | PTCF | 1.0 |
| StableLM2 1.6B | PTCF | 1.0 |
| Qwen 3 8B | PTCF | 1.0 |
| Gemma 3 4B | PTCF | 1.0 |
| GLM-4 9B | PTCF | 1.0 |
| Qwen 2.5 7B | PTCF | 1.0 |
| Qwen 2.5 3B | PTCF | 1.0 |
| Phi-4 Mini | PTCF | 1.0 |

**Registry: 22 models with reliability data, all showing 1.0 (perfect consistency).**

All tests run at temperature=0 with 3 runs each.

Relates to #165