### PR TITLE
feat: add confidence/quality flag for test results with high parse failure rate

### DIFF
--- a/agent.html
+++ b/agent.html
@@ -273,6 +273,7 @@ nav a:hover, nav a.active { color: var(--accent); }
       '<div class="agent-header">'
       + '<div class="agent-name">' + nameHtml + '</div>'
       + '<a class="agent-type-badge" href="/type/' + esc(a.type) + '">' + esc(a.type) + '</a>'
+      + (a.confidence != null && a.confidence < 0.5 ? ' <span title="Low parse confidence: ' + Math.round(a.confidence * 100) + '%" style="cursor:help;font-size:1.2rem">⚠️</span>' : '')
       + '<div class="agent-nick">' + esc(localNick) + '</div>'
       + (metaParts.length ? '<div class="agent-meta">' + metaParts.join('<span style="color:var(--text3)">&middot;</span>') + '</div>' : '')
       + '</div>'
@@ -282,6 +283,13 @@ nav a:hover, nav a.active { color: var(--accent); }
       + '<div class="card"><div class="reliability-info">'
       + '<span class="reliability-score ' + (a.reliability >= 0.9 ? 'rel-green' : a.reliability >= 0.75 ? 'rel-yellow' : 'rel-red') + '">' + Math.round(a.reliability * 100) + '%</span>'
       + '<span class="reliability-label">consistent across ' + (a.reliabilityRuns || '?') + ' runs</span>'
+      + '</div></div></div>' : '')
+
+      + (a.confidence != null ? '<div class="section">'
+      + '<div class="section-title">Parse Confidence' + (a.confidence < 0.5 ? ' ⚠️' : '') + '</div>'
+      + '<div class="card"><div class="reliability-info">'
+      + '<span class="reliability-score ' + (a.confidence >= 0.9 ? 'rel-green' : a.confidence >= 0.5 ? 'rel-yellow' : 'rel-red') + '">' + Math.round(a.confidence * 100) + '%</span>'
+      + '<span class="reliability-label">' + (a.parseFailures || 0) + ' of 16 questions needed re-parsing</span>'
       + '</div></div></div>' : '')
 
       + (dimHtml ? '<div class="section">'

--- a/agents.html
+++ b/agents.html
@@ -253,6 +253,7 @@ nav a:hover, nav a.active { color: var(--accent); }
         return '<div class="card">'
           + '<div class="card-name">' + nameHtml + '</div>'
           + '<a class="pill" href="/type/' + esc(a.type) + '" style="text-decoration:none">' + esc(a.type) + '</a>'
+          + (a.confidence != null && a.confidence < 0.5 ? ' <span title="Low parse confidence: ' + Math.round(a.confidence * 100) + '%" style="cursor:help">⚠️</span>' : '')
           + (a.nick ? ' <span class="card-nick">' + esc(a.nick) + '</span>' : '')
           + (a.model || a.provider ? '<div class="card-model">' + esc([a.model, a.provider].filter(Boolean).join(' · ')) + '</div>' : '')
           + (a.dimensions ? '<div class="card-scores">' + a.dimensions.map(d => {

--- a/api-server.js
+++ b/api-server.js
@@ -409,6 +409,10 @@ const server = http.createServer((req, res) => {
           if (typeof provider === 'string' && provider) entry.provider = provider.slice(0, 32);
           if (typeof parsed.consistency === 'number' && parsed.consistency >= 0 && parsed.consistency <= 100) entry.consistency = Math.round(parsed.consistency * 100) / 100;
           if (typeof parsed.runs === 'number' && Number.isInteger(parsed.runs) && parsed.runs > 0) entry.runs = parsed.runs;
+          if (typeof parsed.parseFailures === 'number' && Number.isInteger(parsed.parseFailures) && parsed.parseFailures >= 0) {
+            entry.parseFailures = parsed.parseFailures;
+            entry.confidence = Math.round(((16 - parsed.parseFailures) / 16) * 1000) / 1000;
+          }
           if (existing !== -1) {
             agentData.agents[existing] = entry;
           } else {

--- a/cli/bin/abti.js
+++ b/cli/bin/abti.js
@@ -358,6 +358,7 @@ async function runAuto() {
 
   const questions = await getQuestions();
   const answers = [];
+  let parseFailures = 0;
 
   for (let i = 0; i < questions.length; i++) {
     const q = questions[i];
@@ -383,6 +384,7 @@ async function runAuto() {
         break;
       } catch (err) {
         lastErr = err;
+        parseFailures++;
         process.stderr.write(`  Parse failed (attempt ${attempt + 1}/3): ${err.message}\n`);
       }
     }
@@ -391,18 +393,21 @@ async function runAuto() {
     process.stderr.write(`  Question ${i + 1}/${questions.length}... ${answer ? 'A' : 'B'}\n`);
   }
 
-  return answers;
+  return { answers, parseFailures };
 }
 
 // ── Interactive quiz ────────────────────────────────────────────────────────
 async function run() {
   let answers;
 
+  let parseFailures = 0;
   if (autoMode) {
     if (runsN > 1) {
       return await runMulti();
     }
-    answers = await runAuto();
+    const autoResult = await runAuto();
+    answers = autoResult.answers;
+    parseFailures = autoResult.parseFailures;
   } else {
     if (runsN > 1) { console.error('  --runs only works with --auto mode'); process.exit(1); }
     answers = await runInteractive();
@@ -455,6 +460,7 @@ async function run() {
       if (agentUrl) body.agentUrl = agentUrl;
       if (model) body.model = model;
       if (provider) body.provider = provider;
+      if (parseFailures > 0) body.parseFailures = parseFailures;
       await httpPost(`${API_BASE}/api/agent-test`, body);
       if (!jsonMode) console.log(`\n  ${t.submitted}`);
     } catch (err) {
@@ -469,9 +475,12 @@ async function run() {
 // ── Multi-run mode ─────────────────────────────────────────────────────────
 async function runMulti() {
   const allRuns = [];
+  let totalParseFailures = 0;
 
   for (let r = 0; r < runsN; r++) {
-    const answers = await runAuto();
+    const autoResult = await runAuto();
+    const answers = autoResult.answers;
+    totalParseFailures += autoResult.parseFailures;
     const result = score(answers);
     const { code, scores } = result;
     const nick = NICKS[lang][code];
@@ -572,6 +581,7 @@ async function runMulti() {
       if (provider) body.provider = provider;
       body.consistency = consistency;
       body.runs = runsN;
+      if (totalParseFailures > 0) body.parseFailures = totalParseFailures;
       await httpPost(`${API_BASE}/api/agent-test`, body);
       if (!jsonMode) console.log(`\n  ${t.submitted}`);
     } catch (err) {

--- a/data/results.json
+++ b/data/results.json
@@ -3103,6 +3103,8 @@
       ],
       "model": "tinyllama",
       "provider": "ollama",
+      "parseFailures": 10,
+      "confidence": 0.375,
       "reliability": 1,
       "reliabilityRuns": 2
     }

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -848,3 +848,44 @@ describe('POST /api/agent-test consistency fields', () => {
     assert.equal(agent.runs, 3);
   });
 });
+
+describe('POST /api/agent-test parseFailures/confidence', () => {
+  it('stores parseFailures and computes confidence', async () => {
+    rateLimitMap.clear();
+    const r = await req('/api/agent-test', {
+      method: 'POST',
+      body: { answers: Array(16).fill(1), agentName: 'ParseFailBot', parseFailures: 10 }
+    });
+    assert.equal(r.status, 200);
+    const data = JSON.parse(fs.readFileSync(path.join(tmpDir, 'results.json'), 'utf8'));
+    const agent = data.agents.find(a => a.name === 'ParseFailBot');
+    assert.equal(agent.parseFailures, 10);
+    assert.equal(agent.confidence, 0.375);
+  });
+
+  it('stores confidence 1.0 for zero parseFailures', async () => {
+    rateLimitMap.clear();
+    const r = await req('/api/agent-test', {
+      method: 'POST',
+      body: { answers: Array(16).fill(1), agentName: 'PerfectBot', parseFailures: 0 }
+    });
+    assert.equal(r.status, 200);
+    const data = JSON.parse(fs.readFileSync(path.join(tmpDir, 'results.json'), 'utf8'));
+    const agent = data.agents.find(a => a.name === 'PerfectBot');
+    assert.equal(agent.parseFailures, 0);
+    assert.equal(agent.confidence, 1);
+  });
+
+  it('omits parseFailures/confidence when not provided', async () => {
+    rateLimitMap.clear();
+    const r = await req('/api/agent-test', {
+      method: 'POST',
+      body: { answers: Array(16).fill(1), agentName: 'NoParseBot' }
+    });
+    assert.equal(r.status, 200);
+    const data = JSON.parse(fs.readFileSync(path.join(tmpDir, 'results.json'), 'utf8'));
+    const agent = data.agents.find(a => a.name === 'NoParseBot');
+    assert.equal(agent.parseFailures, undefined);
+    assert.equal(agent.confidence, undefined);
+  });
+});


### PR DESCRIPTION
## Summary

Add a confidence/quality metric based on parse failure rate during LLM testing. Models that struggle to follow simple A/B instructions now get flagged so users can distinguish between "confidently typed" and "barely answered the questions."

## Changes

- **CLI** (`cli/bin/abti.js`): Track `parseFailures` counter in `runAuto()`, include in submit body for both single-run and multi-run modes
- **API Server** (`api-server.js`): Accept `parseFailures` field, compute `confidence = (16 - parseFailures) / 16`, store both in agent data
- **Agents page** (`agents.html`): Show ⚠️ badge next to type for agents with confidence < 0.5
- **Agent detail page** (`agent.html`): Show ⚠️ badge in header + dedicated Parse Confidence section with percentage and failure count
- **Data** (`data/results.json`): Backfill tinyllama with `parseFailures: 10, confidence: 0.375`
- **Tests** (`test/api.test.js`): 3 new tests — stores parseFailures/computes confidence, handles zero failures, omits fields when not provided

## Confidence calculation

```
confidence = (16 - parseFailures) / 16
```

| parseFailures | confidence | Display |
|---|---|---|
| 0 | 1.0 | Green |
| 4 | 0.75 | Yellow |
| 8 | 0.5 | Yellow |
| 10 | 0.375 | Red + ⚠️ badge |

## Test results

All 148 tests pass (3 new).

Closes #255