### PR TITLE
feat(cli): honor https_proxy/http_proxy environment variables

### DIFF
--- a/cli/bin/abti.js
+++ b/cli/bin/abti.js
@@ -5,6 +5,7 @@ const readline = require('readline');
 const https = require('https');
 const http = require('http');
 const fs = require('fs');
+const { createProxyAgent } = require('../../lib/proxy');
 
 // ── Config ──────────────────────────────────────────────────────────────────
 const API_BASE = 'https://abti.kagura-agent.com';
@@ -116,6 +117,7 @@ const autoPromptFile = opt('--prompt-file') || opt('--system-prompt-file') || nu
 const llmBaseUrl = opt('--llm-base-url') || opt('--base-url') || null;
 const runsN = Math.min(Math.max(parseInt(opt('--runs') || '1', 10) || 1, 1), 10);
 const maxTokensOverride = opt('--max-tokens') ? parseInt(opt('--max-tokens'), 10) : null;
+const noProxyFlag = flag('--no-proxy');
 
 // Keep backward compat: --model and --provider used for submit metadata too
 const model = autoModel;
@@ -153,6 +155,7 @@ if (flag('--help') || flag('-h')) {
     --badge                  Print markdown badge snippet after results
     --runs <N>               Run the test N times (1-10, auto mode only)
     --max-tokens <N>         Override max_tokens for API calls (default: 2048 reasoning, 4 others)
+    --no-proxy               Ignore proxy environment variables
 
   Prompt options:
     --prompt <text>          System prompt for the agent persona (alias: --system-prompt)
@@ -176,7 +179,8 @@ if (flag('--help') || flag('-h')) {
 // ── HTTP helper ─────────────────────────────────────────────────────────────
 function httpGet(url) {
   return new Promise((resolve, reject) => {
-    https.get(url, res => {
+    const agent = createProxyAgent(url, noProxyFlag);
+    https.get(url, { agent }, res => {
       let data = '';
       res.on('data', c => data += c);
       res.on('end', () => {
@@ -191,7 +195,7 @@ function httpPost(url, body) {
   const payload = JSON.stringify(body);
   const u = new URL(url);
   return new Promise((resolve, reject) => {
-    const req = https.request({hostname: u.hostname, port: u.port || 443, path: u.pathname, method: 'POST', headers: {'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(payload)}}, res => {
+    const req = https.request({hostname: u.hostname, port: u.port || 443, path: u.pathname, method: 'POST', agent: createProxyAgent(url, noProxyFlag), headers: {'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(payload)}}, res => {
       let data = '';
       res.on('data', c => data += c);
       res.on('end', () => {
@@ -239,7 +243,11 @@ function readStdinLines() {
 function llmRequestRaw(options, payload) {
   return new Promise((resolve, reject) => {
     const mod = options.port === 443 || (!options.port && !options.protocol) || (options.protocol || 'https:') === 'https:' ? https : http;
+    const proto = options.protocol || 'https:';
     delete options.protocol;
+    // Inject proxy agent
+    const reconstructedUrl = `${proto}//${options.hostname}${options.port ? ':' + options.port : ''}${options.path}`;
+    if (!options.agent) options.agent = createProxyAgent(reconstructedUrl, noProxyFlag);
     const req = mod.request(options, res => {
       let data = '';
       res.on('data', c => data += c);

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -1,0 +1,105 @@
+'use strict';
+
+const net = require('net');
+const tls = require('tls');
+const http = require('http');
+const { URL } = require('url');
+
+// ── no_proxy check ─────────────────────────────────────────────────────────
+function shouldBypassProxy(hostname, noProxy) {
+  if (!noProxy) return false;
+  const entries = noProxy.split(',').map(e => e.trim()).filter(Boolean);
+  for (const entry of entries) {
+    if (entry === '*') return true;
+    const pattern = entry.startsWith('.') ? entry : '.' + entry;
+    if (hostname === entry || hostname.endsWith(pattern)) return true;
+  }
+  return false;
+}
+
+// ── Resolve proxy URL from env ─────────────────────────────────────────────
+function getProxyUrl(targetUrl) {
+  const parsed = new URL(targetUrl);
+  const noProxy = process.env.no_proxy || process.env.NO_PROXY || '';
+  if (shouldBypassProxy(parsed.hostname, noProxy)) return undefined;
+
+  if (parsed.protocol === 'https:') {
+    return process.env.https_proxy || process.env.HTTPS_PROXY ||
+           process.env.http_proxy || process.env.HTTP_PROXY || undefined;
+  }
+  return process.env.http_proxy || process.env.HTTP_PROXY || undefined;
+}
+
+// ── ProxyAgent (HTTP CONNECT tunnel) ───────────────────────────────────────
+class ProxyAgent extends http.Agent {
+  constructor(proxyUrl) {
+    super({ keepAlive: false });
+    this.proxy = new URL(proxyUrl);
+  }
+
+  createConnection(options, cb) {
+    const proxyHost = this.proxy.hostname;
+    const proxyPort = parseInt(this.proxy.port, 10) || (this.proxy.protocol === 'https:' ? 443 : 80);
+    const targetHost = options.host || options.hostname;
+    const targetPort = options.port || 443;
+
+    // Connect to proxy
+    const connectFn = this.proxy.protocol === 'https:'
+      ? () => tls.connect({ host: proxyHost, port: proxyPort, servername: proxyHost })
+      : () => net.connect({ host: proxyHost, port: proxyPort });
+
+    const socket = connectFn();
+
+    // Build CONNECT request
+    let connectReq = `CONNECT ${targetHost}:${targetPort} HTTP/1.1\r\nHost: ${targetHost}:${targetPort}\r\n`;
+    if (this.proxy.username || this.proxy.password) {
+      const creds = Buffer.from(`${decodeURIComponent(this.proxy.username)}:${decodeURIComponent(this.proxy.password)}`).toString('base64');
+      connectReq += `Proxy-Authorization: Basic ${creds}\r\n`;
+    }
+    connectReq += '\r\n';
+
+    socket.once('error', cb);
+    socket.write(connectReq);
+
+    let buf = '';
+    const onData = (chunk) => {
+      buf += chunk.toString();
+      const headerEnd = buf.indexOf('\r\n\r\n');
+      if (headerEnd < 0) return;
+      socket.removeListener('data', onData);
+      socket.removeListener('error', cb);
+
+      const statusLine = buf.slice(0, buf.indexOf('\r\n'));
+      const statusCode = parseInt(statusLine.split(' ')[1], 10);
+      if (statusCode !== 200) {
+        socket.destroy();
+        return cb(new Error(`Proxy CONNECT failed: ${statusLine}`));
+      }
+
+      // If target is HTTPS, wrap in TLS
+      if (options._defaultPort === 443 || options.servername || (options.port || 443) === 443) {
+        const tlsSocket = tls.connect({
+          socket,
+          host: targetHost,
+          servername: options.servername || targetHost,
+        }, () => {
+          cb(null, tlsSocket);
+        });
+        tlsSocket.once('error', cb);
+      } else {
+        cb(null, socket);
+      }
+    };
+    socket.on('data', onData);
+  }
+}
+
+// ── Factory ────────────────────────────────────────────────────────────────
+function createProxyAgent(targetUrl, noProxyFlag) {
+  if (noProxyFlag) return undefined;
+  const proxyUrl = getProxyUrl(targetUrl);
+  if (!proxyUrl) return undefined;
+  return new ProxyAgent(proxyUrl);
+}
+
+module.exports = { shouldBypassProxy, getProxyUrl, ProxyAgent, createProxyAgent };


### PR DESCRIPTION
## Summary

Fixes #281 — CLI `https.request` and `https.get` calls don't honor `https_proxy` / `HTTPS_PROXY` environment variables.

## Changes

### New: `lib/proxy.js`
Zero-dependency proxy support using only built-in Node.js modules (`http`, `net`, `tls`, `url`):
- **`shouldBypassProxy(hostname, noProxy)`** — checks `no_proxy`/`NO_PROXY` with comma-separated hostnames, `.domain` wildcards, and `*`
- **`getProxyUrl(targetUrl)`** — resolves proxy URL from env vars. For HTTPS targets: `https_proxy` → `HTTPS_PROXY` → `http_proxy` → `HTTP_PROXY`. For HTTP targets: `http_proxy` → `HTTP_PROXY`
- **`ProxyAgent`** — extends `http.Agent`, establishes HTTP CONNECT tunnels with TLS wrapping and optional `Proxy-Authorization` (Basic auth)
- **`createProxyAgent(targetUrl, noProxyFlag)`** — factory that returns a `ProxyAgent` or `undefined`

### Modified: `cli/bin/abti.js`
- Added `--no-proxy` flag to disable proxy detection
- `httpGet`: passes proxy agent to `https.get`
- `httpPost`: passes proxy agent to `https.request`
- `llmRequestRaw`: reconstructs URL from options and injects proxy agent

## Design Decisions
- **Zero runtime dependencies** — uses HTTP CONNECT tunnel pattern with built-in `net`/`tls` modules
- **Standard env var precedence** — follows the widely-adopted convention (`https_proxy` > `HTTPS_PROXY` > `http_proxy` > `HTTP_PROXY`)
- **`no_proxy` support** — comma-separated hostnames, domain patterns (`.example.com`), and wildcard (`*`)
- **CLI-only change** — GitHub Action (`action/index.js`) not modified as it has its own environment

## Testing
All 163 existing tests pass.