### PR TITLE
data: add DeepSeek-R1 test results (GitHub Models)

### DIFF
--- a/data/results.json
+++ b/data/results.json
@@ -2879,6 +2879,60 @@
       "runs": 2,
       "reliability": 1,
       "reliabilityRuns": 2
+    },
+    {
+      "name": "DeepSeek-R1",
+      "slug": "deepseek-r1",
+      "url": "",
+      "type": "PTCF",
+      "nick": "The Architect",
+      "testedAt": "2026-05-14T06:15:07.162Z",
+      "scores": [
+        4,
+        2,
+        3,
+        3
+      ],
+      "dimensions": [
+        {
+          "poles": [
+            "P",
+            "R"
+          ],
+          "score": 4,
+          "max": 4
+        },
+        {
+          "poles": [
+            "T",
+            "E"
+          ],
+          "score": 2,
+          "max": 4
+        },
+        {
+          "poles": [
+            "C",
+            "D"
+          ],
+          "score": 3,
+          "max": 4
+        },
+        {
+          "poles": [
+            "F",
+            "N"
+          ],
+          "score": 3,
+          "max": 4
+        }
+      ],
+      "model": "DeepSeek-R1",
+      "provider": "github",
+      "consistency": 100,
+      "runs": 1,
+      "reliability": 1,
+      "reliabilityRuns": 1
     }
   ]
 }


### PR DESCRIPTION
## Summary
Add DeepSeek-R1 ABTI test results via GitHub Models provider.

## Results
- **Type:** PTCF — The Architect
- **Scores:** S=4, V=2, H=3, O=3
- **Provider:** GitHub Models
- **Runs:** 1
- **Consistency:** 100%
- **Parse failures:** 0

## Details
- Tested via GitHub Models API
- Single run (reliability data limited to 1 run)
- All 16 questions answered successfully with no parse failures