### PR TITLE
fix: include list.test.js in npm test script

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "abti",
   "private": true,
   "scripts": {
-    "test": "node --test test/api.test.js test/mcp.test.js test/mcp-http.test.js test/compatibility.test.js test/cross-compatibility.test.js test/auto-reload.test.js test/parseAnswer.test.js test/provider.test.js test/resume.test.js",
+    "test": "node --test test/api.test.js test/mcp.test.js test/mcp-http.test.js test/compatibility.test.js test/cross-compatibility.test.js test/auto-reload.test.js test/parseAnswer.test.js test/provider.test.js test/resume.test.js test/list.test.js",
     "generate-og": "node scripts/generate-og-images.js"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

Add `test/list.test.js` to the `npm test` script in `package.json`.

## Problem

The list subcommand tests (6 tests) were created in #290/#292 but the `npm test` script was never updated to include them. This means list formatting regressions go undetected in CI.

## Changes

- Added `test/list.test.js` to the test runner in `package.json`

## Verification

```
Before: 172 tests (all pass)
After:  178 tests (all pass, +6 from list.test.js)
```

Fixes #299