### PR TITLE
fix: add reliability normalization guard to website

### DIFF
--- a/agent.html
+++ b/agent.html
@@ -214,6 +214,8 @@ nav a:hover, nav a.active { color: var(--accent); }
 
   function render() {
     var a = agentData;
+    // Auto-normalize reliability values > 1 (percentage → decimal)
+    if (a.reliability != null && a.reliability > 1) a.reliability = a.reliability / 100;
     var p = profileData;
     var labels = lang === 'zh'
       ? { strengths: '优势', blindSpots: '盲区', workStyle: '工作风格', dimensions: '维度分析', bestPaired: '最佳搭档', back: '← 返回 Agents', tuningTips: '💡 调优建议' }

--- a/agents.html
+++ b/agents.html
@@ -278,6 +278,8 @@ nav a:hover, nav a.active { color: var(--accent); }
 
     // Distribution visualization
     const agents = data.agents;
+    // Auto-normalize reliability values > 1 (percentage → decimal)
+    agents.forEach(a => { if (a.reliability != null && a.reliability > 1) a.reliability = a.reliability / 100; });
     const n = agents.length;
     if (n > 0) {
       const dims = [


### PR DESCRIPTION
Follow-up to #320.

The website pages (agents.html, agent.html) use the same `Math.round(reliability * 100) + '%'` pattern as the CLI. If any future data entry uses percentage format (0-100) instead of decimal (0-1), the website would show '10000%'.

Adds the same auto-normalization guard: `if (reliability > 1) reliability /= 100`.