### PR TITLE
data: add GPT-4.1 reliability score (100%, 3 runs)

### DIFF
--- a/data/results.json
+++ b/data/results.json
@@ -580,7 +580,11 @@
         }
       ],
       "model": "gpt-4.1",
-      "provider": "openai"
+      "provider": "openai",
+      "reliability": 1,
+      "reliabilityRuns": 3,
+      "consistency": 100,
+      "runs": 3
     },
     {
       "name": "GPT-5 mini",


### PR DESCRIPTION
## What

Add reliability data for GPT-4.1 based on 3 test runs via GitHub Models provider.

## Results

| Run | Type | Scores |
|-----|------|--------|
| 1 | PTCF | [2,2,2,2] |
| 2 | PTCF | [2,2,2,2] |
| 3 | PTCF | [2,2,2,2] |

**Reliability: 100% (3/3 consistent)**

Matches existing OpenAI provider result (PTCF [2,2,2,2]).

## Impact

Reliability coverage: 48/58 → 49/58 (84%)

Closes the last GitHub Models model in #301.