### PR TITLE
data: add mathstral:7b and nemotron-mini:4b, update reliability data

### DIFF
--- a/data/reliability/mathstral-7b-run-1.json
+++ b/data/reliability/mathstral-7b-run-1.json
@@ -1,0 +1,8 @@
+{
+  "model": "mathstral:7b",
+  "provider": "ollama",
+  "run": 1,
+  "answers": ["A","A","A","A","A","A","A","A","B","B","B","A","A","B","A","B"],
+  "type": "PTDF",
+  "dimensions": [4, 4, 1, 2]
+}

--- a/data/reliability/mathstral-7b-run-2.json
+++ b/data/reliability/mathstral-7b-run-2.json
@@ -1,0 +1,8 @@
+{
+  "model": "mathstral:7b",
+  "provider": "ollama",
+  "run": 2,
+  "answers": ["A","A","A","A","A","A","A","A","B","B","B","A","A","B","A","B"],
+  "type": "PTDF",
+  "dimensions": [4, 4, 1, 2]
+}

--- a/data/reliability/mathstral-7b-run-3.json
+++ b/data/reliability/mathstral-7b-run-3.json
@@ -1,0 +1,8 @@
+{
+  "model": "mathstral:7b",
+  "provider": "ollama",
+  "run": 3,
+  "answers": ["A","A","A","A","A","A","A","A","B","B","B","A","A","B","A","B"],
+  "type": "PTDF",
+  "dimensions": [4, 4, 1, 2]
+}

--- a/data/reliability/nemotron-mini-4b-run-1.json
+++ b/data/reliability/nemotron-mini-4b-run-1.json
@@ -1,0 +1,8 @@
+{
+  "model": "nemotron-mini:4b",
+  "provider": "ollama",
+  "run": 1,
+  "answers": ["B","B","B","A","B","B","B","B","B","A","B","B","A","B","A","B"],
+  "type": "REDF",
+  "dimensions": [1, 0, 1, 2]
+}

--- a/data/reliability/nemotron-mini-4b-run-2.json
+++ b/data/reliability/nemotron-mini-4b-run-2.json
@@ -1,0 +1,8 @@
+{
+  "model": "nemotron-mini:4b",
+  "provider": "ollama",
+  "run": 2,
+  "answers": ["B","B","B","A","B","B","B","B","B","A","B","B","A","B","A","B"],
+  "type": "REDF",
+  "dimensions": [1, 0, 1, 2]
+}

--- a/data/reliability/nemotron-mini-4b-run-3.json
+++ b/data/reliability/nemotron-mini-4b-run-3.json
@@ -1,0 +1,8 @@
+{
+  "model": "nemotron-mini:4b",
+  "provider": "ollama",
+  "run": 3,
+  "answers": ["B","B","B","A","B","B","B","B","B","A","B","B","A","B","A","B"],
+  "type": "REDF",
+  "dimensions": [1, 0, 1, 2]
+}

--- a/data/results.json
+++ b/data/results.json
@@ -105,7 +105,8 @@
       "provider": "ollama",
       "consistency": 100,
       "runs": 5,
-      "reliability": 1
+      "reliability": 1,
+      "reliabilityRuns": 3
     },
     {
       "name": "Qwen 2.5 7B",
@@ -158,7 +159,8 @@
       "provider": "ollama",
       "consistency": 100,
       "runs": 5,
-      "reliability": 1
+      "reliability": 1,
+      "reliabilityRuns": 3
     },
     {
       "name": "Kagura (Opus 4.7)",
@@ -311,7 +313,8 @@
       "provider": "ollama",
       "consistency": 100,
       "runs": 3,
-      "reliability": 1
+      "reliability": 1,
+      "reliabilityRuns": 3
     },
     {
       "name": "Phi-4 Mini",
@@ -364,7 +367,8 @@
       "provider": "ollama",
       "consistency": 100,
       "runs": 3,
-      "reliability": 1
+      "reliability": 1,
+      "reliabilityRuns": 3
     },
     {
       "name": "Mistral 7B",
@@ -417,7 +421,8 @@
       "provider": "ollama",
       "consistency": 100,
       "runs": 3,
-      "reliability": 1
+      "reliability": 1,
+      "reliabilityRuns": 3
     },
     {
       "name": "DeepSeek R1 7B",
@@ -470,7 +475,8 @@
       "provider": "ollama",
       "consistency": 100,
       "runs": 1,
-      "reliability": 1
+      "reliability": 1,
+      "reliabilityRuns": 3
     },
     {
       "name": "Llama 3.1 8B",
@@ -523,7 +529,8 @@
       "provider": "ollama",
       "consistency": 100,
       "runs": 3,
-      "reliability": 1
+      "reliability": 1,
+      "reliabilityRuns": 3
     },
     {
       "name": "GPT-4.1",
@@ -1828,7 +1835,8 @@
       ],
       "model": "gemma2:2b",
       "provider": "ollama",
-      "reliability": 1
+      "reliability": 1,
+      "reliabilityRuns": 3
     },
     {
       "name": "Yi 6B",
@@ -2291,7 +2299,8 @@
       ],
       "model": "qwen3:4b",
       "provider": "ollama",
-      "reliability": 1
+      "reliability": 1,
+      "reliabilityRuns": 3
     },
     {
       "name": "Qwen 3 1.7B",
@@ -2444,7 +2453,8 @@
       ],
       "model": "internlm2:7b",
       "provider": "ollama",
-      "reliability": 1
+      "reliability": 1,
+      "reliabilityRuns": 3
     },
     {
       "name": "StableLM 2 1.6B",
@@ -2495,7 +2505,8 @@
       ],
       "model": "stablelm2:1.6b",
       "provider": "ollama",
-      "reliability": 1
+      "reliability": 1,
+      "reliabilityRuns": 3
     },
     {
       "name": "Qwen 3 8B",
@@ -2546,7 +2557,8 @@
       ],
       "model": "qwen3:8b",
       "provider": "ollama",
-      "reliability": 1
+      "reliability": 1,
+      "reliabilityRuns": 3
     },
     {
       "name": "glm4:9b",
@@ -2597,7 +2609,8 @@
       ],
       "model": "glm4:9b",
       "provider": "ollama",
-      "reliability": 1
+      "reliability": 1,
+      "reliabilityRuns": 3
     },
     {
       "name": "Gemma 3 12B",
@@ -2704,6 +2717,114 @@
       "confidence": 0.375,
       "reliability": 1,
       "reliabilityRuns": 2
+    },
+    {
+      "name": "Mathstral 7B",
+      "slug": "mathstral-7b",
+      "url": "",
+      "type": "PTDF",
+      "nick": "The Strategist",
+      "testedAt": "2026-05-10T07:38:18.000Z",
+      "scores": [
+        4,
+        4,
+        1,
+        2
+      ],
+      "dimensions": [
+        {
+          "poles": [
+            "P",
+            "R"
+          ],
+          "score": 4,
+          "max": 4
+        },
+        {
+          "poles": [
+            "T",
+            "E"
+          ],
+          "score": 4,
+          "max": 4
+        },
+        {
+          "poles": [
+            "C",
+            "D"
+          ],
+          "score": 1,
+          "max": 4
+        },
+        {
+          "poles": [
+            "F",
+            "N"
+          ],
+          "score": 2,
+          "max": 4
+        }
+      ],
+      "model": "mathstral:7b",
+      "provider": "ollama",
+      "consistency": 100,
+      "runs": 3,
+      "reliability": 1,
+      "reliabilityRuns": 3
+    },
+    {
+      "name": "Nemotron Mini 4B",
+      "slug": "nemotron-mini-4b",
+      "url": "",
+      "type": "REDF",
+      "nick": "The Companion",
+      "testedAt": "2026-05-10T07:38:18.000Z",
+      "scores": [
+        1,
+        0,
+        1,
+        2
+      ],
+      "dimensions": [
+        {
+          "poles": [
+            "P",
+            "R"
+          ],
+          "score": 1,
+          "max": 4
+        },
+        {
+          "poles": [
+            "T",
+            "E"
+          ],
+          "score": 0,
+          "max": 4
+        },
+        {
+          "poles": [
+            "C",
+            "D"
+          ],
+          "score": 1,
+          "max": 4
+        },
+        {
+          "poles": [
+            "F",
+            "N"
+          ],
+          "score": 2,
+          "max": 4
+        }
+      ],
+      "model": "nemotron-mini:4b",
+      "provider": "ollama",
+      "consistency": 100,
+      "runs": 3,
+      "reliability": 1,
+      "reliabilityRuns": 3
     }
   ]
 }


### PR DESCRIPTION
## Changes

### New models tested (3 runs each, all 100% consistency)
- **Mathstral 7B** (mathstral:7b) — PTDF (The Strategist)
- **Nemotron Mini 4B** (nemotron-mini:4b) — REDF (The Companion)

### Reliability data updates
Updated reliabilityRuns field for 13 existing local Ollama models that had reliability run files but were missing the count in results.json:
- qwen2.5:3b, qwen2.5:7b, gemma3:4b, phi4-mini, mistral:7b
- deepseek-r1:7b, llama3.1:8b, gemma2:2b, qwen3:4b
- internlm2:7b, stablelm2:1.6b, qwen3:8b, glm4:9b

All showed 100% reliability (same type across all runs).

### Summary
- Total agents: 53 → 55
- Models with reliability data: 12 → 28