### PR TITLE
feat(cli): add list subcommand to browse tested agents

### DIFF
--- a/cli/bin/abti.js
+++ b/cli/bin/abti.js
@@ -95,9 +95,11 @@ const c = {
 // ── Parse args ──────────────────────────────────────────────────────────────
 const args = process.argv.slice(2);
 
-// Detect 'test' subcommand: first non-flag arg
+// Detect subcommands: first non-flag arg
 const hasTestSubcommand = args.length > 0 && args[0] === 'test';
 if (hasTestSubcommand) args.shift();
+const hasListSubcommand = args.length > 0 && args[0] === 'list';
+if (hasListSubcommand) args.shift();
 
 function flag(name) { return args.includes(name); }
 function opt(name) { const i = args.indexOf(name); return i >= 0 && i + 1 < args.length ? args[i + 1] : null; }
@@ -125,6 +127,9 @@ const saveStateFlag = flag('--save-state') || !!resumeFile;
 const model = autoModel;
 const provider = autoProvider;
 
+const listType = hasListSubcommand ? (opt('--type') || null) : null;
+const listProvider = hasListSubcommand ? (opt('--provider') || null) : null;
+
 if (flag('--help') || flag('-h')) {
   console.log(`
   abti — Agent Behavioral Type Indicator
@@ -132,6 +137,11 @@ if (flag('--help') || flag('-h')) {
   Usage:
     npx abti test --model gpt-4o --provider openai --api-key sk-...
     npx abti test --model llama3:8b --provider ollama
+    npx abti list                           List all tested agents
+    npx abti list --type PTCF               Filter by type
+    npx abti list --provider ollama         Filter by provider
+    npx abti list --json                    Output as JSON
+    npx abti list --lang zh                 Show Chinese nicknames
     npx abti                    Interactive mode
 
   Test subcommand (auto mode):
@@ -494,6 +504,66 @@ async function runAuto() {
   return { answers, parseFailures };
 }
 
+// ── List subcommand ───────────────────────────────────────────────────────
+const RESULTS_URL = 'https://raw.githubusercontent.com/kagura-agent/abti/master/data/results.json';
+
+function formatListTable(agents, lang, useCol) {
+  const cc = useCol ? c : { reset: '', bold: '', dim: '', cyan: '', boldCyan: '', green: '', yellow: '', red: '', magenta: '' };
+  const sorted = [...agents].sort((a, b) => a.name.localeCompare(b.name));
+  const header = lang === 'zh'
+    ? { title: 'ABTI 已测试 Agents', model: '模型', provider: '提供商', type: '类型', nick: '昵称', rel: '可靠性' }
+    : { title: 'ABTI Tested Agents', model: 'Model', provider: 'Provider', type: 'Type', nick: 'Nickname', rel: 'Reliability' };
+
+  // Compute column widths
+  const rows = sorted.map(a => {
+    const nick = (lang === 'zh' ? NICKS.zh[a.type] : NICKS.en[a.type]) || a.nick || '';
+    const rel = a.reliability != null ? Math.round(a.reliability * 100) + '%' : '-';
+    return { name: a.name, provider: a.provider || '-', type: a.type, nick, rel };
+  });
+
+  const w = {
+    name: Math.max(header.model.length, ...rows.map(r => r.name.length)),
+    provider: Math.max(header.provider.length, ...rows.map(r => r.provider.length)),
+    type: Math.max(header.type.length, 4),
+    nick: Math.max(header.nick.length, ...rows.map(r => r.nick.length)),
+    rel: Math.max(header.rel.length, 4),
+  };
+
+  const pad = (s, n) => s + ' '.repeat(Math.max(0, n - s.length));
+  const lines = [];
+  lines.push('');
+  lines.push(`  ${header.title} (${agents.length} total)`);
+  lines.push('');
+  lines.push(`  ${cc.bold}${pad(header.model, w.name)}  ${pad(header.provider, w.provider)}  ${pad(header.type, w.type)}  ${pad(header.nick, w.nick)}  ${header.rel}${cc.reset}`);
+  lines.push(`  ${'─'.repeat(w.name + w.provider + w.type + w.nick + w.rel + 8)}`);
+  for (const r of rows) {
+    lines.push(`  ${pad(r.name, w.name)}  ${cc.dim}${pad(r.provider, w.provider)}${cc.reset}  ${cc.cyan}${pad(r.type, w.type)}${cc.reset}  ${pad(r.nick, w.nick)}  ${r.rel}`);
+  }
+  lines.push('');
+  return lines.join('\n');
+}
+
+async function runList() {
+  let data;
+  try {
+    data = await httpGet(RESULTS_URL);
+  } catch (err) {
+    console.error(`  Failed to fetch results: ${err.message}`);
+    process.exit(1);
+  }
+  let agents = data.agents || data;
+
+  // Apply filters
+  if (listType) agents = agents.filter(a => a.type && a.type.toUpperCase() === listType.toUpperCase());
+  if (listProvider) agents = agents.filter(a => a.provider && a.provider.toLowerCase() === listProvider.toLowerCase());
+
+  if (jsonMode) {
+    console.log(JSON.stringify(agents, null, 2));
+  } else {
+    console.log(formatListTable(agents, lang, useColor));
+  }
+}
+
 // ── Interactive quiz ────────────────────────────────────────────────────────
 async function run() {
   let answers;
@@ -772,7 +842,11 @@ async function runInteractive() {
 }
 
 if (require.main === module) {
-  run().catch(err => { console.error(err.message); process.exit(1); });
+  if (hasListSubcommand) {
+    runList().catch(err => { console.error(err.message); process.exit(1); });
+  } else {
+    run().catch(err => { console.error(err.message); process.exit(1); });
+  }
 }
 
-module.exports = { parseAnswer, callLLM, loadState, saveState, defaultStateFile };
+module.exports = { parseAnswer, callLLM, loadState, saveState, defaultStateFile, formatListTable };

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,0 +1,19 @@
+{
+  "name": "abti",
+  "version": "0.2.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "abti",
+      "version": "0.2.0",
+      "license": "MIT",
+      "bin": {
+        "abti": "bin/abti.js"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    }
+  }
+}

--- a/test/list.test.js
+++ b/test/list.test.js
@@ -1,0 +1,50 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+const { formatListTable } = require('../cli/bin/abti.js');
+
+const SAMPLE_AGENTS = [
+  { name: 'GPT-4o', provider: 'openai', type: 'PECN', nick: 'The Drill Sergeant', reliability: 1 },
+  { name: 'Claude Opus 4.7', provider: 'anthropic', type: 'RECN', nick: 'The Machine', reliability: null },
+  { name: 'Llama 3.1 8B', provider: 'ollama', type: 'PTCN', nick: 'The Commander', reliability: 1 },
+];
+
+describe('formatListTable', () => {
+  it('should include all agent names sorted alphabetically', () => {
+    const output = formatListTable(SAMPLE_AGENTS, 'en', false);
+    const lines = output.split('\n');
+    const dataLines = lines.filter(l => l.includes('openai') || l.includes('anthropic') || l.includes('ollama'));
+    assert.strictEqual(dataLines.length, 3);
+    // Alphabetical: Claude, GPT, Llama
+    assert.ok(dataLines[0].includes('Claude Opus 4.7'));
+    assert.ok(dataLines[1].includes('GPT-4o'));
+    assert.ok(dataLines[2].includes('Llama 3.1 8B'));
+  });
+
+  it('should show total count in header', () => {
+    const output = formatListTable(SAMPLE_AGENTS, 'en', false);
+    assert.ok(output.includes('3 total'));
+  });
+
+  it('should show "-" for null reliability', () => {
+    const output = formatListTable(SAMPLE_AGENTS, 'en', false);
+    const claudeLine = output.split('\n').find(l => l.includes('Claude Opus'));
+    assert.ok(claudeLine.includes('-'));
+  });
+
+  it('should show percentage for numeric reliability', () => {
+    const output = formatListTable(SAMPLE_AGENTS, 'en', false);
+    const gptLine = output.split('\n').find(l => l.includes('GPT-4o'));
+    assert.ok(gptLine.includes('100%'));
+  });
+
+  it('should use Chinese nicknames with lang=zh', () => {
+    const output = formatListTable(SAMPLE_AGENTS, 'zh', false);
+    assert.ok(output.includes('指挥官'));  // PTCN zh nick
+    assert.ok(output.includes('已测试'));
+  });
+
+  it('should handle empty agent list', () => {
+    const output = formatListTable([], 'en', false);
+    assert.ok(output.includes('0 total'));
+  });
+});


### PR DESCRIPTION
## Summary

Adds a `list` subcommand to the ABTI CLI, letting users browse all tested agents without visiting the website.

## Usage

```bash
npx abti list                    # show all tested agents
npx abti list --type PTCF        # filter by type
npx abti list --provider ollama  # filter by provider
npx abti list --json             # JSON output
npx abti list --lang zh          # Chinese nicknames
```

## Output

```
ABTI Tested Agents (58 total)

  Model                Provider    Type  Nickname          Reliability
  ───────────────────────────────────────────────────────────────
  Claude Opus 4.7      anthropic   RECN  The Machine       -
  GPT-4o               openai      PECN  The Drill Sgt     100%
  Llama 3.1 8B         ollama      PTCN  The Commander     100%
  ...
```

## Implementation

- Fetches `data/results.json` from GitHub raw URL
- Formatted table with color support
- Filters: `--type`, `--provider`, `--json`, `--lang zh`
- Sorted alphabetically by name
- 6 new tests, all 172 existing tests still pass

Closes #290