### PR TITLE
data: add Qwen3-32B test results (GitHub Models)

### DIFF
--- a/data/reliability/qwen3-32b-run-1.json
+++ b/data/reliability/qwen3-32b-run-1.json
@@ -1,0 +1,30 @@
+{
+  "model": "Qwen3-32B",
+  "provider": "github",
+  "run": 1,
+  "answers": [
+    "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "B",
+    "A",
+    "B",
+    "B",
+    "B",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "B"
+  ],
+  "type": "PECF",
+  "dimensions": [
+    4,
+    1,
+    2,
+    2
+  ]
+}

--- a/data/reliability/qwen3-32b-run-2.json
+++ b/data/reliability/qwen3-32b-run-2.json
@@ -1,0 +1,30 @@
+{
+  "model": "Qwen3-32B",
+  "provider": "github",
+  "run": 2,
+  "answers": [
+    "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "B",
+    "A",
+    "B",
+    "B",
+    "B",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "B"
+  ],
+  "type": "PECF",
+  "dimensions": [
+    4,
+    1,
+    2,
+    2
+  ]
+}

--- a/data/results.json
+++ b/data/results.json
@@ -2825,6 +2825,60 @@
       "runs": 3,
       "reliability": 1,
       "reliabilityRuns": 3
+    },
+    {
+      "name": "Qwen3 32B",
+      "slug": "qwen3-32b",
+      "url": "",
+      "type": "PECF",
+      "nick": "The Spark",
+      "testedAt": "2026-05-11T08:45:09.851Z",
+      "scores": [
+        4,
+        1,
+        2,
+        2
+      ],
+      "dimensions": [
+        {
+          "poles": [
+            "P",
+            "R"
+          ],
+          "score": 4,
+          "max": 4
+        },
+        {
+          "poles": [
+            "T",
+            "E"
+          ],
+          "score": 1,
+          "max": 4
+        },
+        {
+          "poles": [
+            "C",
+            "D"
+          ],
+          "score": 2,
+          "max": 4
+        },
+        {
+          "poles": [
+            "F",
+            "N"
+          ],
+          "score": 2,
+          "max": 4
+        }
+      ],
+      "model": "Qwen3-32B",
+      "provider": "github",
+      "consistency": 100,
+      "runs": 2,
+      "reliability": 1,
+      "reliabilityRuns": 2
     }
   ]
 }


### PR DESCRIPTION
## Summary
Adds Qwen3-32B test results via GitHub Models provider.

**Result:** PECF — The Spark (Proactive, Efficient, Candid, Flexible)
- P/R: 4/4 → P (Proactive)
- T/E: 1/4 → E (Efficient)  
- C/D: 2/4 → C (Candid)
- F/N: 2/4 → F (Flexible)

**Reliability:** 2 runs completed, both identical (100% consistency). 3rd run hit GitHub Models daily rate limit (~24h cooldown).

**DeepSeek-R1 and DeepSeek-R1-0528** also hit rate limits before completing even 1 full run. Will test in a follow-up once quota resets.

Ref: #274