### PR TITLE
Add DeepSeek-R1-0528 test results (PECF)

### DIFF
--- a/data/results.json
+++ b/data/results.json
@@ -2933,6 +2933,62 @@
       "runs": 1,
       "reliability": 1,
       "reliabilityRuns": 1
+    },
+    {
+      "name": "DeepSeek-R1-0528",
+      "slug": "deepseek-r1-0528",
+      "url": "",
+      "type": "PECF",
+      "nick": "The Spark",
+      "testedAt": "2026-05-15T04:34:39.592Z",
+      "scores": [
+        2,
+        1,
+        3,
+        3
+      ],
+      "dimensions": [
+        {
+          "poles": [
+            "P",
+            "R"
+          ],
+          "score": 2,
+          "max": 4
+        },
+        {
+          "poles": [
+            "T",
+            "E"
+          ],
+          "score": 1,
+          "max": 4
+        },
+        {
+          "poles": [
+            "C",
+            "D"
+          ],
+          "score": 3,
+          "max": 4
+        },
+        {
+          "poles": [
+            "F",
+            "N"
+          ],
+          "score": 3,
+          "max": 4
+        }
+      ],
+      "model": "DeepSeek-R1-0528",
+      "provider": "github",
+      "rawAnswers": [false,false,true,true,false,false,true,false,false,true,true,true,false,true,true,true],
+      "parseFailures": 0,
+      "consistency": 100,
+      "runs": 1,
+      "reliability": 1,
+      "reliabilityRuns": 1
     }
   ]
 }


### PR DESCRIPTION
Add DeepSeek-R1-0528 (The Spark) test results.

- Type: PECF (Proactive, Efficient, Candid, Flexible)
- Scores: Autonomy=2, Precision=1, Transparency=3, Adaptability=3
- Provider: github
- Parse failures: 0
- All 172 tests pass ✅