### PR TITLE
Mark Cohere Command R/R+ as deprecated on GitHub Models

### DIFF
--- a/data/results.json
+++ b/data/results.json
@@ -1532,7 +1532,9 @@
         }
       ],
       "model": "Cohere-command-r-plus-08-2024",
-      "provider": "github"
+      "provider": "github",
+      "deprecated": true,
+      "deprecatedReason": "GitHub Models endpoint returning 500 auth error since 2026-05-16"
     },
     {
       "name": "Mistral Medium 3",
@@ -1788,7 +1790,9 @@
         }
       ],
       "model": "Cohere-command-r-08-2024",
-      "provider": "github"
+      "provider": "github",
+      "deprecated": true,
+      "deprecatedReason": "GitHub Models endpoint returning 500 auth error since 2026-05-16"
     },
     {
       "name": "Granite 3.3 8B",


### PR DESCRIPTION
## What

Adds `deprecated: true` and `deprecatedReason` fields to both Cohere Command R and Command R+ agent entries in results.json.

## Why

GitHub Models endpoint has been returning 500 `invalid_model_endpoint_authentication` errors for both Cohere models since 2026-05-16. Multiple attempts across different days confirm the models are no longer available.

## Impact

- 2 agents marked as deprecated
- No reliability testing possible for these models
- Data is more accurate about actual model availability

Closes #312