### PR TITLE
chore: bump CLI to v0.2.0 for npm publish

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+## 0.2.0 (2026-05-09)
+
+### New Features
+- **OpenRouter provider** — test models via OpenRouter (`--provider openrouter`)
+- **GitHub Models provider** — test models via GitHub Models (`--provider github`)
+- **Groq provider** — test models via Groq (`--provider groq`)
+- `abti test` subcommand — quick one-liner testing
+- ANSI colors in terminal output
+- `--badge` flag to show badge markdown after results
+- Confidence/quality flag for results with high parse failure rate
+- Retry on parse failure for more reliable results
+
+### Bug Fixes
+- Guard `run()` behind `require.main` check (fixes import side effects)
+- Better `parseAnswer` for reasoning models (handles missing `<think>` tags)
+
+## 0.1.0
+
+- Initial release with Anthropic, OpenAI, and Ollama providers

--- a/cli/README.md
+++ b/cli/README.md
@@ -44,9 +44,14 @@ npx abti test --provider deepseek --model deepseek-chat
 # Ollama (local)
 npx abti test --provider ollama --model llama3.1
 
-# Via OpenRouter
-npx abti test --provider openai --model meta-llama/llama-3-70b \
-  --base-url https://openrouter.ai/api --api-key sk-or-...
+# OpenRouter
+npx abti test --provider openrouter --model anthropic/claude-sonnet-4-20250514 --api-key sk-or-...
+
+# Groq
+npx abti test --provider groq --model llama-3.3-70b-versatile --api-key gsk_...
+
+# GitHub Models (uses GITHUB_TOKEN)
+npx abti test --provider github --model gpt-4o
 ```
 
 ### Options
@@ -59,7 +64,7 @@ npx abti test --provider openai --model meta-llama/llama-3-70b \
 | `--name <name>` | Agent name for registry |
 | `--url <url>` | Agent URL for registry |
 | `--model <model>` | Model name |
-| `--provider <provider>` | Provider: `openai`, `anthropic`, `gemini`, `deepseek`, `ollama` (default: `openai`) |
+| `--provider <provider>` | Provider: `openai`, `anthropic`, `gemini`, `deepseek`, `ollama`, `openrouter`, `groq`, `github` (default: `openai`) |
 | `--api-key <key>` | API key (or set env var) |
 | `--submit` | Submit result to the ABTI registry |
 | `--runs <N>` | Run the test N times (1-10) and show consistency report |
@@ -83,6 +88,9 @@ npx abti test --provider openai --model meta-llama/llama-3-70b \
 - `ANTHROPIC_API_KEY` — for `--provider anthropic`
 - `GOOGLE_AI_API_KEY` — for `--provider gemini`
 - `DEEPSEEK_API_KEY` — for `--provider deepseek`
+- `OPENROUTER_API_KEY` — for `--provider openrouter`
+- `GROQ_API_KEY` — for `--provider groq`
+- `GITHUB_TOKEN` — for `--provider github`
 
 ### Examples
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "abti",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Agent Behavioral Type Indicator \u2014 discover your AI agent's personality type from the terminal",
   "bin": {
     "abti": "bin/abti.js"


### PR DESCRIPTION
Bumps CLI version to 0.2.0 and adds CHANGELOG + updated README with new provider examples.

Closes #267

## Changes
- Bump version 0.1.0 → 0.2.0
- Add CHANGELOG.md documenting all changes since 0.1.0
- Update README with OpenRouter, Groq, GitHub Models examples

After merge: `cd cli && npm publish --access public`