### PR TITLE
feat: add GitHub Models and Groq provider support to CLI and GitHub Action

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ Test any AI agent from the command line:
 npx @kagura-agent/abti --auto --provider openai --model gpt-4o --api-key sk-...
 npx @kagura-agent/abti --auto --provider anthropic --model claude-sonnet-4-20250514
 npx @kagura-agent/abti --auto --provider ollama --model llama3.1
+npx @kagura-agent/abti --auto --provider github --model gpt-4o
+npx @kagura-agent/abti --auto --provider groq --model llama-3.3-70b-versatile
 ```
 
 Ollama requires no API key — just make sure Ollama is running locally.

--- a/action/README.md
+++ b/action/README.md
@@ -2,7 +2,7 @@
 
 Run an [ABTI personality test](https://abti.kagura-agent.com) on your AI agent directly in GitHub Actions.
 
-The action sends each scenario question to an LLM (OpenAI, Anthropic, or Google Gemini), collects its choices, and reports the resulting ABTI type as a job summary, outputs, and optional PR comment.
+The action sends each scenario question to an LLM (OpenAI, Anthropic, Google Gemini, GitHub Models, or Groq), collects its choices, and reports the resulting ABTI type as a job summary, outputs, and optional PR comment.
 
 ## Inputs
 
@@ -10,7 +10,7 @@ The action sends each scenario question to an LLM (OpenAI, Anthropic, or Google 
 |-------|----------|---------|-------------|
 | `agent-prompt` | No | — | Agent system prompt string |
 | `agent-prompt-file` | No | — | Path to file containing system prompt (e.g. `AGENTS.md`) |
-| `provider` | **Yes** | — | `openai`, `anthropic`, or `gemini` |
+| `provider` | **Yes** | — | `openai`, `anthropic`, `gemini`, `github`, or `groq` |
 | `model` | **Yes** | — | Model name (e.g. `gpt-4o`, `claude-sonnet-4-20250514`) |
 | `api-key` | **Yes** | — | API key for the LLM provider |
 | `agent-name` | No | `<model> (<provider>)` | Display name for the agent in the registry |
@@ -46,6 +46,26 @@ The action sends each scenario question to an LLM (OpenAI, Anthropic, or Google 
     provider: gemini
     model: gemini-2.5-flash
     api-key: ${{ secrets.GOOGLE_AI_API_KEY }}
+```
+
+### Basic — test with GitHub Models
+
+```yaml
+- uses: kagura-agent/abti@v1
+  with:
+    provider: github
+    model: gpt-4o
+    api-key: ${{ secrets.GITHUB_TOKEN }}
+```
+
+### Basic — test with Groq
+
+```yaml
+- uses: kagura-agent/abti@v1
+  with:
+    provider: groq
+    model: llama-3.3-70b-versatile
+    api-key: ${{ secrets.GROQ_API_KEY }}
 ```
 
 ### With agent system prompt from file
@@ -101,5 +121,5 @@ The action sends each scenario question to an LLM (OpenAI, Anthropic, or Google 
 ## Requirements
 
 - Node.js 20+ (provided by GitHub Actions runners)
-- An OpenAI, Anthropic, or Google AI API key stored as a repository secret
+- An OpenAI, Anthropic, Google AI, GitHub, or Groq API key stored as a repository secret
 - For PR comments: `GITHUB_TOKEN` with `pull-requests: write` permission

--- a/action/index.js
+++ b/action/index.js
@@ -250,7 +250,9 @@ function callLLM(provider, apiKey, model, systemPrompt, userMessage, baseUrl) {
   if (provider === 'openai') return callOpenAI(apiKey, model, systemPrompt, userMessage, baseUrl);
   if (provider === 'anthropic') return callAnthropic(apiKey, model, systemPrompt, userMessage, baseUrl);
   if (provider === 'gemini') return callGemini(apiKey, model, systemPrompt, userMessage);
-  throw new Error(`Unknown provider: ${provider}. Must be "openai", "anthropic", or "gemini".`);
+  if (provider === 'github') return callOpenAI(apiKey, model, systemPrompt, userMessage, baseUrl || 'https://models.inference.ai.azure.com');
+  if (provider === 'groq') return callOpenAI(apiKey, model, systemPrompt, userMessage, baseUrl || 'https://api.groq.com/openai');
+  throw new Error(`Unknown provider: ${provider}. Must be "openai", "anthropic", "gemini", "github", or "groq".`);
 }
 
 // ─── Answer parsing ──────────────────────────────────────────────────────────

--- a/cli/bin/abti.js
+++ b/cli/bin/abti.js
@@ -134,6 +134,8 @@ if (flag('--help') || flag('-h')) {
     npx abti test --provider anthropic --model claude-sonnet-4-20250514
     npx abti test --provider gemini --model gemini-2.0-flash
     npx abti test --provider deepseek --model deepseek-chat
+    npx abti test --provider github --model gpt-4o
+    npx abti test --provider groq --model llama-3.3-70b-versatile
     npx abti test --provider ollama --model llama3.1
 
   Options:
@@ -142,8 +144,8 @@ if (flag('--help') || flag('-h')) {
     --name <name>            Agent name for registry
     --url <url>              Agent URL for registry
     --model <model>          Model name
-    --provider <provider>    Provider: openai|anthropic|gemini|deepseek|ollama (default: openai)
-    --api-key <key>          API key (or set OPENAI_API_KEY / ANTHROPIC_API_KEY / GOOGLE_AI_API_KEY / DEEPSEEK_API_KEY)
+    --provider <provider>    Provider: openai|anthropic|gemini|deepseek|github|groq|ollama (default: openai)
+    --api-key <key>          API key (or set OPENAI_API_KEY / ANTHROPIC_API_KEY / GOOGLE_AI_API_KEY / DEEPSEEK_API_KEY / GROQ_API_KEY / GITHUB_TOKEN)
     --submit                 Submit result to the ABTI registry
     --badge                  Print markdown badge snippet after results
     --runs <N>               Run the test N times (1-10, auto mode only)
@@ -160,6 +162,8 @@ if (flag('--help') || flag('-h')) {
     npx abti test --provider openai --model gpt-4o --json --submit --name "my-agent"
     npx abti test --provider anthropic --model claude-sonnet-4-20250514 --badge
     npx abti --lang zh --json
+    npx abti test --provider github --model gpt-4o --api-key ghp_...
+    npx abti test --provider groq --model llama-3.3-70b-versatile --api-key gsk_...
 `);
   process.exit(0);
 }
@@ -296,8 +300,10 @@ function callLLM(prov, apiKey, mdl, systemPrompt, userMessage, baseUrl) {
   if (prov === 'anthropic') return callAnthropic(apiKey, mdl, systemPrompt, userMessage, baseUrl);
   if (prov === 'gemini') return callGemini(apiKey, mdl, systemPrompt, userMessage);
   if (prov === 'deepseek') return callOpenAI(apiKey, mdl, systemPrompt, userMessage, 'https://api.deepseek.com');
+  if (prov === 'github') return callOpenAI(apiKey, mdl, systemPrompt, userMessage, baseUrl || 'https://models.inference.ai.azure.com');
+  if (prov === 'groq') return callOpenAI(apiKey, mdl, systemPrompt, userMessage, baseUrl || 'https://api.groq.com/openai');
   if (prov === 'ollama') return callOpenAI(apiKey || 'ollama', mdl, systemPrompt, userMessage, 'http://localhost:11434', isReasoningModel(mdl) ? { think: false } : undefined);
-  throw new Error(`Unknown provider: ${prov}. Must be "openai", "anthropic", "gemini", "deepseek", or "ollama".`);
+  throw new Error(`Unknown provider: ${prov}. Must be "openai", "anthropic", "gemini", "deepseek", "github", "groq", or "ollama".`);
 }
 
 function isReasoningModel(modelName) {
@@ -336,7 +342,8 @@ function parseAnswer(response) {
 function resolveApiKey(prov, explicit) {
   if (explicit) return explicit;
   if (prov === 'ollama') return 'ollama';
-  const envMap = { openai: 'OPENAI_API_KEY', anthropic: 'ANTHROPIC_API_KEY', gemini: 'GOOGLE_AI_API_KEY', deepseek: 'DEEPSEEK_API_KEY' };
+  if (prov === 'github') return process.env.GITHUB_TOKEN || (() => { throw new Error('No API key provided. Use --api-key or set GITHUB_TOKEN'); })();
+  const envMap = { openai: 'OPENAI_API_KEY', anthropic: 'ANTHROPIC_API_KEY', gemini: 'GOOGLE_AI_API_KEY', deepseek: 'DEEPSEEK_API_KEY', groq: 'GROQ_API_KEY' };
   const envKey = envMap[prov];
   if (envKey && process.env[envKey]) return process.env[envKey];
   throw new Error(`No API key provided. Use --api-key or set ${envKey}`);


### PR DESCRIPTION
## Summary

Add **GitHub Models** and **Groq** as first-class providers in the CLI and GitHub Action, lowering the barrier for testing AI agents.

### GitHub Models
- Uses `GITHUB_TOKEN` (most developers already have one)
- Free access to GPT-4o, Llama, Mistral, and many other models
- Zero additional signup required

### Groq
- Fast inference with a free tier
- Great for quick testing

Both use the OpenAI-compatible API format, so they route through the existing `callOpenAI()` function.

## Changes

| File | Changes |
|------|---------|
| `cli/bin/abti.js` | Add `github` + `groq` to `callLLM()`, `resolveApiKey()`, help text |
| `action/index.js` | Add `github` + `groq` to `callLLM()` routing |
| `action/README.md` | Document new providers with usage examples |
| `README.md` | Add CLI examples |

## Testing

All 159 tests pass. The routing follows the same pattern already used for `deepseek` and `ollama` in the CLI.

Closes #261