### PR TITLE
fix(proxy): extend https.Agent for HTTPS CONNECT tunnel

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -3,6 +3,7 @@
 const net = require('net');
 const tls = require('tls');
 const http = require('http');
+const https = require('https');
 const { URL } = require('url');
 
 // ── no_proxy check ─────────────────────────────────────────────────────────
@@ -31,7 +32,7 @@ function getProxyUrl(targetUrl) {
 }
 
 // ── ProxyAgent (HTTP CONNECT tunnel) ───────────────────────────────────────
-class ProxyAgent extends http.Agent {
+class ProxyAgent extends https.Agent {
   constructor(proxyUrl) {
     super({ keepAlive: false });
     this.proxy = new URL(proxyUrl);


### PR DESCRIPTION
## Problem

PR #282 added proxy support via `ProxyAgent` which extends `http.Agent`. However, `http.Agent` has `protocol: 'http:'`, and when passed to `https.request()` / `https.get()`, Node.js validates the agent protocol and throws:

```
TypeError [ERR_INVALID_PROTOCOL]: Protocol "https:" not supported. Expected "http:"
```

This means the proxy feature is completely broken for all HTTPS targets (which is every API call).

## Fix

Extend `https.Agent` instead of `http.Agent`. This sets `protocol: 'https:'` which is accepted by `https.request()`. The CONNECT tunnel behavior is unchanged since `createConnection` is fully overridden.

## Testing

Verified locally: proxy tunnel works correctly with `https_proxy=http://127.0.0.1:1083` for both `httpGet` and `httpPost` to HTTPS endpoints.

Closes #281 (proxy support was non-functional)