### PR TITLE
data: add reliability scores for Llama 3.3 70B and Llama 3.1 405B

### DIFF
--- a/data/results.json
+++ b/data/results.json
@@ -1012,7 +1012,10 @@
         }
       ],
       "model": "Meta-Llama-3.1-405B-Instruct",
-      "provider": "github"
+      "provider": "github",
+      "reliability": 100,
+      "reliabilityRuns": 3,
+      "reliabilityNote": "3/3 PTCN [3,3,4,1]"
     },
     {
       "name": "Llama 4 Scout 17B",
@@ -1350,7 +1353,10 @@
         }
       ],
       "model": "Llama-3.3-70B-Instruct",
-      "provider": "github"
+      "provider": "github",
+      "reliability": 100,
+      "reliabilityRuns": 3,
+      "reliabilityNote": "3/3 PECN [2,1,3,1]"
     },
     {
       "name": "Llama 4 Maverick 17B",


### PR DESCRIPTION
Both models scored 100% reliability (3/3 identical runs):
- Llama 3.3 70B: PECN [2,1,3,1]
- Llama 3.1 405B: PTCN [3,3,4,1]

Coverage: 45/58 → 47/58 (81%)

Part of #301