### PR TITLE
data: add Qwen3-32B test result (GitHub Models)

### DIFF
--- a/data/results.json
+++ b/data/results.json
@@ -2704,6 +2704,60 @@
       "confidence": 0.375,
       "reliability": 1,
       "reliabilityRuns": 2
+    },
+    {
+      "name": "Qwen3-32B",
+      "slug": "qwen3-32b",
+      "url": "",
+      "type": "PTCF",
+      "nick": "The Architect",
+      "testedAt": "2026-05-11T00:53:29.327Z",
+      "scores": [
+        4,
+        2,
+        3,
+        3
+      ],
+      "dimensions": [
+        {
+          "poles": [
+            "P",
+            "R"
+          ],
+          "score": 4,
+          "max": 4
+        },
+        {
+          "poles": [
+            "T",
+            "E"
+          ],
+          "score": 2,
+          "max": 4
+        },
+        {
+          "poles": [
+            "C",
+            "D"
+          ],
+          "score": 3,
+          "max": 4
+        },
+        {
+          "poles": [
+            "F",
+            "N"
+          ],
+          "score": 3,
+          "max": 4
+        }
+      ],
+      "model": "Qwen3-32B",
+      "provider": "github",
+      "parseFailures": 0,
+      "confidence": 1.0,
+      "reliability": 1.0,
+      "reliabilityRuns": 2
     }
   ]
 }


### PR DESCRIPTION
## Results

- **Model**: Qwen3-32B (via GitHub Models API)
- **Type**: PTCF — The Architect
- **Scores**: P=4/4, T=2/4, C=3/4, F=3/4
- **Reliability**: 100% (2 identical runs)
- **Parse failures**: 0

## Notes

- Used `--max-tokens 512` to manage reasoning token budget (Qwen3 uses `<think>` tags)
- Required `node --use-env-proxy` (Node 24 feature) — the CLI's raw `https.request` doesn't honor `https_proxy` env var, causing it to hit per-IP rate limits. See #280 for the fix.
- DeepSeek-R1 and DeepSeek-R1-0528 still rate-limited, will test in subsequent cycles.

Closes partial progress on #274.