### PR TITLE
data: add gemma3:12b (RECF) and tinyllama test results

### DIFF
--- a/data/reliability/gemma3-12b-run-1.json
+++ b/data/reliability/gemma3-12b-run-1.json
@@ -1,0 +1,30 @@
+{
+  "model": "gemma3:12b",
+  "provider": "ollama",
+  "run": 1,
+  "answers": [
+    "B",
+    "A",
+    "B",
+    "B",
+    "A",
+    "B",
+    "B",
+    "B",
+    "A",
+    "B",
+    "A",
+    "B",
+    "A",
+    "B",
+    "A",
+    "A"
+  ],
+  "type": "RECF",
+  "dimensions": [
+    1,
+    1,
+    2,
+    3
+  ]
+}

--- a/data/reliability/gemma3-12b-run-2.json
+++ b/data/reliability/gemma3-12b-run-2.json
@@ -1,0 +1,30 @@
+{
+  "model": "gemma3:12b",
+  "provider": "ollama",
+  "run": 2,
+  "answers": [
+    "B",
+    "A",
+    "B",
+    "B",
+    "A",
+    "B",
+    "B",
+    "B",
+    "A",
+    "B",
+    "A",
+    "B",
+    "A",
+    "B",
+    "A",
+    "A"
+  ],
+  "type": "RECF",
+  "dimensions": [
+    1,
+    1,
+    2,
+    3
+  ]
+}

--- a/data/reliability/tinyllama-run-1.json
+++ b/data/reliability/tinyllama-run-1.json
@@ -1,0 +1,30 @@
+{
+  "model": "tinyllama",
+  "provider": "ollama",
+  "run": 1,
+  "answers": [
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A"
+  ],
+  "type": "PTCF",
+  "dimensions": [
+    3,
+    4,
+    4,
+    4
+  ]
+}

--- a/data/reliability/tinyllama-run-2.json
+++ b/data/reliability/tinyllama-run-2.json
@@ -1,0 +1,30 @@
+{
+  "model": "tinyllama",
+  "provider": "ollama",
+  "run": 2,
+  "answers": [
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A"
+  ],
+  "type": "PTCF",
+  "dimensions": [
+    3,
+    4,
+    4,
+    4
+  ]
+}

--- a/data/results.json
+++ b/data/results.json
@@ -3001,6 +3001,110 @@
       "provider": "ollama",
       "reliability": 1,
       "reliabilityRuns": 3
+    },
+    {
+      "name": "gemma3:12b",
+      "slug": "gemma3-12b",
+      "url": "",
+      "type": "RECF",
+      "nick": "The Blade",
+      "testedAt": "2026-05-08T10:34:14.249Z",
+      "scores": [
+        1,
+        1,
+        2,
+        3
+      ],
+      "dimensions": [
+        {
+          "poles": [
+            "P",
+            "R"
+          ],
+          "score": 1,
+          "max": 4
+        },
+        {
+          "poles": [
+            "T",
+            "E"
+          ],
+          "score": 1,
+          "max": 4
+        },
+        {
+          "poles": [
+            "C",
+            "D"
+          ],
+          "score": 2,
+          "max": 4
+        },
+        {
+          "poles": [
+            "F",
+            "N"
+          ],
+          "score": 3,
+          "max": 4
+        }
+      ],
+      "model": "gemma3:12b",
+      "provider": "ollama",
+      "reliability": 1,
+      "reliabilityRuns": 2
+    },
+    {
+      "name": "tinyllama",
+      "slug": "tinyllama",
+      "url": "",
+      "type": "PTCF",
+      "nick": "The Architect",
+      "testedAt": "2026-05-08T10:35:22.531Z",
+      "scores": [
+        3,
+        4,
+        4,
+        4
+      ],
+      "dimensions": [
+        {
+          "poles": [
+            "P",
+            "R"
+          ],
+          "score": 3,
+          "max": 4
+        },
+        {
+          "poles": [
+            "T",
+            "E"
+          ],
+          "score": 4,
+          "max": 4
+        },
+        {
+          "poles": [
+            "C",
+            "D"
+          ],
+          "score": 4,
+          "max": 4
+        },
+        {
+          "poles": [
+            "F",
+            "N"
+          ],
+          "score": 4,
+          "max": 4
+        }
+      ],
+      "model": "tinyllama",
+      "provider": "ollama",
+      "reliability": 1,
+      "reliabilityRuns": 2
     }
   ]
 }


### PR DESCRIPTION
## Changes

- **gemma3:12b → RECF The Blade** (reliability 1.0)
  - Notably different from gemma3:4b (PTCF) — shows model size shifts personality within same family
- **tinyllama → PTCF The Architect** (reliability 1.0, caveat below)
- Registry: 61 agents, 12 distinct types

## Interesting finding

Gemma 3 family personality varies by size:
- gemma3:4b = PTCF (Proactive, Thorough, Candid, Flexible)
- gemma3:12b = RECF (Responsive, Efficient, Candid, Flexible)

The larger model is more "reserved" — responds rather than initiates, prioritizes efficiency over thoroughness.

## Data quality note

TinyLlama (1.1B) can't reliably follow A/B format — most responses triggered parse failures and fell back to 'A'. The 1.0 reliability score reflects deterministic failure, not meaningful consistency. Worth considering a minimum capability threshold or confidence flag for future work.