### PR TITLE
data: add reliability score for Aya Expanse 8B

### DIFF
--- a/data/reliability/aya-expanse-8b-run-1.json
+++ b/data/reliability/aya-expanse-8b-run-1.json
@@ -1,0 +1,30 @@
+{
+  "model": "aya-expanse:8b",
+  "provider": "ollama",
+  "run": 1,
+  "answers": [
+    "A",
+    "B",
+    "B",
+    "A",
+    "A",
+    "B",
+    "B",
+    "B",
+    "A",
+    "B",
+    "A",
+    "A",
+    "B",
+    "B",
+    "A",
+    "B"
+  ],
+  "type": "PECN",
+  "dimensions": [
+    2,
+    1,
+    3,
+    1
+  ]
+}

--- a/data/reliability/aya-expanse-8b-run-2.json
+++ b/data/reliability/aya-expanse-8b-run-2.json
@@ -1,0 +1,30 @@
+{
+  "model": "aya-expanse:8b",
+  "provider": "ollama",
+  "run": 2,
+  "answers": [
+    "A",
+    "B",
+    "B",
+    "A",
+    "A",
+    "B",
+    "B",
+    "B",
+    "A",
+    "B",
+    "A",
+    "A",
+    "B",
+    "B",
+    "A",
+    "B"
+  ],
+  "type": "PECN",
+  "dimensions": [
+    2,
+    1,
+    3,
+    1
+  ]
+}

--- a/data/reliability/aya-expanse-8b-run-3.json
+++ b/data/reliability/aya-expanse-8b-run-3.json
@@ -1,0 +1,30 @@
+{
+  "model": "aya-expanse:8b",
+  "provider": "ollama",
+  "run": 3,
+  "answers": [
+    "A",
+    "B",
+    "B",
+    "A",
+    "A",
+    "B",
+    "B",
+    "B",
+    "A",
+    "B",
+    "A",
+    "A",
+    "B",
+    "B",
+    "A",
+    "B"
+  ],
+  "type": "PECN",
+  "dimensions": [
+    2,
+    1,
+    3,
+    1
+  ]
+}

--- a/data/results.json
+++ b/data/results.json
@@ -1832,12 +1832,12 @@
       "name": "Aya Expanse 8B",
       "slug": "aya-expanse-8b",
       "url": "",
-      "type": "PTCN",
-      "nick": "The Commander",
+      "type": "PECN",
+      "nick": "The Drill Sergeant",
       "testedAt": "2026-05-04T01:56:26.347Z",
       "scores": [
         2,
-        3,
+        1,
         3,
         1
       ],
@@ -1855,7 +1855,7 @@
             "T",
             "E"
           ],
-          "score": 3,
+          "score": 1,
           "max": 4
         },
         {
@@ -1876,7 +1876,9 @@
         }
       ],
       "model": "aya-expanse:8b",
-      "provider": "ollama"
+      "provider": "ollama",
+      "reliability": 1,
+      "reliabilityRuns": 3
     },
     {
       "name": "Gemma 2 2B",


### PR DESCRIPTION
## Changes

- Run 3x reliability tests for Aya Expanse 8B (Ollama)
- All 3 runs: PECN [2,1,3,1] — 100% consistent
- Type updated from PTCN → PECN based on reliability testing (Precision dimension shifted from Thorough to Efficient)
- Reliability coverage: 38/58 agents (65.5%)

## Reliability Data

| Run | Type | Scores |
|-----|------|--------|
| 1 | PECN | [2,1,3,1] |
| 2 | PECN | [2,1,3,1] |
| 3 | PECN | [2,1,3,1] |

Part of #301