### PR TITLE
fix: normalize reliability data to decimal format

### DIFF
--- a/cli/bin/abti.js
+++ b/cli/bin/abti.js
@@ -549,6 +549,8 @@ async function runAuto() {
 const RESULTS_URL = 'https://raw.githubusercontent.com/kagura-agent/abti/master/data/results.json';
 
 function formatListTable(agents, lang, useCol) {
+  // Auto-normalize reliability values > 1 (percentage → decimal)
+  agents.forEach(a => { if (a.reliability != null && a.reliability > 1) a.reliability = a.reliability / 100; });
   const cc = useCol ? c : { reset: '', bold: '', dim: '', cyan: '', boldCyan: '', green: '', yellow: '', red: '', magenta: '' };
   const sorted = [...agents].sort((a, b) => a.name.localeCompare(b.name));
   const header = lang === 'zh'

--- a/data/results.json
+++ b/data/results.json
@@ -1013,7 +1013,7 @@
       ],
       "model": "Meta-Llama-3.1-405B-Instruct",
       "provider": "github",
-      "reliability": 100,
+      "reliability": 1,
       "reliabilityRuns": 3,
       "reliabilityNote": "3/3 PTCN [3,3,4,1]"
     },
@@ -1146,7 +1146,7 @@
       ],
       "model": "cohere-command-a",
       "provider": "github",
-      "reliability": 100,
+      "reliability": 1,
       "badge": "https://abti.kagura-agent.com/badge/PTCF"
     },
     {
@@ -1198,7 +1198,7 @@
       ],
       "model": "Ministral-3B",
       "provider": "github",
-      "reliability": 100,
+      "reliability": 1,
       "badge": "https://abti.kagura-agent.com/badge/PTCF"
     },
     {
@@ -1251,7 +1251,7 @@
       "model": "Phi-4",
       "provider": "github",
       "desc": "Responsive, thorough, diplomatic, principled. Meticulous, measured, speaks softly and carries a big bibliography.",
-      "reliability": 100
+      "reliability": 1
     },
     {
       "name": "Phi 4 Multimodal",
@@ -1302,7 +1302,7 @@
       ],
       "model": "Phi-4-multimodal-instruct",
       "provider": "github",
-      "reliability": 100,
+      "reliability": 1,
       "badge": "https://abti.kagura-agent.com/badge/PTCN"
     },
     {
@@ -1354,7 +1354,7 @@
       ],
       "model": "Llama-3.3-70B-Instruct",
       "provider": "github",
-      "reliability": 100,
+      "reliability": 1,
       "reliabilityRuns": 3,
       "reliabilityNote": "3/3 PECN [2,1,3,1]"
     },
@@ -1487,7 +1487,7 @@
       ],
       "model": "mistral-small-2503",
       "provider": "github",
-      "reliability": 100,
+      "reliability": 1,
       "badge": "https://abti.kagura-agent.com/badge/PTCF"
     },
     {
@@ -1591,7 +1591,7 @@
       ],
       "model": "mistral-medium-2505",
       "provider": "github",
-      "reliability": 100,
+      "reliability": 1,
       "badge": "https://abti.kagura-agent.com/badge/RECF"
     },
     {
@@ -1643,7 +1643,7 @@
       ],
       "model": "Llama-3.2-90B-Vision-Instruct",
       "provider": "github",
-      "reliability": 100
+      "reliability": 1
     },
     {
       "name": "Llama 3.2 11B Vision",
@@ -1694,7 +1694,7 @@
       ],
       "model": "Llama-3.2-11B-Vision-Instruct",
       "provider": "github",
-      "reliability": 100,
+      "reliability": 1,
       "badge": "https://abti.kagura-agent.com/badge/PTCF"
     },
     {
@@ -1746,7 +1746,7 @@
       ],
       "model": "Codestral-2501",
       "provider": "github",
-      "reliability": 100,
+      "reliability": 1,
       "badge": "https://abti.kagura-agent.com/badge/PTCF"
     },
     {
@@ -2163,7 +2163,7 @@
       "model": "openai/gpt-4.1-mini",
       "provider": "github",
       "desc": "Proactive, efficient, candid, flexible. Fast-moving generalist who says what they think and adapts on the fly.",
-      "reliability": 100
+      "reliability": 1
     },
     {
       "name": "GPT-4.1 nano",
@@ -2215,7 +2215,7 @@
       "model": "openai/gpt-4.1-nano",
       "provider": "github",
       "desc": "Proactive, efficient, candid, principled. All gas, no brakes, no filter, no exceptions.",
-      "reliability": 100
+      "reliability": 1
     },
     {
       "name": "SmolLM2 1.7B",


### PR DESCRIPTION
Fixes #319

## Problem
13 agents had reliability stored as percentage (0-100) instead of decimal (0-1) in `data/results.json`. The CLI's `list` command multiplies by 100 for display (`Math.round(a.reliability * 100) + '%'`), causing these entries to show as `10000%` instead of `100%`.

## Changes
- **data/results.json**: Normalize all 13 affected agents from `100` → `1`
- **cli/bin/abti.js**: Add auto-normalization guard in `formatListTable()` — any `reliability > 1` is divided by 100, preventing future display bugs

## Affected agents
Llama 3.1 405B, Cohere Command A, Ministral 3B, Phi 4, Phi 4 Multimodal, Llama 3.3 70B, Mistral Small 3.1, Mistral Medium 3, Llama 3.2 90B Vision, Llama 3.2 11B Vision, Codestral, GPT-4.1 mini, GPT-4.1 nano

## Tests
```
180 pass, 0 fail
```