### PR TITLE
feat(action): add expected-type input for personality drift detection

### DIFF
--- a/action/README.md
+++ b/action/README.md
@@ -17,6 +17,7 @@ The action sends each scenario question to an LLM (OpenAI, Anthropic, Google Gem
 | `post-comment` | No | `false` | Post a PR comment with results |
 | `api-base-url` | No | `https://abti.kagura-agent.com` | ABTI API base URL |
 | `lang` | No | `en` | Language for questions (`en` or `zh`) |
+| `expected-type` | No | — | Expected ABTI type code (e.g. `PTCF`). Fails the action on mismatch for drift detection. |
 
 ## Outputs
 
@@ -25,6 +26,8 @@ The action sends each scenario question to an LLM (OpenAI, Anthropic, Google Gem
 | `type` | ABTI type code (e.g. `PTCF`) |
 | `nickname` | Type nickname (e.g. `The Architect`) |
 | `badge-url` | URL for the ABTI badge SVG |
+| `drift` | Whether personality drift was detected (`true`/`false`). Only set when `expected-type` is provided. |
+| `drift-dimensions` | Comma-separated dimensions that shifted (e.g. `Autonomy,Precision`). Empty if no drift. |
 
 ## Usage
 
@@ -107,6 +110,40 @@ The action sends each scenario question to an LLM (OpenAI, Anthropic, Google Gem
     echo "Type: ${{ steps.abti.outputs.type }}"
     echo "Nickname: ${{ steps.abti.outputs.nickname }}"
     echo "Badge: ${{ steps.abti.outputs.badge-url }}"
+```
+
+### Personality drift detection
+
+Fail the action if the agent's personality drifts from the expected type — useful as a CI guardrail for model upgrades or prompt changes:
+
+```yaml
+- uses: kagura-agent/abti@v1
+  with:
+    provider: openai
+    model: gpt-4o
+    api-key: ${{ secrets.OPENAI_API_KEY }}
+    agent-prompt-file: AGENTS.md
+    expected-type: PTCF  # fail if personality drifts
+```
+
+When drift is detected, the action:
+- Fails with a clear error showing which dimensions shifted
+- Adds a drift comparison table to the job summary
+- Sets `drift` and `drift-dimensions` outputs for downstream steps
+
+```yaml
+# Use drift outputs for conditional logic
+- uses: kagura-agent/abti@v1
+  id: abti
+  continue-on-error: true
+  with:
+    provider: openai
+    model: gpt-4o
+    api-key: ${{ secrets.OPENAI_API_KEY }}
+    expected-type: PTCF
+
+- if: steps.abti.outputs.drift == 'true'
+  run: echo "Personality shifted on: ${{ steps.abti.outputs.drift-dimensions }}"
 ```
 
 ## How It Works

--- a/action/action.yml
+++ b/action/action.yml
@@ -36,6 +36,9 @@ inputs:
     description: 'Language for questions (en or zh)'
     required: false
     default: 'en'
+  expected-type:
+    description: 'Expected ABTI type code (e.g. PTCF). If set, the action fails when the result differs — enabling personality drift detection in CI.'
+    required: false
 
 outputs:
   type:
@@ -44,6 +47,10 @@ outputs:
     description: 'Type nickname (e.g. The Architect)'
   badge-url:
     description: 'URL for the ABTI badge SVG'
+  drift:
+    description: 'Whether personality drift was detected (true/false). Only set when expected-type is provided.'
+  drift-dimensions:
+    description: 'Comma-separated list of dimensions that shifted (e.g. Autonomy,Precision). Empty if no drift.'
 
 branding:
   icon: 'users'

--- a/action/index.js
+++ b/action/index.js
@@ -260,6 +260,32 @@ function callLLM(provider, apiKey, model, systemPrompt, userMessage, baseUrl) {
 
 // ─── Answer parsing ──────────────────────────────────────────────────────────
 
+// ─── Drift detection ─────────────────────────────────────────────────────────
+
+const DIMENSIONS = [
+  { name: 'Autonomy', poles: ['P', 'R'] },
+  { name: 'Precision', poles: ['T', 'E'] },
+  { name: 'Transparency', poles: ['C', 'D'] },
+  { name: 'Adaptability', poles: ['F', 'N'] },
+];
+
+/**
+ * Compare two ABTI type codes (e.g. 'PTCF' vs 'RECN') and return drift info.
+ * Returns { drifted: boolean, dimensions: string[] } where dimensions lists
+ * the names of dimensions that changed.
+ */
+function detectDrift(expected, actual) {
+  const e = expected.toUpperCase();
+  const a = actual.toUpperCase();
+  const shifted = [];
+  for (let i = 0; i < DIMENSIONS.length; i++) {
+    if (e[i] !== a[i]) shifted.push(DIMENSIONS[i].name);
+  }
+  return { drifted: shifted.length > 0, dimensions: shifted };
+}
+
+// ─── Answer parsing ──────────────────────────────────────────────────────────
+
 /**
  * Extract A or B from an LLM response. Returns 1 for A, 0 for B.
  */
@@ -434,6 +460,15 @@ async function run() {
   setOutput('nickname', result.nick);
   setOutput('badge-url', badgeUrl);
 
+  // 4b. Drift detection
+  const expectedType = getInput('expected-type');
+  let drift = null;
+  if (expectedType) {
+    drift = detectDrift(expectedType, result.type);
+    setOutput('drift', String(drift.drifted));
+    setOutput('drift-dimensions', drift.dimensions.join(','));
+  }
+
   // 5. Write job summary
   const summary = [
     `## 🌸 ABTI Result: ${result.type} — ${result.nick}`,
@@ -463,8 +498,33 @@ async function run() {
     ...result.blindSpots.map((s) => `- ${s}`),
   ].join('\n');
 
+  // 5b. Add drift section to summary if drift detected
+  if (drift && drift.drifted) {
+    const driftSection = [
+      '',
+      '### ⚠️ Personality Drift Detected',
+      '',
+      `**Expected:** ${expectedType.toUpperCase()} → **Actual:** ${result.type}`,
+      '',
+      '| Dimension | Expected | Actual | Status |',
+      '|-----------|----------|--------|--------|',
+      ...DIMENSIONS.map((dim, i) => {
+        const exp = expectedType.toUpperCase()[i];
+        const act = result.type[i];
+        const status = exp === act ? '✅' : '❌ shifted';
+        return `| ${dim.name} | ${exp} (${dim.poles[0] === exp ? dim.poles[0] : dim.poles[1]}) | ${act} (${dim.poles[0] === act ? dim.poles[0] : dim.poles[1]}) | ${status} |`;
+      }),
+    ].join('\n');
+    writeSummary(driftSection);
+  }
+
   writeSummary(summary);
   info('Job summary written');
+
+  // 5c. Fail the action if drift detected
+  if (drift && drift.drifted) {
+    setFailed(`Personality drift detected: expected ${expectedType.toUpperCase()} but got ${result.type}. Shifted dimensions: ${drift.dimensions.join(', ')}`);
+  }
 
   // 6. Optionally post PR comment
   if (postCommentFlag) {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "abti",
   "private": true,
   "scripts": {
-    "test": "node --test test/api.test.js test/mcp.test.js test/mcp-http.test.js test/compatibility.test.js test/cross-compatibility.test.js test/auto-reload.test.js test/parseAnswer.test.js test/provider.test.js test/resume.test.js test/list.test.js",
+    "test": "node --test test/api.test.js test/mcp.test.js test/mcp-http.test.js test/compatibility.test.js test/cross-compatibility.test.js test/auto-reload.test.js test/parseAnswer.test.js test/provider.test.js test/resume.test.js test/list.test.js test/action-drift.test.js",
     "generate-og": "node scripts/generate-og-images.js",
     "generate-sitemap": "node scripts/generate-sitemap.js",
     "generate-og-agents": "node scripts/generate-agent-og.js"

--- a/test/action-drift.test.js
+++ b/test/action-drift.test.js
@@ -1,0 +1,90 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+// Extract detectDrift logic for unit testing (mirrors action/index.js)
+const DIMENSIONS = [
+  { name: 'Autonomy', poles: ['P', 'R'] },
+  { name: 'Precision', poles: ['T', 'E'] },
+  { name: 'Transparency', poles: ['C', 'D'] },
+  { name: 'Adaptability', poles: ['F', 'N'] },
+];
+
+function detectDrift(expected, actual) {
+  const e = expected.toUpperCase();
+  const a = actual.toUpperCase();
+  const shifted = [];
+  for (let i = 0; i < DIMENSIONS.length; i++) {
+    if (e[i] !== a[i]) shifted.push(DIMENSIONS[i].name);
+  }
+  return { drifted: shifted.length > 0, dimensions: shifted };
+}
+
+describe('detectDrift', () => {
+  it('should detect no drift when types match exactly', () => {
+    const result = detectDrift('PTCF', 'PTCF');
+    assert.equal(result.drifted, false);
+    assert.deepEqual(result.dimensions, []);
+  });
+
+  it('should be case-insensitive', () => {
+    const result = detectDrift('ptcf', 'PTCF');
+    assert.equal(result.drifted, false);
+    assert.deepEqual(result.dimensions, []);
+  });
+
+  it('should detect single dimension drift (Autonomy)', () => {
+    const result = detectDrift('PTCF', 'RTCF');
+    assert.equal(result.drifted, true);
+    assert.deepEqual(result.dimensions, ['Autonomy']);
+  });
+
+  it('should detect single dimension drift (Precision)', () => {
+    const result = detectDrift('PTCF', 'PECF');
+    assert.equal(result.drifted, true);
+    assert.deepEqual(result.dimensions, ['Precision']);
+  });
+
+  it('should detect single dimension drift (Transparency)', () => {
+    const result = detectDrift('PTCF', 'PTDF');
+    assert.equal(result.drifted, true);
+    assert.deepEqual(result.dimensions, ['Transparency']);
+  });
+
+  it('should detect single dimension drift (Adaptability)', () => {
+    const result = detectDrift('PTCF', 'PTCN');
+    assert.equal(result.drifted, true);
+    assert.deepEqual(result.dimensions, ['Adaptability']);
+  });
+
+  it('should detect multiple dimension drift', () => {
+    const result = detectDrift('PTCF', 'REDN');
+    assert.equal(result.drifted, true);
+    assert.deepEqual(result.dimensions, ['Autonomy', 'Precision', 'Transparency', 'Adaptability']);
+  });
+
+  it('should detect two dimension drift', () => {
+    const result = detectDrift('PTCF', 'RECF');
+    assert.equal(result.drifted, true);
+    assert.deepEqual(result.dimensions, ['Autonomy', 'Precision']);
+  });
+
+  it('should handle all 16 types against themselves (no drift)', () => {
+    const types = [
+      'PTCF', 'PTCN', 'PTDF', 'PTDN',
+      'PECF', 'PECN', 'PEDF', 'PEDN',
+      'RTCF', 'RTCN', 'RTDF', 'RTDN',
+      'RECF', 'RECN', 'REDF', 'REDN',
+    ];
+    for (const t of types) {
+      const result = detectDrift(t, t);
+      assert.equal(result.drifted, false, `Expected no drift for ${t}`);
+    }
+  });
+
+  it('should correctly identify opposite types as full drift', () => {
+    // PTCF opposite is REDN (all 4 dimensions flipped)
+    const result = detectDrift('PTCF', 'REDN');
+    assert.equal(result.drifted, true);
+    assert.equal(result.dimensions.length, 4);
+  });
+});


### PR DESCRIPTION
Closes #333

## What

Add an `expected-type` input to the GitHub Action that enables personality drift detection in CI. When set, the action compares the test result against the expected type and **fails if the personality has shifted**.

## Changes

- **action/action.yml**: Add `expected-type` input and `drift`/`drift-dimensions` outputs
- **action/index.js**: Add `detectDrift()` function and drift check after test completion
  - Compares each of the 4 dimensions (Autonomy, Precision, Transparency, Adaptability)
  - Fails with clear error showing which dimensions shifted
  - Adds drift comparison table to job summary
- **test/action-drift.test.js**: 10 unit tests for drift detection logic
- **action/README.md**: Document new input/outputs with usage examples
- **package.json**: Add drift test to test suite

## Usage

```yaml
- uses: kagura-agent/abti@v1
  with:
    provider: openai
    model: gpt-4o
    api-key: ${{ secrets.OPENAI_API_KEY }}
    agent-prompt-file: AGENTS.md
    expected-type: PTCF  # fail if personality drifts
```

## Tests

All 190 tests pass (180 existing + 10 new drift detection tests).