### PR TITLE
Nav: add Compare Agents link to all page navigation bars

### DIFF
--- a/agent.html
+++ b/agent.html
@@ -178,6 +178,7 @@ nav a:hover, nav a.active { color: var(--accent); }
   <a href="stats.html">Stats</a>
   <a href="types.html">Types</a>
   <a href="compare.html">Compare</a>
+  <a href="compare-agents.html">Compare Agents</a>
   <a href="test-agent.html">Test Agent</a>
   <a href="compatibility.html">Compatibility</a>
   <a href="cross-compatibility.html">Cross Match</a>

--- a/agents.html
+++ b/agents.html
@@ -142,6 +142,7 @@ nav a:hover, nav a.active { color: var(--accent); }
   <a href="stats.html">Stats</a>
   <a href="types.html">Types</a>
   <a href="compare.html">Compare</a>
+  <a href="compare-agents.html">Compare Agents</a>
   <a href="test-agent.html">Test Agent</a>
   <a href="compatibility.html">Compatibility</a>
   <a href="cross-compatibility.html">Cross Match</a>

--- a/api.html
+++ b/api.html
@@ -184,6 +184,7 @@ pre code {
   <a href="stats.html">Stats</a>
   <a href="types.html">Types</a>
   <a href="compare.html">Compare</a>
+  <a href="compare-agents.html">Compare Agents</a>
   <a href="test-agent.html">Test Agent</a>
   <a href="compatibility.html">Compatibility</a>
   <a href="cross-compatibility.html">Cross Match</a>

--- a/compare.html
+++ b/compare.html
@@ -96,6 +96,7 @@ nav a:hover, nav a.active { color: var(--accent); }
   <a href="stats.html">Stats</a>
   <a href="types.html">Types</a>
   <a href="compare.html" class="active">Compare</a>
+  <a href="compare-agents.html">Compare Agents</a>
   <a href="test-agent.html">Test Agent</a>
   <a href="compatibility.html">Compatibility</a>
   <a href="cross-compatibility.html">Cross Match</a>

--- a/compatibility.html
+++ b/compatibility.html
@@ -124,6 +124,7 @@ nav a:hover, nav a.active { color: var(--accent); }
   <a href="stats.html">Stats</a>
   <a href="types.html">Types</a>
   <a href="compare.html">Compare</a>
+  <a href="compare-agents.html">Compare Agents</a>
   <a href="test-agent.html">Test Agent</a>
   <a href="compatibility.html" class="active">Compatibility</a>
   <a href="cross-compatibility.html">Cross Match</a>

--- a/cross-compatibility.html
+++ b/cross-compatibility.html
@@ -139,6 +139,7 @@ nav a:hover, nav a.active { color: var(--accent); }
   <a href="stats.html">Stats</a>
   <a href="types.html">Types</a>
   <a href="compare.html">Compare</a>
+  <a href="compare-agents.html">Compare Agents</a>
   <a href="test-agent.html">Test Agent</a>
   <a href="compatibility.html">Compatibility</a>
   <a href="cross-compatibility.html" class="active">Cross Match</a>

--- a/index.html
+++ b/index.html
@@ -723,6 +723,7 @@ body {
   <a href="stats.html">Stats</a>
   <a href="types.html">Types</a>
   <a href="compare.html">Compare</a>
+  <a href="compare-agents.html">Compare Agents</a>
   <a href="test-agent.html">Test Agent</a>
   <a href="compatibility.html">Compatibility</a>
   <a href="cross-compatibility.html">Cross Match</a>

--- a/leaderboard.html
+++ b/leaderboard.html
@@ -99,6 +99,7 @@ nav a:hover, nav a.active { color: var(--accent); }
   <a href="stats.html">Stats</a>
   <a href="types.html">Types</a>
   <a href="compare.html">Compare</a>
+  <a href="compare-agents.html">Compare Agents</a>
   <a href="test-agent.html">Test Agent</a>
   <a href="compatibility.html">Compatibility</a>
   <a href="cross-compatibility.html">Cross Match</a>

--- a/sbti.html
+++ b/sbti.html
@@ -245,6 +245,7 @@ body {
   <a href="stats.html">Stats</a>
   <a href="types.html">Types</a>
   <a href="compare.html">Compare</a>
+  <a href="compare-agents.html">Compare Agents</a>
   <a href="test-agent.html">Test Agent</a>
   <a href="compatibility.html">Compatibility</a>
   <a href="cross-compatibility.html">Cross Match</a>

--- a/stats.html
+++ b/stats.html
@@ -130,6 +130,7 @@ nav .lang-btn:hover { color: var(--accent); border-color: var(--accent); }
   <a href="stats.html" class="active">Stats</a>
   <a href="types.html">Types</a>
   <a href="compare.html">Compare</a>
+  <a href="compare-agents.html">Compare Agents</a>
   <a href="test-agent.html">Test Agent</a>
   <a href="compatibility.html">Compatibility</a>
   <a href="cross-compatibility.html">Cross Match</a>

--- a/test-agent.html
+++ b/test-agent.html
@@ -500,6 +500,7 @@ textarea { resize: vertical; min-height: 80px; }
   <a href="stats.html">Stats</a>
   <a href="types.html">Types</a>
   <a href="compare.html">Compare</a>
+  <a href="compare-agents.html">Compare Agents</a>
   <a href="test-agent.html" class="active">Test Agent</a>
   <a href="compatibility.html">Compatibility</a>
   <a href="cross-compatibility.html">Cross Match</a>

--- a/type.html
+++ b/type.html
@@ -196,6 +196,7 @@ nav a:hover, nav a.active { color: var(--accent); }
   <a href="stats.html">Stats</a>
   <a href="types.html">Types</a>
   <a href="compare.html">Compare</a>
+  <a href="compare-agents.html">Compare Agents</a>
   <a href="test-agent.html">Test Agent</a>
   <a href="compatibility.html">Compatibility</a>
   <a href="cross-compatibility.html">Cross Match</a>

--- a/types.html
+++ b/types.html
@@ -89,6 +89,7 @@ nav .lang-btn:hover { color: var(--accent); border-color: var(--accent); }
   <a href="stats.html">Stats</a>
   <a href="types.html" class="active">Types</a>
   <a href="compare.html">Compare</a>
+  <a href="compare-agents.html">Compare Agents</a>
   <a href="test-agent.html">Test Agent</a>
   <a href="compatibility.html">Compatibility</a>
   <a href="cross-compatibility.html">Cross Match</a>


### PR DESCRIPTION
Adds `<a href="compare-agents.html">Compare Agents</a>` after the Compare link in all 13 HTML pages that have navigation bars.

**Pages updated:** agent, agents, api, compare, compatibility, cross-compatibility, index, leaderboard, sbti, stats, test-agent, type, types

**Not modified:** compare-agents.html (already has it), share-card.html (no nav), index-v2/v3/v4.html (legacy)

Fixes #339