### PR TITLE
data: add reliability scores for 7 GitHub Models agents

### DIFF
--- a/data/reliability/codestral-2501-run-1.json
+++ b/data/reliability/codestral-2501-run-1.json
@@ -1,0 +1,1 @@
+{"type":"PTCF","nick":"The Architect","scores":[4,4,4,3],"model":"Codestral-2501","provider":"github"}

--- a/data/reliability/codestral-2501-run-2.json
+++ b/data/reliability/codestral-2501-run-2.json
@@ -1,0 +1,1 @@
+{"type":"PTCF","nick":"The Architect","scores":[4,4,4,3],"model":"Codestral-2501","provider":"github"}

--- a/data/reliability/codestral-2501-run-3.json
+++ b/data/reliability/codestral-2501-run-3.json
@@ -1,0 +1,1 @@
+{"type":"PTCF","nick":"The Architect","scores":[4,4,4,3],"model":"Codestral-2501","provider":"github"}

--- a/data/reliability/cohere-command-a-run-1.json
+++ b/data/reliability/cohere-command-a-run-1.json
@@ -1,0 +1,9 @@
+{
+  "type": "PTCF",
+  "nick": "The Architect",
+  "desc": "Proactive, thorough, candid, flexible. Takes charge, covers every angle, tells it straight, and pivots on a dime.",
+  "scores": [2, 3, 4, 2],
+  "badge": "https://abti.kagura-agent.com/badge/PTCF",
+  "model": "cohere-command-a",
+  "provider": "github"
+}

--- a/data/reliability/cohere-command-a-run-2.json
+++ b/data/reliability/cohere-command-a-run-2.json
@@ -1,0 +1,1 @@
+{"type":"PTCF","nick":"The Architect","desc":"Proactive, thorough, candid, flexible. Takes charge, covers every angle, tells it straight, and pivots on a dime.","scores":[2,3,4,2],"badge":"https://abti.kagura-agent.com/badge/PTCF","model":"cohere-command-a","provider":"github"}

--- a/data/reliability/cohere-command-a-run-3.json
+++ b/data/reliability/cohere-command-a-run-3.json
@@ -1,0 +1,1 @@
+{"type":"PTCF","nick":"The Architect","scores":[2,3,4,2],"model":"cohere-command-a","provider":"github"}

--- a/data/reliability/llama-3-2-11b-vision-run-1.json
+++ b/data/reliability/llama-3-2-11b-vision-run-1.json
@@ -1,0 +1,1 @@
+{"type":"PTCF","nick":"The Architect","scores":[3,4,4,2],"model":"Llama-3.2-11B-Vision-Instruct","provider":"github"}

--- a/data/reliability/llama-3-2-11b-vision-run-2.json
+++ b/data/reliability/llama-3-2-11b-vision-run-2.json
@@ -1,0 +1,1 @@
+{"type":"PTCF","nick":"The Architect","scores":[3,4,4,2],"model":"Llama-3.2-11B-Vision-Instruct","provider":"github"}

--- a/data/reliability/llama-3-2-11b-vision-run-3.json
+++ b/data/reliability/llama-3-2-11b-vision-run-3.json
@@ -1,0 +1,1 @@
+{"type":"PTCF","nick":"The Architect","scores":[3,4,4,2],"model":"Llama-3.2-11B-Vision-Instruct","provider":"github"}

--- a/data/reliability/ministral-3b-run-1.json
+++ b/data/reliability/ministral-3b-run-1.json
@@ -1,0 +1,1 @@
+{"type":"PTCF","nick":"The Architect","scores":[4,3,4,4],"model":"Ministral-3B","provider":"github"}

--- a/data/reliability/ministral-3b-run-2.json
+++ b/data/reliability/ministral-3b-run-2.json
@@ -1,0 +1,1 @@
+{"type":"PTCF","nick":"The Architect","scores":[4,3,4,4],"model":"Ministral-3B","provider":"github"}

--- a/data/reliability/ministral-3b-run-3.json
+++ b/data/reliability/ministral-3b-run-3.json
@@ -1,0 +1,1 @@
+{"type":"PTCF","nick":"The Architect","scores":[4,3,4,4],"model":"Ministral-3B","provider":"github"}

--- a/data/reliability/mistral-medium-2505-run-1.json
+++ b/data/reliability/mistral-medium-2505-run-1.json
@@ -1,0 +1,1 @@
+{"type":"RECF","nick":"The Blade","scores":[1,0,2,2],"model":"mistral-medium-2505","provider":"github"}

--- a/data/reliability/mistral-medium-2505-run-2.json
+++ b/data/reliability/mistral-medium-2505-run-2.json
@@ -1,0 +1,1 @@
+{"type":"RECF","nick":"The Blade","scores":[1,0,2,2],"model":"mistral-medium-2505","provider":"github"}

--- a/data/reliability/mistral-medium-2505-run-3.json
+++ b/data/reliability/mistral-medium-2505-run-3.json
@@ -1,0 +1,1 @@
+{"type":"RECF","nick":"The Blade","scores":[1,0,2,2],"model":"mistral-medium-2505","provider":"github"}

--- a/data/reliability/mistral-small-2503-run-1.json
+++ b/data/reliability/mistral-small-2503-run-1.json
@@ -1,0 +1,1 @@
+{"type":"PTCF","nick":"The Architect","scores":[4,4,4,4],"model":"mistral-small-2503","provider":"github"}

--- a/data/reliability/mistral-small-2503-run-2.json
+++ b/data/reliability/mistral-small-2503-run-2.json
@@ -1,0 +1,1 @@
+{"type":"PTCF","nick":"The Architect","scores":[4,4,4,4],"model":"mistral-small-2503","provider":"github"}

--- a/data/reliability/mistral-small-2503-run-3.json
+++ b/data/reliability/mistral-small-2503-run-3.json
@@ -1,0 +1,1 @@
+{"type":"PTCF","nick":"The Architect","scores":[4,4,4,4],"model":"mistral-small-2503","provider":"github"}

--- a/data/reliability/phi-4-multimodal-run-1.json
+++ b/data/reliability/phi-4-multimodal-run-1.json
@@ -1,0 +1,1 @@
+{"type":"PTCN","nick":"The Commander","scores":[3,2,3,1],"model":"Phi-4-multimodal-instruct","provider":"github"}

--- a/data/reliability/phi-4-multimodal-run-2.json
+++ b/data/reliability/phi-4-multimodal-run-2.json
@@ -1,0 +1,1 @@
+{"type":"PTCN","nick":"The Commander","scores":[3,2,3,1],"model":"Phi-4-multimodal-instruct","provider":"github"}

--- a/data/reliability/phi-4-multimodal-run-3.json
+++ b/data/reliability/phi-4-multimodal-run-3.json
@@ -1,0 +1,1 @@
+{"type":"PTCN","nick":"The Commander","scores":[3,2,3,1],"model":"Phi-4-multimodal-instruct","provider":"github"}

--- a/data/results.json
+++ b/data/results.json
@@ -1098,12 +1098,12 @@
       "name": "Cohere Command A",
       "slug": "cohere-command-a",
       "url": "",
-      "type": "PECF",
-      "nick": "The Spark",
+      "type": "PTCF",
+      "nick": "The Architect",
       "testedAt": "2026-05-03T12:35:47.138Z",
       "scores": [
+        2,
         3,
-        1,
         4,
         2
       ],
@@ -1142,7 +1142,9 @@
         }
       ],
       "model": "cohere-command-a",
-      "provider": "github"
+      "provider": "github",
+      "reliability": 100,
+      "badge": "https://abti.kagura-agent.com/badge/PTCF"
     },
     {
       "name": "Ministral 3B",
@@ -1153,7 +1155,7 @@
       "testedAt": "2026-05-03T12:36:57.212Z",
       "scores": [
         4,
-        4,
+        3,
         4,
         4
       ],
@@ -1192,7 +1194,9 @@
         }
       ],
       "model": "Ministral-3B",
-      "provider": "github"
+      "provider": "github",
+      "reliability": 100,
+      "badge": "https://abti.kagura-agent.com/badge/PTCF"
     },
     {
       "name": "Phi 4",
@@ -1294,7 +1298,9 @@
         }
       ],
       "model": "Phi-4-multimodal-instruct",
-      "provider": "github"
+      "provider": "github",
+      "reliability": 100,
+      "badge": "https://abti.kagura-agent.com/badge/PTCN"
     },
     {
       "name": "Llama 3.3 70B",
@@ -1435,7 +1441,7 @@
       "testedAt": "2026-05-03T13:44:18.673Z",
       "scores": [
         4,
-        3,
+        4,
         4,
         4
       ],
@@ -1474,7 +1480,9 @@
         }
       ],
       "model": "mistral-small-2503",
-      "provider": "github"
+      "provider": "github",
+      "reliability": 100,
+      "badge": "https://abti.kagura-agent.com/badge/PTCF"
     },
     {
       "name": "Cohere Command R+",
@@ -1530,14 +1538,14 @@
       "name": "Mistral Medium 3",
       "slug": "mistral-medium-3",
       "url": "",
-      "type": "PECF",
-      "nick": "The Spark",
+      "type": "RECF",
+      "nick": "The Blade",
       "testedAt": "2026-05-03T13:47:33.339Z",
       "scores": [
-        3,
         1,
+        0,
         2,
-        3
+        2
       ],
       "dimensions": [
         {
@@ -1574,7 +1582,9 @@
         }
       ],
       "model": "mistral-medium-2505",
-      "provider": "github"
+      "provider": "github",
+      "reliability": 100,
+      "badge": "https://abti.kagura-agent.com/badge/RECF"
     },
     {
       "name": "Llama 3.2 90B Vision",
@@ -1630,14 +1640,14 @@
       "name": "Llama 3.2 11B Vision",
       "slug": "llama-3-2-11b-vision",
       "url": "",
-      "type": "PTCN",
-      "nick": "The Commander",
+      "type": "PTCF",
+      "nick": "The Architect",
       "testedAt": "2026-05-03T14:49:56.570Z",
       "scores": [
+        3,
         4,
-        2,
         4,
-        1
+        2
       ],
       "dimensions": [
         {
@@ -1674,7 +1684,9 @@
         }
       ],
       "model": "Llama-3.2-11B-Vision-Instruct",
-      "provider": "github"
+      "provider": "github",
+      "reliability": 100,
+      "badge": "https://abti.kagura-agent.com/badge/PTCF"
     },
     {
       "name": "Codestral (Mistral)",
@@ -1685,7 +1697,7 @@
       "testedAt": "2026-05-03T15:06:19.806Z",
       "scores": [
         4,
-        3,
+        4,
         4,
         3
       ],
@@ -1724,7 +1736,9 @@
         }
       ],
       "model": "Codestral-2501",
-      "provider": "github"
+      "provider": "github",
+      "reliability": 100,
+      "badge": "https://abti.kagura-agent.com/badge/PTCF"
     },
     {
       "name": "Cohere Command R",


### PR DESCRIPTION
Closes #310

## Summary
Tested 7 of 8 models with 3 runs each. All tested models showed **100% reliability** (same type across all 3 runs).

### Results
| Model | Type | Reliability | Notes |
|---|---|---|---|
| cohere-command-a | PTCF | 100% | Type changed from PECF |
| Ministral-3B | PTCF | 100% | Confirmed |
| Phi-4-multimodal-instruct | PTCN | 100% | Confirmed |
| Llama-3.2-11B-Vision-Instruct | PTCF | 100% | Type changed from PTCN |
| Codestral-2501 | PTCF | 100% | Confirmed |
| mistral-small-2503 | PTCF | 100% | Confirmed |
| mistral-medium-2505 | RECF | 100% | Type changed from PECF |

### Skipped
- **Llama-3.2-90B-Vision-Instruct**: 429 rate limited with ~20 hour retry wait. Needs separate testing.

### Type changes
3 models had their types updated to match consistent test results:
- cohere-command-a: PECF → PTCF
- Llama-3.2-11B-Vision-Instruct: PTCN → PTCF
- mistral-medium-2505: PECF → RECF

Raw test data in data/reliability/.