### PR TITLE
fix(cli,action): GitHub Models provider 404 — wrong API path

### DIFF
--- a/action/index.js
+++ b/action/index.js
@@ -105,10 +105,11 @@ function httpPostJSON(url, body) {
 /**
  * Call OpenAI chat completions API.
  */
-function callOpenAI(apiKey, model, systemPrompt, userMessage, baseUrl) {
+function callOpenAI(apiKey, model, systemPrompt, userMessage, baseUrl, chatPath) {
   return new Promise((resolve, reject) => {
+    const suffix = chatPath || '/v1/chat/completions';
     const parsed = baseUrl
-      ? new URL(baseUrl.replace(/\/+$/, '') + '/v1/chat/completions')
+      ? new URL(baseUrl.replace(/\/+$/, '') + suffix)
       : new URL('https://api.openai.com/v1/chat/completions');
     const mod = parsed.protocol === 'https:' ? https : http;
     const payload = JSON.stringify({
@@ -250,7 +251,7 @@ function callLLM(provider, apiKey, model, systemPrompt, userMessage, baseUrl) {
   if (provider === 'openai') return callOpenAI(apiKey, model, systemPrompt, userMessage, baseUrl);
   if (provider === 'anthropic') return callAnthropic(apiKey, model, systemPrompt, userMessage, baseUrl);
   if (provider === 'gemini') return callGemini(apiKey, model, systemPrompt, userMessage);
-  if (provider === 'github') return callOpenAI(apiKey, model, systemPrompt, userMessage, baseUrl || 'https://models.inference.ai.azure.com');
+  if (provider === 'github') return callOpenAI(apiKey, model, systemPrompt, userMessage, baseUrl || 'https://models.inference.ai.azure.com', '/chat/completions');
   if (provider === 'groq') return callOpenAI(apiKey, model, systemPrompt, userMessage, baseUrl || 'https://api.groq.com/openai');
   if (provider === 'openrouter') return callOpenAI(apiKey, model, systemPrompt, userMessage, baseUrl || 'https://openrouter.ai/api/v1');
   if (provider === 'mistral') return callOpenAI(apiKey, model, systemPrompt, userMessage, baseUrl || 'https://api.mistral.ai/v1');

--- a/cli/bin/abti.js
+++ b/cli/bin/abti.js
@@ -297,8 +297,9 @@ async function llmRequest(options, payload) {
   }
 }
 
-function callOpenAI(apiKey, mdl, systemPrompt, userMessage, baseUrl, options, maxTokens) {
-  const parsed = baseUrl ? new URL(baseUrl.replace(/\/+$/, '') + '/v1/chat/completions') : new URL('https://api.openai.com/v1/chat/completions');
+function callOpenAI(apiKey, mdl, systemPrompt, userMessage, baseUrl, options, maxTokens, chatPath) {
+  const suffix = chatPath || '/v1/chat/completions';
+  const parsed = baseUrl ? new URL(baseUrl.replace(/\/+$/, '') + suffix) : new URL('https://api.openai.com/v1/chat/completions');
   const maxTok = maxTokens || (isReasoningModel(mdl) ? 2048 : 4);
   const payload = JSON.stringify({ model: mdl, messages: [{ role: 'system', content: systemPrompt }, { role: 'user', content: userMessage }], max_tokens: maxTok, temperature: 0, ...options });
   return llmRequest({ hostname: parsed.hostname, port: parsed.port, path: parsed.pathname + parsed.search, method: 'POST', protocol: parsed.protocol, headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${apiKey}`, 'Content-Length': Buffer.byteLength(payload) } }, payload)
@@ -327,7 +328,7 @@ function callLLM(prov, apiKey, mdl, systemPrompt, userMessage, baseUrl, maxToken
   if (prov === 'anthropic') return callAnthropic(apiKey, mdl, systemPrompt, userMessage, baseUrl, maxTokens);
   if (prov === 'gemini') return callGemini(apiKey, mdl, systemPrompt, userMessage, maxTokens);
   if (prov === 'deepseek') return callOpenAI(apiKey, mdl, systemPrompt, userMessage, 'https://api.deepseek.com', undefined, maxTokens);
-  if (prov === 'github') return callOpenAI(apiKey, mdl, systemPrompt, userMessage, baseUrl || 'https://models.inference.ai.azure.com', undefined, maxTokens);
+  if (prov === 'github') return callOpenAI(apiKey, mdl, systemPrompt, userMessage, baseUrl || 'https://models.inference.ai.azure.com', undefined, maxTokens, '/chat/completions');
   if (prov === 'groq') return callOpenAI(apiKey, mdl, systemPrompt, userMessage, baseUrl || 'https://api.groq.com/openai', undefined, maxTokens);
   if (prov === 'openrouter') return callOpenAI(apiKey, mdl, systemPrompt, userMessage, baseUrl || 'https://openrouter.ai/api/v1', undefined, maxTokens);
   if (prov === 'mistral') return callOpenAI(apiKey, mdl, systemPrompt, userMessage, baseUrl || 'https://api.mistral.ai/v1', undefined, maxTokens);


### PR DESCRIPTION
## Problem

All `--provider github` requests return 404:
```
npx @kagura-agent/abti test --provider github --model gpt-4.1
# → LLM API returned 404: {"error":{"code":"404","message": "Resource not found"}}
```

## Root Cause

`callOpenAI()` constructs the URL as `baseUrl + '/v1/chat/completions'`. GitHub Models API uses `/chat/completions` (no `/v1/` prefix):

| URL | Status |
|---|---|
| `https://models.inference.ai.azure.com/v1/chat/completions` | ❌ 404 |
| `https://models.inference.ai.azure.com/chat/completions` | ✅ Works |

## Fix

Add `chatPath` parameter to `callOpenAI()` (defaults to `/v1/chat/completions`). The GitHub provider passes `/chat/completions`.

Applied to both `cli/bin/abti.js` and `action/index.js`.

## Verification

```bash
# Before fix: 404
# After fix:
$ node cli/bin/abti.js test --provider github --model gpt-4.1 --json
{"type":"PTCN","nickname":"The Commander",...}
```

All 178 existing tests pass.

Fixes #302