### PR TITLE
data: fill Llama 3.2 90B Vision reliability=100

### DIFF
--- a/data/results.json
+++ b/data/results.json
@@ -1642,7 +1642,8 @@
         }
       ],
       "model": "Llama-3.2-90B-Vision-Instruct",
-      "provider": "github"
+      "provider": "github",
+      "reliability": 100
     },
     {
       "name": "Llama 3.2 11B Vision",


### PR DESCRIPTION
## Summary

Completed 3 reliability runs for Llama 3.2 90B Vision via GitHub Models:

| Run | Type | Scores |
|-----|------|--------|
| 1 | PTCN | [2,3,4,1] |
| 2 | PTCN | [2,3,4,1] |
| 3 | PTCN | [2,3,4,1] |

**Reliability: 100%** (3/3 consistent)

Part of #301.

**Coverage:** 48/58 agents (83%) now have reliability data.