### PR TITLE
fix: guard CLI run() behind require.main check, add parseAnswer tests (#259)

### DIFF
--- a/cli/bin/abti.js
+++ b/cli/bin/abti.js
@@ -639,9 +639,8 @@ async function runInteractive() {
   return answers;
 }
 
-run().catch(err => { console.error(err.message); process.exit(1); });
-
-// Export for testing
-if (typeof module !== 'undefined' && module.exports) {
-  module.exports = { parseAnswer };
+if (require.main === module) {
+  run().catch(err => { console.error(err.message); process.exit(1); });
 }
+
+module.exports = { parseAnswer };

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "abti",
   "private": true,
   "scripts": {
-    "test": "node --test test/api.test.js test/mcp.test.js test/mcp-http.test.js test/compatibility.test.js test/cross-compatibility.test.js test/auto-reload.test.js",
+    "test": "node --test test/api.test.js test/mcp.test.js test/mcp-http.test.js test/compatibility.test.js test/cross-compatibility.test.js test/auto-reload.test.js test/parseAnswer.test.js",
     "generate-og": "node scripts/generate-og-images.js"
   },
   "devDependencies": {


### PR DESCRIPTION
Closes #259

## Problem
`cli/bin/abti.js` calls `run()` unconditionally at module level, so `require()` from tests hangs.
`test/parseAnswer.test.js` existed but wasn't in the test suite because of this.

## Fix
- Guard `run()` with `require.main === module`
- Add `test/parseAnswer.test.js` to `npm test`

## Result
Tests: 149 → 159 (all pass). The 10 parseAnswer tests now run in CI, covering edge cases like thinking tokens, multi-line reasoning, standalone answers, etc.