### PR TITLE
feat: add Mistral AI provider support

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,11 +69,12 @@ Replace `claude-3-5-sonnet` with the agent's slug. Shows "Not Tested" if the age
 Test any AI agent from the command line:
 
 ```bash
-npx @kagura-agent/abti --auto --provider openai --model gpt-4o --api-key sk-...
-npx @kagura-agent/abti --auto --provider anthropic --model claude-sonnet-4-20250514
-npx @kagura-agent/abti --auto --provider ollama --model llama3.1
-npx @kagura-agent/abti --auto --provider github --model gpt-4o
-npx @kagura-agent/abti --auto --provider groq --model llama-3.3-70b-versatile
+npx @kagura-agent/abti test --provider openai --model gpt-4o --api-key sk-...
+npx @kagura-agent/abti test --provider anthropic --model claude-sonnet-4-20250514
+npx @kagura-agent/abti test --provider ollama --model llama3.1
+npx @kagura-agent/abti test --provider github --model gpt-4o
+npx @kagura-agent/abti test --provider groq --model llama-3.3-70b-versatile
+npx @kagura-agent/abti test --provider mistral --model mistral-small-latest
 ```
 
 Ollama requires no API key — just make sure Ollama is running locally.

--- a/action/README.md
+++ b/action/README.md
@@ -10,7 +10,7 @@ The action sends each scenario question to an LLM (OpenAI, Anthropic, Google Gem
 |-------|----------|---------|-------------|
 | `agent-prompt` | No | — | Agent system prompt string |
 | `agent-prompt-file` | No | — | Path to file containing system prompt (e.g. `AGENTS.md`) |
-| `provider` | **Yes** | — | `openai`, `anthropic`, `gemini`, `github`, or `groq` |
+| `provider` | **Yes** | — | `openai`, `anthropic`, `gemini`, `github`, `groq`, `openrouter`, or `mistral` |
 | `model` | **Yes** | — | Model name (e.g. `gpt-4o`, `claude-sonnet-4-20250514`) |
 | `api-key` | **Yes** | — | API key for the LLM provider |
 | `agent-name` | No | `<model> (<provider>)` | Display name for the agent in the registry |

--- a/action/index.js
+++ b/action/index.js
@@ -253,7 +253,8 @@ function callLLM(provider, apiKey, model, systemPrompt, userMessage, baseUrl) {
   if (provider === 'github') return callOpenAI(apiKey, model, systemPrompt, userMessage, baseUrl || 'https://models.inference.ai.azure.com');
   if (provider === 'groq') return callOpenAI(apiKey, model, systemPrompt, userMessage, baseUrl || 'https://api.groq.com/openai');
   if (provider === 'openrouter') return callOpenAI(apiKey, model, systemPrompt, userMessage, baseUrl || 'https://openrouter.ai/api/v1');
-  throw new Error(`Unknown provider: ${provider}. Must be "openai", "anthropic", "gemini", "github", "groq", or "openrouter".`);
+  if (provider === 'mistral') return callOpenAI(apiKey, model, systemPrompt, userMessage, baseUrl || 'https://api.mistral.ai/v1');
+  throw new Error(`Unknown provider: ${provider}. Must be "openai", "anthropic", "gemini", "github", "groq", "openrouter", or "mistral".`);
 }
 
 // ─── Answer parsing ──────────────────────────────────────────────────────────

--- a/cli/README.md
+++ b/cli/README.md
@@ -50,6 +50,9 @@ npx abti test --provider openrouter --model anthropic/claude-sonnet-4-20250514 -
 # Groq
 npx abti test --provider groq --model llama-3.3-70b-versatile --api-key gsk_...
 
+# Mistral
+npx abti test --provider mistral --model mistral-small-latest --api-key ...
+
 # GitHub Models (uses GITHUB_TOKEN)
 npx abti test --provider github --model gpt-4o
 ```
@@ -64,7 +67,7 @@ npx abti test --provider github --model gpt-4o
 | `--name <name>` | Agent name for registry |
 | `--url <url>` | Agent URL for registry |
 | `--model <model>` | Model name |
-| `--provider <provider>` | Provider: `openai`, `anthropic`, `gemini`, `deepseek`, `ollama`, `openrouter`, `groq`, `github` (default: `openai`) |
+| `--provider <provider>` | Provider: `openai`, `anthropic`, `gemini`, `deepseek`, `ollama`, `openrouter`, `groq`, `mistral`, `github` (default: `openai`) |
 | `--api-key <key>` | API key (or set env var) |
 | `--submit` | Submit result to the ABTI registry |
 | `--runs <N>` | Run the test N times (1-10) and show consistency report |
@@ -90,6 +93,7 @@ npx abti test --provider github --model gpt-4o
 - `DEEPSEEK_API_KEY` — for `--provider deepseek`
 - `OPENROUTER_API_KEY` — for `--provider openrouter`
 - `GROQ_API_KEY` — for `--provider groq`
+- `MISTRAL_API_KEY` — for `--provider mistral`
 - `GITHUB_TOKEN` — for `--provider github`
 
 ### Examples

--- a/cli/bin/abti.js
+++ b/cli/bin/abti.js
@@ -137,6 +137,7 @@ if (flag('--help') || flag('-h')) {
     npx abti test --provider github --model gpt-4o
     npx abti test --provider groq --model llama-3.3-70b-versatile
     npx abti test --provider openrouter --model meta-llama/llama-3.3-70b-instruct
+    npx abti test --provider mistral --model mistral-small-latest
     npx abti test --provider ollama --model llama3.1
 
   Options:
@@ -145,7 +146,7 @@ if (flag('--help') || flag('-h')) {
     --name <name>            Agent name for registry
     --url <url>              Agent URL for registry
     --model <model>          Model name
-    --provider <provider>    Provider: openai|anthropic|gemini|deepseek|github|groq|openrouter|ollama (default: openai)
+    --provider <provider>    Provider: openai|anthropic|gemini|deepseek|github|groq|openrouter|mistral|ollama (default: openai)
     --api-key <key>          API key (or set OPENAI_API_KEY / ANTHROPIC_API_KEY / GOOGLE_AI_API_KEY / DEEPSEEK_API_KEY / GROQ_API_KEY / OPENROUTER_API_KEY / GITHUB_TOKEN)
     --submit                 Submit result to the ABTI registry
     --badge                  Print markdown badge snippet after results
@@ -305,8 +306,9 @@ function callLLM(prov, apiKey, mdl, systemPrompt, userMessage, baseUrl) {
   if (prov === 'github') return callOpenAI(apiKey, mdl, systemPrompt, userMessage, baseUrl || 'https://models.inference.ai.azure.com');
   if (prov === 'groq') return callOpenAI(apiKey, mdl, systemPrompt, userMessage, baseUrl || 'https://api.groq.com/openai');
   if (prov === 'openrouter') return callOpenAI(apiKey, mdl, systemPrompt, userMessage, baseUrl || 'https://openrouter.ai/api/v1');
+  if (prov === 'mistral') return callOpenAI(apiKey, mdl, systemPrompt, userMessage, baseUrl || 'https://api.mistral.ai/v1');
   if (prov === 'ollama') return callOpenAI(apiKey || 'ollama', mdl, systemPrompt, userMessage, 'http://localhost:11434', isReasoningModel(mdl) ? { think: false } : undefined);
-  throw new Error(`Unknown provider: ${prov}. Must be "openai", "anthropic", "gemini", "deepseek", "github", "groq", "openrouter", or "ollama".`);
+  throw new Error(`Unknown provider: ${prov}. Must be "openai", "anthropic", "gemini", "deepseek", "github", "groq", "openrouter", "mistral", or "ollama".`);
 }
 
 function isReasoningModel(modelName) {
@@ -346,7 +348,7 @@ function resolveApiKey(prov, explicit) {
   if (explicit) return explicit;
   if (prov === 'ollama') return 'ollama';
   if (prov === 'github') return process.env.GITHUB_TOKEN || (() => { throw new Error('No API key provided. Use --api-key or set GITHUB_TOKEN'); })();
-  const envMap = { openai: 'OPENAI_API_KEY', anthropic: 'ANTHROPIC_API_KEY', gemini: 'GOOGLE_AI_API_KEY', deepseek: 'DEEPSEEK_API_KEY', groq: 'GROQ_API_KEY', openrouter: 'OPENROUTER_API_KEY' };
+  const envMap = { openai: 'OPENAI_API_KEY', anthropic: 'ANTHROPIC_API_KEY', gemini: 'GOOGLE_AI_API_KEY', deepseek: 'DEEPSEEK_API_KEY', groq: 'GROQ_API_KEY', openrouter: 'OPENROUTER_API_KEY', mistral: 'MISTRAL_API_KEY' };
   const envKey = envMap[prov];
   if (envKey && process.env[envKey]) return process.env[envKey];
   throw new Error(`No API key provided. Use --api-key or set ${envKey}`);


### PR DESCRIPTION
Closes #269

## Changes
- Add `mistral` provider to CLI and GitHub Action (OpenAI-compatible API)
- Add `MISTRAL_API_KEY` env var support
- Update CLI help text, README, and root README
- Sync root README: `--auto` → `test` subcommand, `@kagura-agent/abti` → `abti`

## Usage
```bash
npx abti test --provider mistral --model mistral-large-latest
```