### PR TITLE
feat(cli): add list subcommand to browse tested agents

### DIFF
--- a/cli/bin/abti.js
+++ b/cli/bin/abti.js
@@ -95,9 +95,11 @@ const c = {
 // ── Parse args ──────────────────────────────────────────────────────────────
 const args = process.argv.slice(2);
 
-// Detect 'test' subcommand: first non-flag arg
-const hasTestSubcommand = args.length > 0 && args[0] === 'test';
-if (hasTestSubcommand) args.shift();
+// Detect subcommand: first non-flag arg
+const subcommand = args.length > 0 && !args[0].startsWith('-') ? args[0] : null;
+const hasTestSubcommand = subcommand === 'test';
+const hasListSubcommand = subcommand === 'list';
+if (subcommand) args.shift();
 
 function flag(name) { return args.includes(name); }
 function opt(name) { const i = args.indexOf(name); return i >= 0 && i + 1 < args.length ? args[i + 1] : null; }
@@ -126,12 +128,37 @@ const model = autoModel;
 const provider = autoProvider;
 
 if (flag('--help') || flag('-h')) {
+  if (hasListSubcommand) {
+    console.log(`
+  abti list — List all tested agents from the ABTI registry
+
+  Usage:
+    npx abti list
+    npx abti list --type PTCF
+    npx abti list --provider openai
+    npx abti list --sort reliability
+    npx abti list --json
+
+  Options:
+    --type <type>            Filter by ABTI type (e.g. PTCF, RECN)
+    --provider <provider>    Filter by provider (e.g. openai, anthropic)
+    --sort <field>           Sort by: name, type, provider, reliability (default: name)
+    --json                   Output raw JSON
+    --no-proxy               Ignore proxy environment variables
+
+  Examples:
+    npx abti list --type PTCF --sort reliability
+    npx abti list --provider anthropic --json
+`);
+    process.exit(0);
+  }
   console.log(`
   abti — Agent Behavioral Type Indicator
 
   Usage:
     npx abti test --model gpt-4o --provider openai --api-key sk-...
     npx abti test --model llama3:8b --provider ollama
+    npx abti list                List all tested agents
     npx abti                    Interactive mode
 
   Test subcommand (auto mode):
@@ -494,6 +521,89 @@ async function runAuto() {
   return { answers, parseFailures };
 }
 
+// ── List subcommand ────────────────────────────────────────────────────────
+const RESULTS_URL = 'https://raw.githubusercontent.com/kagura-agent/abti/master/data/results.json';
+
+async function runList() {
+  const filterType = opt('--type');
+  const filterProvider = opt('--provider');
+  const sortField = opt('--sort') || 'name';
+
+  if (!['name', 'type', 'provider', 'reliability'].includes(sortField)) {
+    console.error(`  Invalid --sort value: "${sortField}". Must be one of: name, type, provider, reliability`);
+    process.exit(1);
+  }
+
+  let data;
+  try {
+    data = await httpGet(RESULTS_URL);
+  } catch (err) {
+    console.error(`  Failed to fetch results: ${err.message}`);
+    process.exit(1);
+  }
+
+  let agents = data.agents || [];
+
+  if (filterType) {
+    const ft = filterType.toUpperCase();
+    agents = agents.filter(a => a.type === ft);
+  }
+  if (filterProvider) {
+    const fp = filterProvider.toLowerCase();
+    agents = agents.filter(a => (a.provider || '').toLowerCase() === fp);
+  }
+
+  const sortFns = {
+    name: (a, b) => (a.name || '').localeCompare(b.name || ''),
+    type: (a, b) => (a.type || '').localeCompare(b.type || ''),
+    provider: (a, b) => (a.provider || '').localeCompare(b.provider || ''),
+    reliability: (a, b) => (b.reliability || 0) - (a.reliability || 0),
+  };
+  agents.sort(sortFns[sortField]);
+
+  if (jsonMode) {
+    console.log(JSON.stringify(agents, null, 2));
+    return;
+  }
+
+  if (agents.length === 0) {
+    console.log('\n  No agents found matching the given filters.\n');
+    return;
+  }
+
+  // Compute column widths
+  const rows = agents.map(a => ({
+    name: a.name || a.slug || '?',
+    provider: a.provider || '—',
+    type: a.type || '?',
+    nick: a.nick || '—',
+    reliability: a.reliability != null ? (a.reliability * 100).toFixed(0) + '%' : '—',
+  }));
+
+  const cols = ['name', 'provider', 'type', 'nick', 'reliability'];
+  const headers = { name: 'Name', provider: 'Provider', type: 'Type', nick: 'Nickname', reliability: 'Reliability' };
+  const widths = {};
+  for (const col of cols) {
+    widths[col] = Math.max(headers[col].length, ...rows.map(r => r[col].length));
+  }
+
+  const pad = (s, w) => s + ' '.repeat(Math.max(0, w - s.length));
+  const headerLine = cols.map(col => pad(headers[col], widths[col])).join('  ');
+  const separator = cols.map(col => '─'.repeat(widths[col])).join('──');
+
+  console.log(`\n  ${c.bold}${headerLine}${c.reset}`);
+  console.log(`  ${separator}`);
+  for (const row of rows) {
+    const line = cols.map(col => {
+      const val = row[col];
+      if (col === 'type') return c.boldCyan + pad(val, widths[col]) + c.reset;
+      return pad(val, widths[col]);
+    }).join('  ');
+    console.log(`  ${line}`);
+  }
+  console.log(`\n  ${c.dim}${agents.length} agent(s)${c.reset}\n`);
+}
+
 // ── Interactive quiz ────────────────────────────────────────────────────────
 async function run() {
   let answers;
@@ -772,7 +882,11 @@ async function runInteractive() {
 }
 
 if (require.main === module) {
-  run().catch(err => { console.error(err.message); process.exit(1); });
+  if (hasListSubcommand) {
+    runList().catch(err => { console.error(err.message); process.exit(1); });
+  } else {
+    run().catch(err => { console.error(err.message); process.exit(1); });
+  }
 }
 
 module.exports = { parseAnswer, callLLM, loadState, saveState, defaultStateFile };

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "abti",
   "private": true,
   "scripts": {
-    "test": "node --test test/api.test.js test/mcp.test.js test/mcp-http.test.js test/compatibility.test.js test/cross-compatibility.test.js test/auto-reload.test.js test/parseAnswer.test.js test/provider.test.js test/resume.test.js",
+    "test": "node --test test/api.test.js test/mcp.test.js test/mcp-http.test.js test/compatibility.test.js test/cross-compatibility.test.js test/auto-reload.test.js test/parseAnswer.test.js test/provider.test.js test/resume.test.js test/list.test.js",
     "generate-og": "node scripts/generate-og-images.js"
   },
   "devDependencies": {

--- a/test/list-preload.js
+++ b/test/list-preload.js
@@ -1,0 +1,37 @@
+'use strict';
+
+// Preload script: intercept https.get calls to the results URL and return mock data.
+// Usage: node --require ./test/list-preload.js cli/bin/abti.js list ...
+
+const https = require('https');
+const originalGet = https.get;
+
+const RESULTS_URL = 'https://raw.githubusercontent.com/kagura-agent/abti/master/data/results.json';
+
+const MOCK_AGENTS = [
+  { name: 'Alpha Bot', slug: 'alpha-bot', type: 'PTCF', nick: 'The Architect', provider: 'openai', model: 'gpt-4o', reliability: 0.95 },
+  { name: 'Beta Bot', slug: 'beta-bot', type: 'REDN', nick: 'The Diplomat', provider: 'anthropic', model: 'claude-3', reliability: 0.80 },
+  { name: 'Gamma Bot', slug: 'gamma-bot', type: 'PTCF', nick: 'The Architect', provider: 'openai', model: 'gpt-4o-mini', reliability: 1.0 },
+  { name: 'Delta Bot', slug: 'delta-bot', type: 'RECF', nick: 'The Mentor', provider: 'google', model: 'gemini-pro', reliability: 0.60 },
+  { name: 'Epsilon Bot', slug: 'epsilon-bot', type: 'REDN', nick: 'The Diplomat', provider: 'anthropic', model: 'claude-3.5', reliability: null },
+];
+
+https.get = function patchedGet(url, opts, cb) {
+  const urlStr = typeof url === 'string' ? url : url.href;
+  if (urlStr === RESULTS_URL) {
+    if (typeof opts === 'function') { cb = opts; opts = {}; }
+    const json = JSON.stringify({ agents: MOCK_AGENTS });
+    const { PassThrough } = require('stream');
+    const res = new PassThrough();
+    res.statusCode = 200;
+    res.headers = { 'content-type': 'application/json' };
+    process.nextTick(() => {
+      if (cb) cb(res);
+      res.end(json);
+    });
+    // Return a fake request object with on('error') support
+    const fakeReq = new (require('events').EventEmitter)();
+    return fakeReq;
+  }
+  return originalGet.call(this, url, opts, cb);
+};

--- a/test/list.test.js
+++ b/test/list.test.js
@@ -1,0 +1,157 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const { execFile } = require('node:child_process');
+const path = require('node:path');
+
+const CLI = path.resolve(__dirname, '..', 'cli', 'bin', 'abti.js');
+const PRELOAD = path.resolve(__dirname, 'list-preload.js');
+
+function runList(extraArgs = []) {
+  return new Promise((resolve, reject) => {
+    execFile(process.execPath, ['--require', PRELOAD, CLI, 'list', ...extraArgs], {
+      timeout: 10000,
+      env: { ...process.env, NO_COLOR: '1' },
+    }, (err, stdout, stderr) => {
+      resolve({ code: err ? err.code : 0, stdout, stderr });
+    });
+  });
+}
+
+describe('abti list subcommand', () => {
+  it('shows all agents in table format by default', async () => {
+    const { code, stdout } = await runList();
+    assert.equal(code, 0);
+    assert.ok(stdout.includes('Alpha Bot'));
+    assert.ok(stdout.includes('Beta Bot'));
+    assert.ok(stdout.includes('Gamma Bot'));
+    assert.ok(stdout.includes('Delta Bot'));
+    assert.ok(stdout.includes('Epsilon Bot'));
+    assert.ok(stdout.includes('5 agent(s)'));
+  });
+
+  it('filters by --type', async () => {
+    const { code, stdout } = await runList(['--type', 'PTCF']);
+    assert.equal(code, 0);
+    assert.ok(stdout.includes('Alpha Bot'));
+    assert.ok(stdout.includes('Gamma Bot'));
+    assert.ok(!stdout.includes('Beta Bot'));
+    assert.ok(!stdout.includes('Delta Bot'));
+    assert.ok(stdout.includes('2 agent(s)'));
+  });
+
+  it('--type is case insensitive', async () => {
+    const { code, stdout } = await runList(['--type', 'ptcf']);
+    assert.equal(code, 0);
+    assert.ok(stdout.includes('Alpha Bot'));
+    assert.ok(stdout.includes('Gamma Bot'));
+  });
+
+  it('filters by --provider', async () => {
+    const { code, stdout } = await runList(['--provider', 'anthropic']);
+    assert.equal(code, 0);
+    assert.ok(stdout.includes('Beta Bot'));
+    assert.ok(stdout.includes('Epsilon Bot'));
+    assert.ok(!stdout.includes('Alpha Bot'));
+    assert.ok(!stdout.includes('Delta Bot'));
+  });
+
+  it('--provider is case insensitive', async () => {
+    const { code, stdout } = await runList(['--provider', 'OpenAI']);
+    assert.equal(code, 0);
+    assert.ok(stdout.includes('Alpha Bot'));
+    assert.ok(stdout.includes('Gamma Bot'));
+  });
+
+  it('combines --type and --provider filters', async () => {
+    const { code, stdout } = await runList(['--type', 'PTCF', '--provider', 'openai']);
+    assert.equal(code, 0);
+    assert.ok(stdout.includes('Alpha Bot'));
+    assert.ok(stdout.includes('Gamma Bot'));
+    assert.ok(!stdout.includes('Beta Bot'));
+  });
+
+  it('outputs JSON with --json flag', async () => {
+    const { code, stdout } = await runList(['--json']);
+    assert.equal(code, 0);
+    const agents = JSON.parse(stdout);
+    assert.ok(Array.isArray(agents));
+    assert.equal(agents.length, 5);
+    assert.equal(agents[0].name, 'Alpha Bot');
+  });
+
+  it('--json respects filters', async () => {
+    const { code, stdout } = await runList(['--json', '--type', 'REDN']);
+    assert.equal(code, 0);
+    const agents = JSON.parse(stdout);
+    assert.equal(agents.length, 2);
+    assert.ok(agents.every(a => a.type === 'REDN'));
+  });
+
+  it('errors on invalid --sort value', async () => {
+    const { code, stderr } = await runList(['--sort', 'invalid']);
+    assert.notEqual(code, 0);
+    assert.ok(stderr.includes('Invalid --sort value'));
+    assert.ok(stderr.includes('invalid'));
+  });
+
+  it('shows "No agents found" when filters match nothing', async () => {
+    const { code, stdout } = await runList(['--type', 'XXXX']);
+    assert.equal(code, 0);
+    assert.ok(stdout.includes('No agents found'));
+  });
+
+  it('sorts by name by default', async () => {
+    const { code, stdout } = await runList(['--json']);
+    assert.equal(code, 0);
+    const agents = JSON.parse(stdout);
+    const names = agents.map(a => a.name);
+    const sorted = [...names].sort((a, b) => a.localeCompare(b));
+    assert.deepEqual(names, sorted);
+  });
+
+  it('sorts by reliability descending', async () => {
+    const { code, stdout } = await runList(['--json', '--sort', 'reliability']);
+    assert.equal(code, 0);
+    const agents = JSON.parse(stdout);
+    // Gamma (1.0), Alpha (0.95), Beta (0.80), Delta (0.60), Epsilon (null→0)
+    assert.equal(agents[0].name, 'Gamma Bot');
+    assert.equal(agents[1].name, 'Alpha Bot');
+    assert.equal(agents[2].name, 'Beta Bot');
+    assert.equal(agents[3].name, 'Delta Bot');
+    assert.equal(agents[4].name, 'Epsilon Bot');
+  });
+
+  it('sorts by type', async () => {
+    const { code, stdout } = await runList(['--json', '--sort', 'type']);
+    assert.equal(code, 0);
+    const agents = JSON.parse(stdout);
+    const types = agents.map(a => a.type);
+    const sorted = [...types].sort((a, b) => a.localeCompare(b));
+    assert.deepEqual(types, sorted);
+  });
+
+  it('sorts by provider', async () => {
+    const { code, stdout } = await runList(['--json', '--sort', 'provider']);
+    assert.equal(code, 0);
+    const agents = JSON.parse(stdout);
+    const providers = agents.map(a => a.provider);
+    const sorted = [...providers].sort((a, b) => a.localeCompare(b));
+    assert.deepEqual(providers, sorted);
+  });
+
+  it('table output includes headers', async () => {
+    const { code, stdout } = await runList();
+    assert.equal(code, 0);
+    assert.ok(stdout.includes('Name'));
+    assert.ok(stdout.includes('Provider'));
+    assert.ok(stdout.includes('Type'));
+    assert.ok(stdout.includes('Reliability'));
+  });
+
+  it('table shows reliability as percentage', async () => {
+    const { code, stdout } = await runList();
+    assert.equal(code, 0);
+    assert.ok(stdout.includes('95%'));
+    assert.ok(stdout.includes('100%'));
+  });
+});


### PR DESCRIPTION
Closes #290

Adds a `list` subcommand to browse all tested agents from the command line:

```bash
npx @kagura-agent/abti list
npx @kagura-agent/abti list --type PTCF
npx @kagura-agent/abti list --provider ollama
npx @kagura-agent/abti list --json
npx @kagura-agent/abti list --sort reliability
```

Fetches results from the public GitHub data and displays a formatted table with columns: Name, Provider, Type, Nickname, Reliability.

Supports filtering by `--type` and `--provider`, JSON output with `--json`, and sorting with `--sort` (name/type/provider/reliability).