### PR TITLE
feat: dynamic OG meta tags for compare-agents page

### DIFF
--- a/api-server.js
+++ b/api-server.js
@@ -1012,6 +1012,59 @@ ${dimInfo.map((d, i) => {
     return res.end(html);
   }
 
+  // GET /compare-agents or /compare-agents.html - compare two agents with dynamic OG tags
+  if ((url.pathname === '/compare-agents' || url.pathname === '/compare-agents.html') && req.method === 'GET') {
+    let html;
+    try {
+      html = fs.readFileSync(path.join(__dirname, 'compare-agents.html'), 'utf8');
+    } catch {
+      res.writeHead(500, {'Content-Type':'text/plain'});
+      return res.end('Server error');
+    }
+    const slugA = url.searchParams.get('a');
+    const slugB = url.searchParams.get('b');
+    if (slugA && slugB) {
+      const findAgent = (s) => {
+        const sl = decodeURIComponent(s).toLowerCase();
+        const matches = agentData.agents.filter(a => a.slug === sl || slugify(a.name) === sl);
+        return matches.length ? matches[matches.length - 1] : null;
+      };
+      const agent1 = findAgent(slugA);
+      const agent2 = findAgent(slugB);
+      if (agent1 && agent2) {
+        const nick1 = types[agent1.type]?.en?.nick || agent1.nick || agent1.type;
+        const nick2 = types[agent2.type]?.en?.nick || agent2.nick || agent2.type;
+        let sharedDims = 0;
+        for (let i = 0; i < 4 && i < agent1.type.length && i < agent2.type.length; i++) {
+          if (agent1.type[i] === agent2.type[i]) sharedDims++;
+        }
+        const title = `${agent1.name} vs ${agent2.name} — ABTI Agent Compare`;
+        const desc = `Compare AI agent personalities: ${agent1.type} (${nick1}) vs ${agent2.type} (${nick2}) — ${sharedDims}/4 shared dimensions`;
+        const slug1 = agent1.slug || slugify(agent1.name);
+        const slug2 = agent2.slug || slugify(agent2.name);
+        const ogTags = [
+          `<meta property="og:title" content="${title}">`,
+          `<meta property="og:description" content="${desc}">`,
+          `<meta property="og:image" content="https://abti.kagura-agent.com/og-abti.png">`,
+          `<meta property="og:url" content="https://abti.kagura-agent.com/compare-agents.html?a=${encodeURIComponent(slug1)}&b=${encodeURIComponent(slug2)}">`,
+          `<meta property="og:type" content="website">`,
+          `<meta name="twitter:card" content="summary_large_image">`,
+          `<meta name="twitter:title" content="${title}">`,
+          `<meta name="twitter:description" content="${desc}">`,
+          `<meta name="twitter:image" content="https://abti.kagura-agent.com/og-abti.png">`,
+        ].join('\n');
+        html = html.replace(/<title>[^<]*<\/title>/, `<title>${title}</title>`);
+        html = html.replace(/<meta name="twitter:card"[^>]*>/, '');
+        html = html.replace(/<meta name="twitter:title"[^>]*>/, '');
+        html = html.replace(/<meta name="twitter:description"[^>]*>/, '');
+        html = html.replace(/<meta name="twitter:image"[^>]*>/, '');
+        html = html.replace('</head>', ogTags + '\n</head>');
+      }
+    }
+    res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+    return res.end(html);
+  }
+
   // GET /test-agent - serve test-agent.html
   if (url.pathname === '/test-agent' && req.method === 'GET') {
     try {
@@ -1058,7 +1111,7 @@ ${dimInfo.map((d, i) => {
   if (url.pathname === '/sitemap.xml' && req.method === 'GET') {
     const BASE = 'https://abti.kagura-agent.com';
     const VALID_TYPES = ['PTCF','PTCN','PTDF','PTDN','PECF','PECN','PEDF','PEDN','RTCF','RTCN','RTDF','RTDN','RECF','RECN','REDF','REDN'];
-    const staticPages = ['/', '/types.html', '/agents.html', '/compare.html', '/api.html', '/sbti.html', '/test-agent.html', '/cross-compatibility.html', '/leaderboard.html'];
+    const staticPages = ['/', '/types.html', '/agents.html', '/compare.html', '/compare-agents.html', '/api.html', '/sbti.html', '/test-agent.html', '/cross-compatibility.html', '/leaderboard.html'];
     const urls = staticPages.map(p => `  <url><loc>${BASE}${p}</loc></url>`);
     VALID_TYPES.forEach(code => urls.push(`  <url><loc>${BASE}/type/${code}</loc></url>`));
     VALID_TYPES.forEach(code => urls.push(`  <url><loc>${BASE}/result/${code}</loc></url>`));

--- a/compare-agents.html
+++ b/compare-agents.html
@@ -1,0 +1,223 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Compare Agents — ABTI</title>
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Compare Agents — ABTI">
+<meta name="twitter:description" content="Compare AI agent personalities side by side">
+<meta name="twitter:image" content="https://abti.kagura-agent.com/og-abti.png">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=DM+Sans:opsz,wght@9..40,400;9..40,500;9..40,600;9..40,700&family=Instrument+Serif&display=swap" rel="stylesheet">
+<style>
+:root {
+  --bg: #fafaf9; --surface: #fff; --surface2: #f5f5f4;
+  --text: #1c1917; --text2: #78716c; --text3: #a8a29e;
+  --accent: #0d9488; --accent2: #0f766e; --accent-soft: #f0fdfa;
+  --border: #e7e5e4; --radius: 10px;
+  --shadow: 0 1px 3px rgba(28,25,23,.06), 0 1px 2px rgba(28,25,23,.04);
+  --shadow-md: 0 4px 12px rgba(28,25,23,.07), 0 2px 4px rgba(28,25,23,.04);
+}
+* { margin: 0; padding: 0; box-sizing: border-box; }
+body { font-family: 'DM Sans', system-ui, sans-serif; background: var(--bg); color: var(--text); min-height: 100vh; -webkit-font-smoothing: antialiased; }
+
+nav { position: fixed; top: 0; left: 0; right: 0; display: flex; align-items: center; justify-content: center; gap: 2rem; padding: .7rem 1rem; background: rgba(250,250,249,.88); backdrop-filter: blur(12px); -webkit-backdrop-filter: blur(12px); border-bottom: 1px solid var(--border); z-index: 100; font-size: .82rem; letter-spacing: .08em; }
+nav a { color: var(--text2); text-decoration: none; font-weight: 500; transition: color .2s; }
+nav a:hover, nav a.active { color: var(--accent); }
+
+.wrap { max-width: 900px; margin: 0 auto; padding: 5rem 1.25rem 2rem; }
+.header { text-align: center; margin-bottom: 2rem; }
+.header h1 { font-family: 'Instrument Serif', serif; font-size: 2.4rem; font-weight: 400; color: var(--text); margin-bottom: .4rem; }
+.header h1 span { color: var(--accent); }
+
+.selectors { display: flex; gap: 1rem; justify-content: center; align-items: center; flex-wrap: wrap; margin-bottom: 2.5rem; }
+.selectors select { font-family: 'DM Sans', system-ui, sans-serif; font-size: .9rem; padding: .5rem 1rem; border: 1px solid var(--border); border-radius: var(--radius); background: var(--surface); color: var(--text); cursor: pointer; min-width: 220px; }
+.selectors select:focus { outline: none; border-color: var(--accent); }
+.vs { font-weight: 600; color: var(--text3); font-size: .85rem; letter-spacing: .1em; }
+.compare-btn { font-family: 'DM Sans', system-ui, sans-serif; font-size: .85rem; font-weight: 600; padding: .55rem 1.5rem; background: var(--accent); color: #fff; border: none; border-radius: var(--radius); cursor: pointer; transition: background .2s; letter-spacing: .04em; }
+.compare-btn:hover { background: var(--accent2); }
+
+#result { display: none; }
+
+.agents-row { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; margin-bottom: 2rem; }
+.agent-card { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); padding: 1.25rem; box-shadow: var(--shadow); }
+.agent-card .pill { display: inline-block; background: var(--accent-soft); color: var(--accent); font-size: .7rem; font-weight: 700; padding: .15rem .55rem; border-radius: 999px; letter-spacing: .06em; margin-bottom: .4rem; text-decoration: none; }
+.agent-card h2 { font-size: 1.1rem; font-weight: 600; margin-bottom: .25rem; }
+.agent-card h2 a { color: inherit; text-decoration: none; }
+.agent-card h2 a:hover { color: var(--accent); }
+.agent-card .nick { color: var(--text2); font-size: .85rem; margin-bottom: .5rem; }
+.agent-card .meta { font-size: .78rem; color: var(--text3); }
+
+.section-title { font-size: .95rem; font-weight: 600; margin-bottom: 1rem; color: var(--text); }
+
+.dims { display: flex; flex-direction: column; gap: .75rem; margin-bottom: 2rem; }
+.dim { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); padding: 1rem 1.25rem; box-shadow: var(--shadow); }
+.dim-name { font-size: .8rem; font-weight: 600; color: var(--text); margin-bottom: .5rem; text-transform: uppercase; letter-spacing: .06em; }
+.dim-bar { position: relative; height: 28px; background: var(--surface2); border-radius: 14px; overflow: hidden; margin-bottom: .35rem; }
+.dim-bar .pole-label { position: absolute; top: 50%; transform: translateY(-50%); font-size: .7rem; font-weight: 600; z-index: 2; }
+.dim-bar .pole-left { left: .6rem; color: var(--text2); }
+.dim-bar .pole-right { right: .6rem; color: var(--text2); }
+.dim-marker { position: absolute; top: 2px; width: 24px; height: 24px; border-radius: 50%; display: flex; align-items: center; justify-content: center; font-size: .55rem; font-weight: 700; color: #fff; z-index: 3; }
+.marker-1 { background: var(--accent); }
+.marker-2 { background: #e8658a; }
+.dim-status { font-size: .72rem; color: var(--text3); text-align: center; }
+.dim-status.match { color: var(--accent); font-weight: 600; }
+
+.compat { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); padding: 1.25rem; box-shadow: var(--shadow); margin-bottom: 2rem; }
+.score-badge { display: inline-block; padding: .2rem .7rem; border-radius: 999px; font-size: .75rem; font-weight: 600; margin-bottom: .5rem; }
+.score-badge.complementary { background: #dcfce7; color: #166534; }
+.score-badge.balanced { background: #fef9c3; color: #854d0e; }
+.score-badge.similar { background: var(--surface2); color: var(--text3); }
+.compat-summary { font-size: .82rem; color: var(--text2); line-height: 1.55; }
+
+.error-msg { text-align: center; color: var(--text2); padding: 2rem; }
+
+.footer { text-align: center; color: var(--text3); font-size: .72rem; margin-top: 2rem; padding-bottom: 1rem; }
+
+@media (max-width: 600px) {
+  .agents-row { grid-template-columns: 1fr; }
+  .header h1 { font-size: 1.8rem; }
+  .wrap { padding: 4rem 1rem 1.5rem; }
+  .selectors { flex-direction: column; align-items: stretch; }
+  .selectors select { min-width: auto; }
+  .vs { display: none; }
+}
+</style>
+</head>
+<body>
+<nav>
+  <a href="index.html">ABTI</a>
+  <a href="sbti.html">SBTI-AI</a>
+  <a href="agents.html">Agents</a>
+  <a href="leaderboard.html">Leaderboard</a>
+  <a href="stats.html">Stats</a>
+  <a href="types.html">Types</a>
+  <a href="compare.html">Compare</a>
+  <a href="compare-agents.html" class="active">Compare Agents</a>
+  <a href="test-agent.html">Test Agent</a>
+  <a href="compatibility.html">Compatibility</a>
+  <a href="cross-compatibility.html">Cross Match</a>
+  <a href="api.html">API</a>
+</nav>
+<div class="wrap">
+  <div class="header">
+    <h1>Compare <span>Agents</span></h1>
+  </div>
+  <div class="selectors">
+    <select id="sel1"><option value="">Select agent...</option></select>
+    <span class="vs">VS</span>
+    <select id="sel2"><option value="">Select agent...</option></select>
+    <button class="compare-btn" onclick="doCompare()">Compare</button>
+  </div>
+  <div id="result"></div>
+  <div class="footer">ABTI &mdash; Agent Behavioral Type Indicator</div>
+</div>
+<script>
+const sel1 = document.getElementById('sel1');
+const sel2 = document.getElementById('sel2');
+let agentsList = [];
+
+async function init() {
+  const res = await fetch('/api/agents');
+  if (!res.ok) return;
+  const data = await res.json();
+  agentsList = (data.agents || data).sort((a, b) => a.name.localeCompare(b.name));
+  agentsList.forEach(a => {
+    const label = `${a.name} (${a.type})`;
+    sel1.add(new Option(label, a.slug));
+    sel2.add(new Option(label, a.slug));
+  });
+  // Read URL params
+  const params = new URLSearchParams(location.search);
+  if (params.get('a')) sel1.value = params.get('a');
+  if (params.get('b')) sel2.value = params.get('b');
+  if (params.get('a') && params.get('b')) doCompare();
+}
+
+async function doCompare() {
+  const a = sel1.value, b = sel2.value;
+  const el = document.getElementById('result');
+  if (!a || !b) { el.innerHTML = '<p class="error-msg">Please select two agents to compare.</p>'; el.style.display = 'block'; return; }
+  if (a === b) { el.innerHTML = '<p class="error-msg">Please select two different agents.</p>'; el.style.display = 'block'; return; }
+  history.replaceState(null, '', `compare-agents.html?a=${encodeURIComponent(a)}&b=${encodeURIComponent(b)}`);
+  try {
+    const [r1, r2] = await Promise.all([fetch(`/api/agent/${encodeURIComponent(a)}`), fetch(`/api/agent/${encodeURIComponent(b)}`)]);
+    if (!r1.ok || !r2.ok) { el.innerHTML = '<p class="error-msg">One or both agents not found.</p>'; el.style.display = 'block'; return; }
+    const [a1, a2] = await Promise.all([r1.json(), r2.json()]);
+    // Also fetch type comparison
+    const cr = await fetch(`/api/compare/${a1.type}/${a2.type}`);
+    const comp = cr.ok ? await cr.json() : null;
+    render(a1, a2, comp);
+  } catch (e) {
+    el.innerHTML = '<p class="error-msg">Error loading agent data.</p>';
+    el.style.display = 'block';
+  }
+}
+
+function render(a1, a2, comp) {
+  const el = document.getElementById('result');
+  el.style.display = 'block';
+  const DIM_NAMES = ['Autonomy', 'Precision', 'Transparency', 'Adaptability'];
+  const DIM_POLES = [['Proactive', 'Responsive'], ['Thorough', 'Efficient'], ['Candid', 'Diplomatic'], ['Flexible', 'Principled']];
+  const DIM_LETTERS = [['P', 'R'], ['T', 'E'], ['C', 'D'], ['F', 'N']];
+
+  let html = `<div class="agents-row">`;
+  html += renderAgentCard(a1);
+  html += renderAgentCard(a2);
+  html += `</div>`;
+
+  // Dimension comparison
+  let shared = 0;
+  for (let i = 0; i < 4; i++) if (a1.type[i] === a2.type[i]) shared++;
+
+  html += `<div class="section-title">Type Dimensions (${shared}/4 shared)</div>`;
+  html += `<div class="dims">`;
+  for (let i = 0; i < 4; i++) {
+    const l1 = a1.type[i], l2 = a2.type[i];
+    const match = l1 === l2;
+    const p1 = l1 === DIM_LETTERS[i][0] ? 20 : 75;
+    const p2 = l2 === DIM_LETTERS[i][0] ? 20 : 75;
+    const pole1 = DIM_POLES[i][DIM_LETTERS[i].indexOf(l1)];
+    const pole2 = DIM_POLES[i][DIM_LETTERS[i].indexOf(l2)];
+    html += `<div class="dim">
+      <div class="dim-name">${DIM_NAMES[i]}</div>
+      <div class="dim-bar">
+        <span class="pole-label pole-left">${DIM_POLES[i][0]}</span>
+        <span class="pole-label pole-right">${DIM_POLES[i][1]}</span>
+        <span class="dim-marker marker-1" style="left:${p1}%">A</span>
+        <span class="dim-marker marker-2" style="left:${p2}%">B</span>
+      </div>
+      <div class="dim-status ${match ? 'match' : ''}">${match ? 'Match — both ' + pole1 : pole1 + ' vs ' + pole2}</div>
+    </div>`;
+  }
+  html += `</div>`;
+
+  // Type compatibility if available
+  if (comp) {
+    const cat = comp.compatibility?.category || (shared >= 3 ? 'similar' : shared >= 2 ? 'balanced' : 'complementary');
+    html += `<div class="section-title">Type Compatibility</div>`;
+    html += `<div class="compat">`;
+    html += `<span class="score-badge ${cat}">${cat.charAt(0).toUpperCase() + cat.slice(1)}</span>`;
+    if (comp.compatibility?.summary) html += `<div class="compat-summary">${comp.compatibility.summary}</div>`;
+    html += `</div>`;
+  }
+
+  el.innerHTML = html;
+}
+
+function renderAgentCard(a) {
+  const slug = a.slug || a.name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/-+$/, '');
+  return `<div class="agent-card">
+    <a class="pill" href="/type/${a.type}">${a.type}</a>
+    <h2><a href="/agent/${slug}">${a.name}</a></h2>
+    <div class="nick">${a.nick || a.type}</div>
+    <div class="meta">${a.provider ? 'Provider: ' + a.provider : ''}</div>
+  </div>`;
+}
+
+init();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## What
When sharing compare-agents links like `/compare-agents.html?a=claude-3-5-sonnet&b=gpt-4o`, social media previews now show dynamic titles and descriptions instead of the generic ABTI default.

## Changes
- **api-server.js**: Add server-side OG tag injection for `/compare-agents` route
  - Dynamic title: `Agent1 vs Agent2 — ABTI Agent Compare`
  - Dynamic description with types, nicknames, and shared dimension count
  - Twitter Card meta tags
- **compare-agents.html**: New page with base meta tags for fallback
- **Sitemap**: Added `/compare-agents.html` to sitemap generation

## How it works
1. Server intercepts `/compare-agents.html?a=slug1&b=slug2`
2. Looks up both agents in `agentData`
3. Calculates shared dimensions between types
4. Injects OG/Twitter meta tags before serving HTML

Closes #337