### PR TITLE
data: reliability batch 4 — gpt-4o-mini & Phi-4-mini-reasoning

### DIFF
--- a/data/reliability/gpt-4o-mini-run-1.json
+++ b/data/reliability/gpt-4o-mini-run-1.json
@@ -1,0 +1,15 @@
+{
+  "type": "PTCF",
+  "nick": "The Architect",
+  "desc": "Proactive, thorough, candid, flexible. Takes charge, covers every angle, tells it straight, and pivots on a dime.",
+  "scores": [
+    3,
+    4,
+    4,
+    2
+  ],
+  "badge": "https://abti.kagura-agent.com/badge/PTCF",
+  "model": "gpt-4o-mini",
+  "provider": "github"
+}
+

--- a/data/reliability/gpt-4o-mini-run-2.json
+++ b/data/reliability/gpt-4o-mini-run-2.json
@@ -1,0 +1,15 @@
+{
+  "type": "PTCF",
+  "nick": "The Architect",
+  "desc": "Proactive, thorough, candid, flexible. Takes charge, covers every angle, tells it straight, and pivots on a dime.",
+  "scores": [
+    3,
+    4,
+    4,
+    2
+  ],
+  "badge": "https://abti.kagura-agent.com/badge/PTCF",
+  "model": "gpt-4o-mini",
+  "provider": "github"
+}
+

--- a/data/reliability/gpt-4o-mini-run-3.json
+++ b/data/reliability/gpt-4o-mini-run-3.json
@@ -1,0 +1,15 @@
+{
+  "type": "PTCF",
+  "nick": "The Architect",
+  "desc": "Proactive, thorough, candid, flexible. Takes charge, covers every angle, tells it straight, and pivots on a dime.",
+  "scores": [
+    3,
+    4,
+    3,
+    2
+  ],
+  "badge": "https://abti.kagura-agent.com/badge/PTCF",
+  "model": "gpt-4o-mini",
+  "provider": "github"
+}
+

--- a/data/results.json
+++ b/data/results.json
@@ -732,7 +732,8 @@
         }
       ],
       "model": "gpt-4o-mini",
-      "provider": "openai"
+      "provider": "openai",
+      "reliability": 100
     },
     {
       "name": "GPT-5.2",
@@ -2408,7 +2409,8 @@
         }
       ],
       "model": "Phi-4-mini-reasoning",
-      "provider": "github"
+      "provider": "github",
+      "reliability": 0
     },
     {
       "name": "InternLM2 7B",


### PR DESCRIPTION
## Reliability Tests (Batch 4)

### gpt-4o-mini (GitHub Models)
- **Reliability: 100%** — 3/3 runs returned PTCF
- Run 1: PTCF [3,4,4,2]
- Run 2: PTCF [3,4,4,2]
- Run 3: PTCF [3,4,3,2]
- Very consistent. Only dimension 3 (Candor) varied between 3-4.

### Phi-4-mini-reasoning (GitHub Models)
- **Reliability: 0%** — 0/3 runs succeeded
- All 3 attempts failed with parse errors
- The model outputs `<think>` reasoning tags before answering, which the ABTI forced-choice parser cannot handle
- This is a known limitation: reasoning models that emit chain-of-thought tags need special handling

### Files
- `data/reliability/gpt-4o-mini-run-{1,2,3}.json` — raw test outputs
- `data/results.json` — updated reliability scores