### PR TITLE
feat: add OpenRouter provider support

### DIFF
--- a/action/index.js
+++ b/action/index.js
@@ -252,7 +252,8 @@ function callLLM(provider, apiKey, model, systemPrompt, userMessage, baseUrl) {
   if (provider === 'gemini') return callGemini(apiKey, model, systemPrompt, userMessage);
   if (provider === 'github') return callOpenAI(apiKey, model, systemPrompt, userMessage, baseUrl || 'https://models.inference.ai.azure.com');
   if (provider === 'groq') return callOpenAI(apiKey, model, systemPrompt, userMessage, baseUrl || 'https://api.groq.com/openai');
-  throw new Error(`Unknown provider: ${provider}. Must be "openai", "anthropic", "gemini", "github", or "groq".`);
+  if (provider === 'openrouter') return callOpenAI(apiKey, model, systemPrompt, userMessage, baseUrl || 'https://openrouter.ai/api/v1');
+  throw new Error(`Unknown provider: ${provider}. Must be "openai", "anthropic", "gemini", "github", "groq", or "openrouter".`);
 }
 
 // ─── Answer parsing ──────────────────────────────────────────────────────────

--- a/cli/bin/abti.js
+++ b/cli/bin/abti.js
@@ -136,6 +136,7 @@ if (flag('--help') || flag('-h')) {
     npx abti test --provider deepseek --model deepseek-chat
     npx abti test --provider github --model gpt-4o
     npx abti test --provider groq --model llama-3.3-70b-versatile
+    npx abti test --provider openrouter --model meta-llama/llama-3.3-70b-instruct
     npx abti test --provider ollama --model llama3.1
 
   Options:
@@ -144,8 +145,8 @@ if (flag('--help') || flag('-h')) {
     --name <name>            Agent name for registry
     --url <url>              Agent URL for registry
     --model <model>          Model name
-    --provider <provider>    Provider: openai|anthropic|gemini|deepseek|github|groq|ollama (default: openai)
-    --api-key <key>          API key (or set OPENAI_API_KEY / ANTHROPIC_API_KEY / GOOGLE_AI_API_KEY / DEEPSEEK_API_KEY / GROQ_API_KEY / GITHUB_TOKEN)
+    --provider <provider>    Provider: openai|anthropic|gemini|deepseek|github|groq|openrouter|ollama (default: openai)
+    --api-key <key>          API key (or set OPENAI_API_KEY / ANTHROPIC_API_KEY / GOOGLE_AI_API_KEY / DEEPSEEK_API_KEY / GROQ_API_KEY / OPENROUTER_API_KEY / GITHUB_TOKEN)
     --submit                 Submit result to the ABTI registry
     --badge                  Print markdown badge snippet after results
     --runs <N>               Run the test N times (1-10, auto mode only)
@@ -164,6 +165,7 @@ if (flag('--help') || flag('-h')) {
     npx abti --lang zh --json
     npx abti test --provider github --model gpt-4o --api-key ghp_...
     npx abti test --provider groq --model llama-3.3-70b-versatile --api-key gsk_...
+    npx abti test --provider openrouter --model meta-llama/llama-3.3-70b-instruct --api-key sk-or-...
 `);
   process.exit(0);
 }
@@ -302,8 +304,9 @@ function callLLM(prov, apiKey, mdl, systemPrompt, userMessage, baseUrl) {
   if (prov === 'deepseek') return callOpenAI(apiKey, mdl, systemPrompt, userMessage, 'https://api.deepseek.com');
   if (prov === 'github') return callOpenAI(apiKey, mdl, systemPrompt, userMessage, baseUrl || 'https://models.inference.ai.azure.com');
   if (prov === 'groq') return callOpenAI(apiKey, mdl, systemPrompt, userMessage, baseUrl || 'https://api.groq.com/openai');
+  if (prov === 'openrouter') return callOpenAI(apiKey, mdl, systemPrompt, userMessage, baseUrl || 'https://openrouter.ai/api/v1');
   if (prov === 'ollama') return callOpenAI(apiKey || 'ollama', mdl, systemPrompt, userMessage, 'http://localhost:11434', isReasoningModel(mdl) ? { think: false } : undefined);
-  throw new Error(`Unknown provider: ${prov}. Must be "openai", "anthropic", "gemini", "deepseek", "github", "groq", or "ollama".`);
+  throw new Error(`Unknown provider: ${prov}. Must be "openai", "anthropic", "gemini", "deepseek", "github", "groq", "openrouter", or "ollama".`);
 }
 
 function isReasoningModel(modelName) {
@@ -343,7 +346,7 @@ function resolveApiKey(prov, explicit) {
   if (explicit) return explicit;
   if (prov === 'ollama') return 'ollama';
   if (prov === 'github') return process.env.GITHUB_TOKEN || (() => { throw new Error('No API key provided. Use --api-key or set GITHUB_TOKEN'); })();
-  const envMap = { openai: 'OPENAI_API_KEY', anthropic: 'ANTHROPIC_API_KEY', gemini: 'GOOGLE_AI_API_KEY', deepseek: 'DEEPSEEK_API_KEY', groq: 'GROQ_API_KEY' };
+  const envMap = { openai: 'OPENAI_API_KEY', anthropic: 'ANTHROPIC_API_KEY', gemini: 'GOOGLE_AI_API_KEY', deepseek: 'DEEPSEEK_API_KEY', groq: 'GROQ_API_KEY', openrouter: 'OPENROUTER_API_KEY' };
   const envKey = envMap[prov];
   if (envKey && process.env[envKey]) return process.env[envKey];
   throw new Error(`No API key provided. Use --api-key or set ${envKey}`);
@@ -684,4 +687,4 @@ if (require.main === module) {
   run().catch(err => { console.error(err.message); process.exit(1); });
 }
 
-module.exports = { parseAnswer };
+module.exports = { parseAnswer, callLLM };

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "abti",
   "private": true,
   "scripts": {
-    "test": "node --test test/api.test.js test/mcp.test.js test/mcp-http.test.js test/compatibility.test.js test/cross-compatibility.test.js test/auto-reload.test.js test/parseAnswer.test.js",
+    "test": "node --test test/api.test.js test/mcp.test.js test/mcp-http.test.js test/compatibility.test.js test/cross-compatibility.test.js test/auto-reload.test.js test/parseAnswer.test.js test/provider.test.js",
     "generate-og": "node scripts/generate-og-images.js"
   },
   "devDependencies": {

--- a/test/provider.test.js
+++ b/test/provider.test.js
@@ -1,0 +1,37 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+const { callLLM } = require('../cli/bin/abti.js');
+
+describe('callLLM provider routing', () => {
+  it('should throw for unknown provider', () => {
+    assert.throws(
+      () => callLLM('unknown', 'key', 'model', 'sys', 'usr'),
+      /Unknown provider: unknown/
+    );
+  });
+
+  it('should route openrouter to callOpenAI (rejects with network error, not unknown provider)', async () => {
+    // openrouter should be recognized and attempt an API call (which fails with network/fetch error, not "Unknown provider")
+    const promise = callLLM('openrouter', 'test-key', 'test-model', 'system', 'user');
+    await assert.rejects(promise, (err) => {
+      assert.ok(!err.message.includes('Unknown provider'), 'should not throw Unknown provider for openrouter');
+      return true;
+    });
+  });
+
+  it('should route groq to callOpenAI (rejects with network error, not unknown provider)', async () => {
+    const promise = callLLM('groq', 'test-key', 'test-model', 'system', 'user');
+    await assert.rejects(promise, (err) => {
+      assert.ok(!err.message.includes('Unknown provider'), 'should not throw Unknown provider for groq');
+      return true;
+    });
+  });
+
+  it('should include openrouter in error message for unknown providers', () => {
+    try {
+      callLLM('bad', 'key', 'model', 'sys', 'usr');
+    } catch (e) {
+      assert.ok(e.message.includes('openrouter'), 'error message should list openrouter as valid provider');
+    }
+  });
+});


### PR DESCRIPTION
Closes #265

Adds OpenRouter as a provider for both CLI and GitHub Action. OpenRouter uses the OpenAI-compatible API format (`https://openrouter.ai/api/v1`), giving access to 100+ models through a single API key.

### Changes
- **CLI** (`cli/bin/abti.js`): Added `openrouter` provider routing via `callOpenAI()`, env var `OPENROUTER_API_KEY`, help text & usage examples
- **Action** (`action/index.js`): Added `openrouter` provider routing
- **Tests**: Added `test/provider.test.js` with unit tests for provider routing (openrouter + groq), included in `npm test`
- Exported `callLLM` from CLI module for testability

### Usage
```bash
npx abti test --provider openrouter --model mistralai/mistral-large-latest --api-key sk-or-...
npx abti test --provider openrouter --model meta-llama/llama-3.3-70b-instruct
```

### Test Results
163 tests, 0 failures (all existing + 4 new provider routing tests)