### PR TITLE
data: add reliability scores for GPT-4o mini (GitHub Models)

### DIFF
--- a/data/results.json
+++ b/data/results.json
@@ -688,14 +688,14 @@
       "name": "GPT-4o mini",
       "slug": "gpt-4o-mini",
       "url": "",
-      "type": "PTCN",
-      "nick": "The Commander",
-      "testedAt": "2026-05-02T14:46:35.029Z",
+      "type": "PTCF",
+      "nick": "The Architect",
+      "testedAt": "2026-05-16T04:45:15.000Z",
       "scores": [
         3,
-        2,
-        3,
-        1
+        4,
+        4,
+        2
       ],
       "dimensions": [
         {
@@ -711,7 +711,7 @@
             "T",
             "E"
           ],
-          "score": 2,
+          "score": 4,
           "max": 4
         },
         {
@@ -719,7 +719,7 @@
             "C",
             "D"
           ],
-          "score": 3,
+          "score": 4,
           "max": 4
         },
         {
@@ -727,12 +727,14 @@
             "F",
             "N"
           ],
-          "score": 1,
+          "score": 2,
           "max": 4
         }
       ],
       "model": "gpt-4o-mini",
-      "provider": "openai"
+      "provider": "openai",
+      "reliability": 1,
+      "reliabilityRuns": 3
     },
     {
       "name": "GPT-5.2",


### PR DESCRIPTION
## Summary

Add reliability testing results for GPT-4o mini on GitHub Models provider.

### Results

| Model | Runs | Results | Reliability |
|-------|------|---------|-------------|
| GPT-4o mini | 3/3 | PTCF, PTCF, PTCF | 100% |

Updated type from PTCN → PTCF based on consistent 3-run reliability testing (newer, more comprehensive than original single run).

### Blocked Models

The following models from #301 could not be completed:

- **Llama-4-Scout-17B-16E-Instruct**: 429 rate limit with ~10h cooldown on first request
- **Llama-4-Maverick-17B-128E-Instruct-FP8**: Completed 1/3 runs (PTCN), then hit 429 rate limit (~10h cooldown)
- **Phi-4-mini-reasoning**: Parser fails — model returns `<think>` reasoning tags that the response parser can't handle (related to #237)

### Testing

All 178 tests pass.

Partial fix for #301.