### PR TITLE
feat: Agent vs Agent comparison page

### DIFF
--- a/agent.html
+++ b/agent.html
@@ -178,6 +178,7 @@ nav a:hover, nav a.active { color: var(--accent); }
   <a href="stats.html">Stats</a>
   <a href="types.html">Types</a>
   <a href="compare.html">Compare</a>
+  <a href="compare-agents.html">Agent Compare</a>
   <a href="test-agent.html">Test Agent</a>
   <a href="compatibility.html">Compatibility</a>
   <a href="cross-compatibility.html">Cross Match</a>

--- a/agents.html
+++ b/agents.html
@@ -142,6 +142,7 @@ nav a:hover, nav a.active { color: var(--accent); }
   <a href="stats.html">Stats</a>
   <a href="types.html">Types</a>
   <a href="compare.html">Compare</a>
+  <a href="compare-agents.html">Agent Compare</a>
   <a href="test-agent.html">Test Agent</a>
   <a href="compatibility.html">Compatibility</a>
   <a href="cross-compatibility.html">Cross Match</a>

--- a/api-server.js
+++ b/api-server.js
@@ -561,6 +561,67 @@ const server = http.createServer((req, res) => {
     return;
   }
 
+  // GET /api/compare/agents/:slug1/:slug2 - compare two agents
+  const agentCompareMatch = url.pathname.match(/^\/api\/compare\/agents\/([^/]+)\/([^/]+)$/);
+  if (agentCompareMatch && req.method === 'GET') {
+    const slug1 = decodeURIComponent(agentCompareMatch[1]).toLowerCase();
+    const slug2 = decodeURIComponent(agentCompareMatch[2]).toLowerCase();
+    const a1 = agentData.agents.find(a => a.slug === slug1 || slugify(a.name) === slug1);
+    const a2 = agentData.agents.find(a => a.slug === slug2 || slugify(a.name) === slug2);
+    if (!a1 || !a2) {
+      res.writeHead(404, {'Content-Type':'application/json'});
+      return res.end(JSON.stringify({error:`Agent not found: ${!a1 ? slug1 : slug2}`}));
+    }
+    const code1 = a1.type, code2 = a2.type;
+    const lang = url.searchParams.get('lang') || 'en';
+
+    const dimensions = [];
+    for (let i = 0; i < 4; i++) {
+      const dn = (dimNames[lang] || dimNames.en)[i];
+      const dl = (dimLabels[lang] || dimLabels.en)[i];
+      const letter1 = code1[i];
+      const letter2 = code2[i];
+      const pole1 = letter1 === DL[i][0] ? dl[0] : dl[1];
+      const pole2 = letter2 === DL[i][0] ? dl[0] : dl[1];
+      dimensions.push({
+        name: dn,
+        poles: dl,
+        letters: DL[i],
+        type1: { letter: letter1, pole: pole1 },
+        type2: { letter: letter2, pole: pole2 },
+        match: letter1 === letter2,
+        score1: a1.scores?.[i] ?? null,
+        score2: a2.scores?.[i] ?? null
+      });
+    }
+
+    const r1 = richProfiles[code1];
+    const r2 = richProfiles[code2];
+    const p1 = r1?.[lang] || r1?.en || {};
+    const p2 = r2?.[lang] || r2?.en || {};
+    const compat1 = p1.bestPairedWith?.some(bp => bp.type === code2) || false;
+    const compat2 = p2.bestPairedWith?.some(bp => bp.type === code1) || false;
+    const compatibility = {
+      mutual: compat1 && compat2,
+      type1RecommendsType2: compat1,
+      type2RecommendsType1: compat2,
+      reason1: p1.bestPairedWith?.find(bp => bp.type === code2)?.reason || null,
+      reason2: p2.bestPairedWith?.find(bp => bp.type === code1)?.reason || null
+    };
+
+    const shared = dimensions.filter(d => d.match).length;
+
+    const strip = ({answers, ...rest}) => rest;
+    res.writeHead(200, {'Content-Type':'application/json'});
+    return res.end(JSON.stringify({
+      agent1: strip(a1),
+      agent2: strip(a2),
+      dimensions,
+      sharedDimensions: shared,
+      compatibility
+    }));
+  }
+
   // GET /api/compare/:type1/:type2 - compare two types
   const compareMatch = url.pathname.match(/^\/api\/compare\/([A-Za-z]{4})\/([A-Za-z]{4})$/);
   if (compareMatch && req.method === 'GET') {
@@ -1058,7 +1119,7 @@ ${dimInfo.map((d, i) => {
   if (url.pathname === '/sitemap.xml' && req.method === 'GET') {
     const BASE = 'https://abti.kagura-agent.com';
     const VALID_TYPES = ['PTCF','PTCN','PTDF','PTDN','PECF','PECN','PEDF','PEDN','RTCF','RTCN','RTDF','RTDN','RECF','RECN','REDF','REDN'];
-    const staticPages = ['/', '/types.html', '/agents.html', '/compare.html', '/api.html', '/sbti.html', '/test-agent.html', '/cross-compatibility.html', '/leaderboard.html'];
+    const staticPages = ['/', '/types.html', '/agents.html', '/compare.html', '/compare-agents.html', '/api.html', '/sbti.html', '/test-agent.html', '/cross-compatibility.html', '/leaderboard.html'];
     const urls = staticPages.map(p => `  <url><loc>${BASE}${p}</loc></url>`);
     VALID_TYPES.forEach(code => urls.push(`  <url><loc>${BASE}/type/${code}</loc></url>`));
     VALID_TYPES.forEach(code => urls.push(`  <url><loc>${BASE}/result/${code}</loc></url>`));
@@ -1441,7 +1502,7 @@ ${dimInfo.map((d, i) => {
   }
 
   res.writeHead(404, {'Content-Type':'application/json'});
-  res.end(JSON.stringify({error:'not found',endpoints:['GET /api/test','GET /api/sbti/test','GET /api/types','GET /api/sbti/types','POST /api/agent-test','POST /api/sbti/agent-test','GET /api/agents','GET /api/agent/:slug','GET /api/stats','GET /api/compare/:type1/:type2','GET /api/compatibility','GET /api/compatibility/matrix','GET /api/compatibility/human','GET /api/compatibility/cross','GET /badge/:type','GET /badge/agent/:slug','GET /sbti/badge/:type','GET /type/:code','GET /agent/:slug','GET /result/:type','GET /sbti/result/:type','GET /test-agent','GET /api/openapi.json','POST /mcp','GET /mcp','DELETE /mcp']}));
+  res.end(JSON.stringify({error:'not found',endpoints:['GET /api/test','GET /api/sbti/test','GET /api/types','GET /api/sbti/types','POST /api/agent-test','POST /api/sbti/agent-test','GET /api/agents','GET /api/agent/:slug','GET /api/stats','GET /api/compare/agents/:slug1/:slug2','GET /api/compare/:type1/:type2','GET /api/compatibility','GET /api/compatibility/matrix','GET /api/compatibility/human','GET /api/compatibility/cross','GET /badge/:type','GET /badge/agent/:slug','GET /sbti/badge/:type','GET /type/:code','GET /agent/:slug','GET /result/:type','GET /sbti/result/:type','GET /test-agent','GET /api/openapi.json','POST /mcp','GET /mcp','DELETE /mcp']}));
 });
 
 if (require.main === module) {

--- a/api.html
+++ b/api.html
@@ -184,6 +184,7 @@ pre code {
   <a href="stats.html">Stats</a>
   <a href="types.html">Types</a>
   <a href="compare.html">Compare</a>
+  <a href="compare-agents.html">Agent Compare</a>
   <a href="test-agent.html">Test Agent</a>
   <a href="compatibility.html">Compatibility</a>
   <a href="cross-compatibility.html">Cross Match</a>

--- a/compare-agents.html
+++ b/compare-agents.html
@@ -3,10 +3,10 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Compare Types — ABTI</title>
+<title>Agent Compare — ABTI</title>
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="Compare Types — ABTI">
-<meta name="twitter:description" content="Compare AI agent behavioral types side by side">
+<meta name="twitter:title" content="Agent Compare — ABTI">
+<meta name="twitter:description" content="Compare AI agents side by side with dimensional analysis">
 <meta name="twitter:image" content="https://abti.kagura-agent.com/og-abti.png">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -16,7 +16,7 @@
   --bg: #fafaf9; --surface: #fff; --surface2: #f5f5f4;
   --text: #1c1917; --text2: #78716c; --text3: #a8a29e;
   --accent: #0d9488; --accent2: #0f766e; --accent-soft: #f0fdfa;
-  --border: #e7e5e4; --radius: 10px;
+  --border: #e7e5e4; --radius: 14px;
   --shadow: 0 1px 3px rgba(28,25,23,.06), 0 1px 2px rgba(28,25,23,.04);
   --shadow-md: 0 4px 12px rgba(28,25,23,.07), 0 2px 4px rgba(28,25,23,.04);
 }
@@ -33,7 +33,7 @@ nav a:hover, nav a.active { color: var(--accent); }
 .header h1 span { color: var(--accent); }
 
 .selectors { display: flex; gap: 1rem; justify-content: center; align-items: center; flex-wrap: wrap; margin-bottom: 2.5rem; }
-.selectors select { font-family: 'DM Sans', system-ui, sans-serif; font-size: .9rem; padding: .5rem 1rem; border: 1px solid var(--border); border-radius: var(--radius); background: var(--surface); color: var(--text); cursor: pointer; min-width: 180px; }
+.selectors select { font-family: 'DM Sans', system-ui, sans-serif; font-size: .9rem; padding: .5rem 1rem; border: 1px solid var(--border); border-radius: var(--radius); background: var(--surface); color: var(--text); cursor: pointer; min-width: 200px; }
 .selectors select:focus { outline: none; border-color: var(--accent); }
 .vs { font-weight: 600; color: var(--text3); font-size: .85rem; letter-spacing: .1em; }
 .compare-btn { font-family: 'DM Sans', system-ui, sans-serif; font-size: .85rem; font-weight: 600; padding: .55rem 1.5rem; background: var(--accent); color: #fff; border: none; border-radius: var(--radius); cursor: pointer; transition: background .2s; letter-spacing: .04em; }
@@ -41,27 +41,24 @@ nav a:hover, nav a.active { color: var(--accent); }
 
 #result { display: none; }
 
-.types-row { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; margin-bottom: 2rem; }
-.type-card { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); padding: 1.25rem; box-shadow: var(--shadow); }
-.type-card .pill { display: inline-block; background: var(--accent-soft); color: var(--accent); font-size: .7rem; font-weight: 700; padding: .15rem .55rem; border-radius: 999px; letter-spacing: .06em; margin-bottom: .4rem; }
-.type-card h2 { font-size: 1.1rem; font-weight: 600; margin-bottom: .25rem; }
-.type-card .nick { color: var(--text2); font-size: .85rem; margin-bottom: .75rem; }
-.type-card h3 { font-size: .78rem; font-weight: 600; color: var(--text); margin-bottom: .35rem; text-transform: uppercase; letter-spacing: .06em; }
-.type-card ul { list-style: none; margin-bottom: .75rem; }
-.type-card li { font-size: .82rem; color: var(--text2); line-height: 1.5; padding-left: .9rem; position: relative; margin-bottom: .2rem; }
-.type-card li::before { content: ''; position: absolute; left: 0; top: .55em; width: 4px; height: 4px; border-radius: 50%; background: var(--accent); }
-.type-card .work-style { font-size: .82rem; color: var(--text2); line-height: 1.55; }
+.agents-row { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; margin-bottom: 2rem; }
+.agent-card { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); padding: 1.25rem; box-shadow: var(--shadow); }
+.agent-card .type-pill { display: inline-block; background: var(--accent-soft); color: var(--accent); font-size: .7rem; font-weight: 700; padding: .15rem .55rem; border-radius: 999px; letter-spacing: .06em; margin-bottom: .4rem; }
+.agent-card h2 { font-size: 1.1rem; font-weight: 600; margin-bottom: .15rem; }
+.agent-card .nick { color: var(--text2); font-size: .82rem; margin-bottom: .5rem; }
+.agent-card .meta { font-size: .78rem; color: var(--text3); line-height: 1.6; }
+.agent-card .meta strong { color: var(--text2); font-weight: 600; }
 
 .section-title { font-size: .95rem; font-weight: 600; margin-bottom: 1rem; color: var(--text); }
 
 .dims { display: flex; flex-direction: column; gap: .75rem; margin-bottom: 2rem; }
 .dim { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); padding: 1rem 1.25rem; box-shadow: var(--shadow); }
 .dim-name { font-size: .8rem; font-weight: 600; color: var(--text); margin-bottom: .5rem; text-transform: uppercase; letter-spacing: .06em; }
-.dim-bar { position: relative; height: 28px; background: var(--surface2); border-radius: 14px; overflow: hidden; margin-bottom: .35rem; }
-.dim-bar .pole-label { position: absolute; top: 50%; transform: translateY(-50%); font-size: .7rem; font-weight: 600; z-index: 2; }
-.dim-bar .pole-left { left: .6rem; color: var(--text2); }
-.dim-bar .pole-right { right: .6rem; color: var(--text2); }
-.dim-marker { position: absolute; top: 2px; width: 24px; height: 24px; border-radius: 50%; display: flex; align-items: center; justify-content: center; font-size: .65rem; font-weight: 700; color: #fff; z-index: 3; transition: left .3s; }
+.dim-scale { position: relative; height: 28px; background: var(--surface2); border-radius: 14px; overflow: hidden; margin-bottom: .35rem; }
+.dim-scale .pole-label { position: absolute; top: 50%; transform: translateY(-50%); font-size: .7rem; font-weight: 600; z-index: 2; }
+.dim-scale .pole-left { left: .6rem; color: var(--text2); }
+.dim-scale .pole-right { right: .6rem; color: var(--text2); }
+.dim-marker { position: absolute; top: 2px; width: 24px; height: 24px; border-radius: 50%; display: flex; align-items: center; justify-content: center; font-size: .6rem; font-weight: 700; color: #fff; z-index: 3; transition: left .3s; }
 .marker-1 { background: var(--accent); }
 .marker-2 { background: #e8658a; }
 .dim-status { font-size: .72rem; color: var(--text3); text-align: center; }
@@ -78,7 +75,7 @@ nav a:hover, nav a.active { color: var(--accent); }
 .footer { text-align: center; color: var(--text3); font-size: .72rem; margin-top: 2rem; padding-bottom: 1rem; }
 
 @media (max-width: 600px) {
-  .types-row { grid-template-columns: 1fr; }
+  .agents-row { grid-template-columns: 1fr; }
   .header h1 { font-size: 1.8rem; }
   .wrap { padding: 4rem 1rem 1.5rem; }
   .selectors { flex-direction: column; align-items: stretch; }
@@ -95,8 +92,8 @@ nav a:hover, nav a.active { color: var(--accent); }
   <a href="leaderboard.html">Leaderboard</a>
   <a href="stats.html">Stats</a>
   <a href="types.html">Types</a>
-  <a href="compare.html" class="active">Compare</a>
-  <a href="compare-agents.html">Agent Compare</a>
+  <a href="compare.html">Compare</a>
+  <a href="compare-agents.html" class="active">Agent Compare</a>
   <a href="test-agent.html">Test Agent</a>
   <a href="compatibility.html">Compatibility</a>
   <a href="cross-compatibility.html">Cross Match</a>
@@ -104,75 +101,76 @@ nav a:hover, nav a.active { color: var(--accent); }
 </nav>
 <div class="wrap">
   <div class="header">
-    <h1>Compare <span>Types</span></h1>
+    <h1>Agent <span>Compare</span></h1>
   </div>
   <div class="selectors">
-    <select id="sel1"></select>
+    <select id="sel1"><option value="">Select agent...</option></select>
     <span class="vs">VS</span>
-    <select id="sel2"></select>
+    <select id="sel2"><option value="">Select agent...</option></select>
     <button class="compare-btn" onclick="doCompare()">Compare</button>
   </div>
   <div id="result"></div>
   <div class="footer">ABTI &mdash; Agent Behavioral Type Indicator</div>
 </div>
 <script>
-const TYPES = [
-  'PTCF','PTCN','PTDF','PTDN','PECF','PECN','PEDF','PEDN',
-  'RTCF','RTCN','RTDF','RTDN','RECF','RECN','REDF','REDN'
-];
-
 const sel1 = document.getElementById('sel1');
 const sel2 = document.getElementById('sel2');
+let agents = [];
 
-TYPES.forEach(t => {
-  sel1.add(new Option(t, t));
-  sel2.add(new Option(t, t));
+fetch('/api/agents').then(r => r.json()).then(data => {
+  agents = data.agents || [];
+  agents.forEach(a => {
+    sel1.add(new Option(`${a.name} (${a.type})`, a.slug));
+    sel2.add(new Option(`${a.name} (${a.type})`, a.slug));
+  });
+  const params = new URLSearchParams(location.search);
+  if (params.get('a')) sel1.value = params.get('a');
+  if (params.get('b')) sel2.value = params.get('b');
+  if (params.get('a') && params.get('b')) doCompare();
 });
-sel2.value = 'REDN';
-
-// Read URL params
-const params = new URLSearchParams(location.search);
-if (params.get('a') && TYPES.includes(params.get('a').toUpperCase())) sel1.value = params.get('a').toUpperCase();
-if (params.get('b') && TYPES.includes(params.get('b').toUpperCase())) sel2.value = params.get('b').toUpperCase();
-if (params.get('a') && params.get('b')) doCompare();
 
 async function doCompare() {
   const a = sel1.value, b = sel2.value;
-  history.replaceState(null, '', `compare.html?a=${a}&b=${b}`);
-  const res = await fetch(`/api/compare/${a}/${b}`);
+  if (!a || !b) return;
+  history.replaceState(null, '', `compare-agents.html?a=${encodeURIComponent(a)}&b=${encodeURIComponent(b)}`);
+  const res = await fetch(`/api/compare/agents/${encodeURIComponent(a)}/${encodeURIComponent(b)}`);
   if (!res.ok) { document.getElementById('result').innerHTML = '<p style="color:red">Error loading comparison</p>'; document.getElementById('result').style.display='block'; return; }
-  const d = await res.json();
-  render(d);
+  render(await res.json());
 }
 
 function render(d) {
   const el = document.getElementById('result');
   el.style.display = 'block';
+  const a1 = d.agent1, a2 = d.agent2;
 
-  const t1 = d.type1, t2 = d.type2;
-
-  let html = `<div class="types-row">`;
-  html += renderTypeCard(t1);
-  html += renderTypeCard(t2);
+  let html = `<div class="agents-row">`;
+  html += agentCard(a1);
+  html += agentCard(a2);
   html += `</div>`;
 
   html += `<div class="section-title">Dimensions (${d.sharedDimensions}/4 shared)</div>`;
   html += `<div class="dims">`;
-  d.dimensions.forEach(dim => {
-    const m1pos = dim.type1.letter === dim.letters[0] ? 20 : 75;
-    const m2pos = dim.type2.letter === dim.letters[0] ? 20 : 75;
+  const dimLabels = ['Proactive / Reactive','Transparent / Encrypted','Convergent / Divergent','Nurturing / Stoic'];
+  d.dimensions.forEach((dim, i) => {
+    const s1 = dim.score1, s2 = dim.score2;
+    const hasScores = s1 !== null && s2 !== null;
+    const pos1 = hasScores ? 5 + (s1 / 4) * 85 : (dim.type1.letter === dim.letters[0] ? 20 : 75);
+    const pos2 = hasScores ? 5 + (s2 / 4) * 85 : (dim.type2.letter === dim.letters[0] ? 20 : 75);
     html += `<div class="dim">
-      <div class="dim-name">${dim.name}</div>
-      <div class="dim-bar">
+      <div class="dim-name">${dimLabels[i]}</div>
+      <div class="dim-scale">
         <span class="pole-label pole-left">${dim.poles[0]}</span>
         <span class="pole-label pole-right">${dim.poles[1]}</span>
-        <span class="dim-marker marker-1" style="left:${m1pos}%">${t1.code.slice(0,2)}</span>
-        <span class="dim-marker marker-2" style="left:${m2pos}%">${t2.code.slice(0,2)}</span>
+        <span class="dim-marker marker-1" style="left:${pos1}%">${a1.name.slice(0,2)}</span>
+        <span class="dim-marker marker-2" style="left:${pos2}%">${a2.name.slice(0,2)}</span>
       </div>
-      <div class="dim-status ${dim.match ? 'match' : ''}">${dim.match ? 'Match — both ' + dim.type1.pole : dim.type1.pole + ' vs ' + dim.type2.pole}</div>
+      <div class="dim-status ${dim.match ? 'match' : ''}">${dim.match ? 'Match — both ' + dim.type1.pole : dim.type1.pole + ' vs ' + dim.type2.pole}${hasScores ? ' (' + s1.toFixed(1) + ' vs ' + s2.toFixed(1) + ')' : ''}</div>
     </div>`;
   });
   html += `</div>`;
+
+  // Type comparison summary
+  html += `<div class="section-title">Type Comparison: ${a1.type} vs ${a2.type}</div>`;
 
   // Compatibility
   const c = d.compatibility;
@@ -180,27 +178,26 @@ function render(d) {
   if (c.mutual) { badgeClass = 'mutual'; badgeText = 'Mutually recommended pair'; }
   else if (c.type1RecommendsType2 || c.type2RecommendsType1) { badgeClass = 'partial'; badgeText = 'One-way recommendation'; }
 
-  html += `<div class="section-title">Compatibility</div>`;
   html += `<div class="compat">`;
   html += `<span class="compat-badge ${badgeClass}">${badgeText}</span>`;
-  if (c.reason1) html += `<div class="compat-reason"><strong>${t1.code}→${t2.code}:</strong> ${c.reason1}</div>`;
-  if (c.reason2) html += `<div class="compat-reason"><strong>${t2.code}→${t1.code}:</strong> ${c.reason2}</div>`;
+  if (c.reason1) html += `<div class="compat-reason"><strong>${a1.type}→${a2.type}:</strong> ${c.reason1}</div>`;
+  if (c.reason2) html += `<div class="compat-reason"><strong>${a2.type}→${a1.type}:</strong> ${c.reason2}</div>`;
   html += `</div>`;
 
   el.innerHTML = html;
 }
 
-function renderTypeCard(t) {
-  let h = `<div class="type-card">
-    <a class="pill" href="/type/${t.code}" style="text-decoration:none">${t.code}</a>
-    <h2><a href="/type/${t.code}" style="color:inherit;text-decoration:none">${t.code}</a></h2>
-    <div class="nick">${t.nick}</div>
-    <h3>Strengths</h3><ul>`;
-  (t.strengths || []).forEach(s => h += `<li>${s}</li>`);
-  h += `</ul><h3>Blind Spots</h3><ul>`;
-  (t.blindSpots || []).forEach(s => h += `<li>${s}</li>`);
-  h += `</ul><h3>Work Style</h3><div class="work-style">${t.workStyle || ''}</div></div>`;
-  return h;
+function agentCard(a) {
+  return `<div class="agent-card">
+    <span class="type-pill">${a.type}</span>
+    <h2>${a.name}</h2>
+    <div class="nick">${a.nick || ''}</div>
+    <div class="meta">
+      ${a.model ? `<div><strong>Model:</strong> ${a.model}</div>` : ''}
+      ${a.provider ? `<div><strong>Provider:</strong> ${a.provider}</div>` : ''}
+      ${a.consistency != null ? `<div><strong>Consistency:</strong> ${a.consistency}%</div>` : ''}
+    </div>
+  </div>`;
 }
 </script>
 </body>

--- a/compatibility.html
+++ b/compatibility.html
@@ -124,6 +124,7 @@ nav a:hover, nav a.active { color: var(--accent); }
   <a href="stats.html">Stats</a>
   <a href="types.html">Types</a>
   <a href="compare.html">Compare</a>
+  <a href="compare-agents.html">Agent Compare</a>
   <a href="test-agent.html">Test Agent</a>
   <a href="compatibility.html" class="active">Compatibility</a>
   <a href="cross-compatibility.html">Cross Match</a>

--- a/cross-compatibility.html
+++ b/cross-compatibility.html
@@ -139,6 +139,7 @@ nav a:hover, nav a.active { color: var(--accent); }
   <a href="stats.html">Stats</a>
   <a href="types.html">Types</a>
   <a href="compare.html">Compare</a>
+  <a href="compare-agents.html">Agent Compare</a>
   <a href="test-agent.html">Test Agent</a>
   <a href="compatibility.html">Compatibility</a>
   <a href="cross-compatibility.html" class="active">Cross Match</a>

--- a/index-v3.html
+++ b/index-v3.html
@@ -86,7 +86,7 @@ nav{position:fixed;top:0;left:0;right:0;z-index:20;display:flex;align-items:cent
 </head>
 <body>
 <nav>
-  <div class="nav-links"><a href="index.html">ABTI</a><a href="sbti.html">SBTI</a><a href="api.html">API</a></div>
+  <div class="nav-links"><a href="index.html">ABTI</a><a href="sbti.html">SBTI</a><a href="api.html">API</a><a href="compare-agents.html">Agent Compare</a></div>
   <button class="lang" onclick="toggleLang()" id="langBtn">EN</button>
 </nav>
 <div class="wrap">

--- a/index-v4.html
+++ b/index-v4.html
@@ -106,6 +106,7 @@ nav a:hover, nav a.active { color: var(--accent); }
   <a href="agents.html">Agents</a>
   <a href="leaderboard.html">Leaderboard</a>
   <a href="api.html">API</a>
+  <a href="compare-agents.html">Agent Compare</a>
   <button class="lang-btn" onclick="toggleLang()" id="langBtn">EN</button>
 </nav>
 <div class="wrap">

--- a/index.html
+++ b/index.html
@@ -723,6 +723,7 @@ body {
   <a href="stats.html">Stats</a>
   <a href="types.html">Types</a>
   <a href="compare.html">Compare</a>
+  <a href="compare-agents.html">Agent Compare</a>
   <a href="test-agent.html">Test Agent</a>
   <a href="compatibility.html">Compatibility</a>
   <a href="cross-compatibility.html">Cross Match</a>

--- a/leaderboard.html
+++ b/leaderboard.html
@@ -99,6 +99,7 @@ nav a:hover, nav a.active { color: var(--accent); }
   <a href="stats.html">Stats</a>
   <a href="types.html">Types</a>
   <a href="compare.html">Compare</a>
+  <a href="compare-agents.html">Agent Compare</a>
   <a href="test-agent.html">Test Agent</a>
   <a href="compatibility.html">Compatibility</a>
   <a href="cross-compatibility.html">Cross Match</a>

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "abti",
   "private": true,
   "scripts": {
-    "test": "node --test test/api.test.js test/mcp.test.js test/mcp-http.test.js test/compatibility.test.js test/cross-compatibility.test.js test/auto-reload.test.js test/parseAnswer.test.js test/provider.test.js test/resume.test.js test/list.test.js test/action-drift.test.js",
+    "test": "node --test test/api.test.js test/mcp.test.js test/mcp-http.test.js test/compatibility.test.js test/cross-compatibility.test.js test/auto-reload.test.js test/parseAnswer.test.js test/provider.test.js test/resume.test.js test/list.test.js test/action-drift.test.js test/compare-agents.test.js",
     "generate-og": "node scripts/generate-og-images.js",
     "generate-sitemap": "node scripts/generate-sitemap.js",
     "generate-og-agents": "node scripts/generate-agent-og.js"

--- a/sbti.html
+++ b/sbti.html
@@ -245,6 +245,7 @@ body {
   <a href="stats.html">Stats</a>
   <a href="types.html">Types</a>
   <a href="compare.html">Compare</a>
+  <a href="compare-agents.html">Agent Compare</a>
   <a href="test-agent.html">Test Agent</a>
   <a href="compatibility.html">Compatibility</a>
   <a href="cross-compatibility.html">Cross Match</a>

--- a/stats.html
+++ b/stats.html
@@ -130,6 +130,7 @@ nav .lang-btn:hover { color: var(--accent); border-color: var(--accent); }
   <a href="stats.html" class="active">Stats</a>
   <a href="types.html">Types</a>
   <a href="compare.html">Compare</a>
+  <a href="compare-agents.html">Agent Compare</a>
   <a href="test-agent.html">Test Agent</a>
   <a href="compatibility.html">Compatibility</a>
   <a href="cross-compatibility.html">Cross Match</a>

--- a/test-agent.html
+++ b/test-agent.html
@@ -500,6 +500,7 @@ textarea { resize: vertical; min-height: 80px; }
   <a href="stats.html">Stats</a>
   <a href="types.html">Types</a>
   <a href="compare.html">Compare</a>
+  <a href="compare-agents.html">Agent Compare</a>
   <a href="test-agent.html" class="active">Test Agent</a>
   <a href="compatibility.html">Compatibility</a>
   <a href="cross-compatibility.html">Cross Match</a>

--- a/test/compare-agents.test.js
+++ b/test/compare-agents.test.js
@@ -1,0 +1,119 @@
+const { describe, it, before, after, beforeEach } = require('node:test');
+const assert = require('node:assert/strict');
+const http = require('node:http');
+const os = require('node:os');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'abti-cmp-'));
+process.env.ABTI_DATA_DIR = tmpDir;
+
+const server = require('../api-server.js');
+const { rateLimitMap, resetData } = require('../api-server.js');
+
+let BASE;
+
+function req(urlPath, opts = {}) {
+  return new Promise((resolve, reject) => {
+    const url = new URL(urlPath, BASE);
+    const o = { hostname: url.hostname, port: url.port, path: url.pathname + url.search, method: opts.method || 'GET', headers: opts.headers || {} };
+    if (opts.body) o.headers['Content-Type'] = 'application/json';
+    const r = http.request(o, (res) => {
+      let d = '';
+      res.on('data', c => d += c);
+      res.on('end', () => resolve({ status: res.statusCode, headers: res.headers, body: d, json() { return JSON.parse(d); } }));
+    });
+    r.on('error', reject);
+    if (opts.body) r.write(typeof opts.body === 'string' ? opts.body : JSON.stringify(opts.body));
+    r.end();
+  });
+}
+
+before(async () => {
+  await new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      const { port } = server.address();
+      BASE = `http://127.0.0.1:${port}`;
+      resolve();
+    });
+  });
+  rateLimitMap.clear();
+
+  // Seed two test agents
+  // answers: array of 16 values, 1=A, 0=B
+  const answers1 = [1,1,1,1, 1,1,1,1, 1,1,1,1, 1,1,1,1]; // all A → PTCN
+  const answers2 = [0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0]; // all B → REDS
+
+  rateLimitMap.clear();
+  const r1 = await req('/api/agent-test', { method: 'POST', body: { agentName: 'Test Agent Alpha', model: 'test-model-1', provider: 'test-provider', answers: answers1 } });
+  rateLimitMap.clear();
+  const r2 = await req('/api/agent-test', { method: 'POST', body: { agentName: 'Test Agent Beta', model: 'test-model-2', provider: 'test-provider', answers: answers2 } });
+  rateLimitMap.clear();
+});
+
+beforeEach(() => { rateLimitMap.clear(); });
+
+after(() => new Promise((resolve) => {
+  server.close(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    delete process.env.ABTI_DATA_DIR;
+    resolve();
+  });
+}));
+
+describe('GET /api/compare/agents/:slug1/:slug2', () => {
+  it('returns comparison for two valid agents', async () => {
+    const r = await req('/api/compare/agents/test-agent-alpha/test-agent-beta');
+    assert.equal(r.status, 200);
+    const j = r.json();
+    assert.ok(j.agent1, 'should have agent1');
+    assert.ok(j.agent2, 'should have agent2');
+    assert.equal(j.agent1.name, 'Test Agent Alpha');
+    assert.equal(j.agent2.name, 'Test Agent Beta');
+    assert.ok(Array.isArray(j.dimensions), 'should have dimensions array');
+    assert.equal(j.dimensions.length, 4);
+    assert.equal(typeof j.sharedDimensions, 'number');
+    assert.ok(j.compatibility, 'should have compatibility');
+    assert.equal(typeof j.compatibility.mutual, 'boolean');
+
+    // Each dimension should have score1 and score2
+    for (const dim of j.dimensions) {
+      assert.ok(dim.name, 'dimension should have name');
+      assert.ok(Array.isArray(dim.poles), 'dimension should have poles');
+      assert.equal(typeof dim.match, 'boolean');
+      assert.equal(typeof dim.score1, 'number');
+      assert.equal(typeof dim.score2, 'number');
+    }
+  });
+
+  it('strips answers from agent data', async () => {
+    const r = await req('/api/compare/agents/test-agent-alpha/test-agent-beta');
+    const j = r.json();
+    assert.equal(j.agent1.answers, undefined, 'agent1 should not have answers');
+    assert.equal(j.agent2.answers, undefined, 'agent2 should not have answers');
+  });
+
+  it('returns 404 for nonexistent agent', async () => {
+    const r = await req('/api/compare/agents/nonexistent-agent/test-agent-alpha');
+    assert.equal(r.status, 404);
+    const j = r.json();
+    assert.ok(j.error.includes('nonexistent-agent'));
+  });
+
+  it('returns 404 when second agent not found', async () => {
+    const r = await req('/api/compare/agents/test-agent-alpha/does-not-exist');
+    assert.equal(r.status, 404);
+    const j = r.json();
+    assert.ok(j.error.includes('does-not-exist'));
+  });
+
+  it('comparing same agent works', async () => {
+    const r = await req('/api/compare/agents/test-agent-alpha/test-agent-alpha');
+    assert.equal(r.status, 200);
+    const j = r.json();
+    assert.equal(j.sharedDimensions, 4, 'same agent should share all dimensions');
+    for (const dim of j.dimensions) {
+      assert.equal(dim.match, true);
+    }
+  });
+});

--- a/type.html
+++ b/type.html
@@ -196,6 +196,7 @@ nav a:hover, nav a.active { color: var(--accent); }
   <a href="stats.html">Stats</a>
   <a href="types.html">Types</a>
   <a href="compare.html">Compare</a>
+  <a href="compare-agents.html">Agent Compare</a>
   <a href="test-agent.html">Test Agent</a>
   <a href="compatibility.html">Compatibility</a>
   <a href="cross-compatibility.html">Cross Match</a>

--- a/types.html
+++ b/types.html
@@ -89,6 +89,7 @@ nav .lang-btn:hover { color: var(--accent); border-color: var(--accent); }
   <a href="stats.html">Stats</a>
   <a href="types.html" class="active">Types</a>
   <a href="compare.html">Compare</a>
+  <a href="compare-agents.html">Agent Compare</a>
   <a href="test-agent.html">Test Agent</a>
   <a href="compatibility.html">Compatibility</a>
   <a href="cross-compatibility.html">Cross Match</a>


### PR DESCRIPTION
Closes #335

## What
Add agent-vs-agent comparison functionality:

### API
- `GET /api/compare/agents/:slug1/:slug2` — returns both agents' data, dimensional score comparison, and compatibility info
- Strips `answers` field from response for privacy
- Supports `?lang=` param for i18n

### Frontend
- New `compare-agents.html` page with:
  - Dual agent selector dropdowns (populated from `/api/agents`)
  - Side-by-side agent cards with type, provider, model info
  - Dimensional comparison bars showing actual scores
  - Compatibility analysis section
  - URL params for deep-linking: `?a=slug1&b=slug2`
- Nav link added across all pages
- Added to sitemap.xml

### Tests
- 5 new tests covering: valid comparison, answer stripping, 404 handling, self-comparison

### Why
Comparing actual agents is more tangible and shareable than abstract type comparison. Supports north star of making ABTI results more engaging.