### PR TITLE
data: add reliability scores for Granite 3.3 8B and Qwen 3 1.7B

### DIFF
--- a/data/reliability/granite3-3-8b-run-1.json
+++ b/data/reliability/granite3-3-8b-run-1.json
@@ -1,0 +1,30 @@
+{
+  "model": "granite3.3:8b",
+  "provider": "ollama",
+  "run": 1,
+  "answers": [
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "A",
+    "B"
+  ],
+  "type": "PTCF",
+  "dimensions": [
+    4,
+    2,
+    4,
+    2
+  ]
+}

--- a/data/reliability/granite3-3-8b-run-2.json
+++ b/data/reliability/granite3-3-8b-run-2.json
@@ -1,0 +1,30 @@
+{
+  "model": "granite3.3:8b",
+  "provider": "ollama",
+  "run": 2,
+  "answers": [
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "A",
+    "B"
+  ],
+  "type": "PTCF",
+  "dimensions": [
+    4,
+    2,
+    4,
+    2
+  ]
+}

--- a/data/reliability/granite3-3-8b-run-3.json
+++ b/data/reliability/granite3-3-8b-run-3.json
@@ -1,0 +1,30 @@
+{
+  "model": "granite3.3:8b",
+  "provider": "ollama",
+  "run": 3,
+  "answers": [
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "A",
+    "B"
+  ],
+  "type": "PTCF",
+  "dimensions": [
+    4,
+    2,
+    4,
+    2
+  ]
+}

--- a/data/reliability/qwen3-1-7b-run-1.json
+++ b/data/reliability/qwen3-1-7b-run-1.json
@@ -1,0 +1,30 @@
+{
+  "model": "qwen3:1.7b",
+  "provider": "ollama",
+  "run": 1,
+  "answers": [
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "B",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B"
+  ],
+  "type": "PTCF",
+  "dimensions": [
+    4,
+    3,
+    2,
+    3
+  ]
+}

--- a/data/reliability/qwen3-1-7b-run-2.json
+++ b/data/reliability/qwen3-1-7b-run-2.json
@@ -1,0 +1,30 @@
+{
+  "model": "qwen3:1.7b",
+  "provider": "ollama",
+  "run": 2,
+  "answers": [
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "B",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B"
+  ],
+  "type": "PTCF",
+  "dimensions": [
+    4,
+    3,
+    2,
+    3
+  ]
+}

--- a/data/reliability/qwen3-1-7b-run-3.json
+++ b/data/reliability/qwen3-1-7b-run-3.json
@@ -1,0 +1,30 @@
+{
+  "model": "qwen3:1.7b",
+  "provider": "ollama",
+  "run": 3,
+  "answers": [
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "B",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B"
+  ],
+  "type": "PTCF",
+  "dimensions": [
+    4,
+    3,
+    2,
+    3
+  ]
+}

--- a/data/results.json
+++ b/data/results.json
@@ -1683,10 +1683,10 @@
       "url": "",
       "type": "PTCF",
       "nick": "The Architect",
-      "testedAt": "2026-05-04T01:47:44.019Z",
+      "testedAt": "2026-05-10T04:47:17.506Z",
       "scores": [
         4,
-        3,
+        2,
         4,
         2
       ],
@@ -1704,7 +1704,7 @@
             "T",
             "E"
           ],
-          "score": 3,
+          "score": 2,
           "max": 4
         },
         {
@@ -1725,7 +1725,9 @@
         }
       ],
       "model": "granite3.3:8b",
-      "provider": "ollama"
+      "provider": "ollama",
+      "reliability": 1,
+      "reliabilityRuns": 3
     },
     {
       "name": "Aya Expanse 8B",
@@ -2297,12 +2299,12 @@
       "url": "",
       "type": "PTCF",
       "nick": "The Architect",
-      "testedAt": "2026-05-07T12:43:34.438Z",
+      "testedAt": "2026-05-10T05:05:14.764Z",
       "scores": [
         4,
-        4,
-        4,
-        4
+        3,
+        2,
+        3
       ],
       "dimensions": [
         {
@@ -2318,7 +2320,7 @@
             "T",
             "E"
           ],
-          "score": 4,
+          "score": 3,
           "max": 4
         },
         {
@@ -2326,7 +2328,7 @@
             "C",
             "D"
           ],
-          "score": 4,
+          "score": 2,
           "max": 4
         },
         {
@@ -2334,12 +2336,14 @@
             "F",
             "N"
           ],
-          "score": 4,
+          "score": 3,
           "max": 4
         }
       ],
       "model": "qwen3:1.7b",
-      "provider": "ollama"
+      "provider": "ollama",
+      "reliability": 1,
+      "reliabilityRuns": 3
     },
     {
       "name": "Phi-4 Mini Reasoning",


### PR DESCRIPTION
Both models show perfect reliability (1.0) across 3 runs:
- **Granite 3.3 8B**: PTCF (The Architect) — all 3 runs consistent
- **Qwen 3 1.7B**: PTCF (The Architect) — all 3 runs consistent

Also updates results.json with latest scores and reliability metadata.

Tests: 163 pass / 0 fail ✅

---

Note: Attempted to test Qwen3-32B, DeepSeek-R1, DeepSeek-R1-0528 (issue #274) but GitHub Models API is rate limited (~21h cooldown). Will retry in next cron cycle.