### PR TITLE
feat(nav): add hamburger menu for mobile viewports

### DIFF
--- a/agent.html
+++ b/agent.html
@@ -54,6 +54,14 @@ nav a:hover, nav a.active { color: var(--accent); }
   transition: all .2s; letter-spacing: .05em;
 }
 .lang-btn:hover { border-color: var(--accent); color: var(--accent); }
+.hamburger { display: none; background: none; border: none; font-size: 1.4rem; cursor: pointer; color: var(--text); padding: .2rem .5rem; position: absolute; right: 1rem; }
+@media (max-width: 600px) {
+  nav { flex-wrap: wrap; justify-content: flex-start; gap: 0; padding: .7rem 1rem; }
+  nav a { display: none; width: 100%; padding: .5rem 0; }
+  nav.open a { display: block; }
+  nav .lang-btn { position: absolute; right: 3rem; top: .55rem; }
+  .hamburger { display: block; }
+}
 
 .wrap { max-width: 640px; margin: 0 auto; padding: 5rem 1.25rem 3rem; }
 
@@ -171,6 +179,7 @@ nav a:hover, nav a.active { color: var(--accent); }
 </head>
 <body>
 <nav>
+  <button class="hamburger" aria-label="Menu">☰</button>
   <a href="index.html">ABTI</a>
   <a href="sbti.html">SBTI-AI</a>
   <a href="agents.html" class="active">Agents</a>
@@ -385,6 +394,14 @@ nav a:hover, nav a.active { color: var(--accent); }
   }
 
   fetchAgent();
+})();
+</script>
+<script>
+(function(){
+  const nav = document.querySelector('nav');
+  const btn = nav.querySelector('.hamburger');
+  btn.addEventListener('click', () => nav.classList.toggle('open'));
+  nav.querySelectorAll('a').forEach(a => a.addEventListener('click', () => nav.classList.remove('open')));
 })();
 </script>
 </body>

--- a/agents.html
+++ b/agents.html
@@ -35,6 +35,13 @@ body { font-family: 'DM Sans', system-ui, sans-serif; background: var(--bg); col
 nav { position: fixed; top: 0; left: 0; right: 0; display: flex; align-items: center; justify-content: center; gap: 2rem; padding: .7rem 1rem; background: rgba(250,250,249,.88); backdrop-filter: blur(12px); -webkit-backdrop-filter: blur(12px); border-bottom: 1px solid var(--border); z-index: 100; font-size: .82rem; letter-spacing: .08em; }
 nav a { color: var(--text2); text-decoration: none; font-weight: 500; transition: color .2s; }
 nav a:hover, nav a.active { color: var(--accent); }
+.hamburger { display: none; background: none; border: none; font-size: 1.4rem; cursor: pointer; color: var(--text); padding: .2rem .5rem; position: absolute; right: 1rem; }
+@media (max-width: 600px) {
+  nav { flex-wrap: wrap; justify-content: flex-start; gap: 0; padding: .7rem 1rem; }
+  nav a { display: none; width: 100%; padding: .5rem 0; }
+  nav.open a { display: block; }
+  .hamburger { display: block; }
+}
 
 .wrap { max-width: 720px; margin: 0 auto; padding: 5rem 1.25rem 2rem; }
 
@@ -135,6 +142,7 @@ nav a:hover, nav a.active { color: var(--accent); }
 </head>
 <body>
 <nav>
+  <button class="hamburger" aria-label="Menu">☰</button>
   <a href="index.html">ABTI</a>
   <a href="sbti.html">SBTI-AI</a>
   <a href="agents.html" class="active">Agents</a>
@@ -358,6 +366,14 @@ nav a:hover, nav a.active { color: var(--accent); }
   }
 })();
 function esc(s) { const d = document.createElement('div'); d.textContent = s; return d.innerHTML; }
+</script>
+<script>
+(function(){
+  const nav = document.querySelector('nav');
+  const btn = nav.querySelector('.hamburger');
+  btn.addEventListener('click', () => nav.classList.toggle('open'));
+  nav.querySelectorAll('a').forEach(a => a.addEventListener('click', () => nav.classList.remove('open')));
+})();
 </script>
 </body>
 </html>

--- a/api.html
+++ b/api.html
@@ -43,6 +43,13 @@ body {
 .nav a { color: var(--text2); text-decoration: none; transition: color 0.2s; letter-spacing: 0.1em; }
 .nav a:hover { color: var(--accent); }
 .nav a.active { color: var(--accent); font-weight: 600; }
+.hamburger { display: none; background: none; border: none; font-size: 1.4rem; cursor: pointer; color: var(--text); padding: .2rem .5rem; position: absolute; right: 1rem; }
+@media (max-width: 600px) {
+  .nav { flex-wrap: wrap; justify-content: flex-start; gap: 0; padding: .7rem 1rem; }
+  .nav a { display: none; width: 100%; padding: .5rem 0; }
+  .nav.open a { display: block; }
+  .hamburger { display: block; }
+}
 
 .container {
   max-width: 760px;
@@ -177,6 +184,7 @@ pre code {
 <body>
 
 <nav class="nav">
+  <button class="hamburger" aria-label="Menu">&#9776;</button>
   <a href="index.html">ABTI</a>
   <a href="sbti.html">SBTI-AI</a>
   <a href="agents.html">Agents</a>
@@ -623,6 +631,14 @@ async function runDemo() {
   btn.disabled = false;
   btn.textContent = 'Run Again';
 }
+</script>
+<script>
+(function(){
+  const nav = document.querySelector('.nav');
+  const btn = nav.querySelector('.hamburger');
+  btn.addEventListener('click', () => nav.classList.toggle('open'));
+  nav.querySelectorAll('a').forEach(a => a.addEventListener('click', () => nav.classList.remove('open')));
+})();
 </script>
 </body>
 </html>

--- a/compare-agents.html
+++ b/compare-agents.html
@@ -26,6 +26,13 @@ body { font-family: 'DM Sans', system-ui, sans-serif; background: var(--bg); col
 nav { position: fixed; top: 0; left: 0; right: 0; display: flex; align-items: center; justify-content: center; gap: 2rem; padding: .7rem 1rem; background: rgba(250,250,249,.88); backdrop-filter: blur(12px); -webkit-backdrop-filter: blur(12px); border-bottom: 1px solid var(--border); z-index: 100; font-size: .82rem; letter-spacing: .08em; }
 nav a { color: var(--text2); text-decoration: none; font-weight: 500; transition: color .2s; }
 nav a:hover, nav a.active { color: var(--accent); }
+.hamburger { display: none; background: none; border: none; font-size: 1.4rem; cursor: pointer; color: var(--text); padding: .2rem .5rem; position: absolute; right: 1rem; }
+@media (max-width: 600px) {
+  nav { flex-wrap: wrap; justify-content: flex-start; gap: 0; padding: .7rem 1rem; }
+  nav a { display: none; width: 100%; padding: .5rem 0; }
+  nav.open a { display: block; }
+  .hamburger { display: block; }
+}
 
 .wrap { max-width: 900px; margin: 0 auto; padding: 5rem 1.25rem 2rem; }
 .header { text-align: center; margin-bottom: 2rem; }
@@ -88,6 +95,7 @@ nav a:hover, nav a.active { color: var(--accent); }
 </head>
 <body>
 <nav>
+  <button class="hamburger" aria-label="Menu">☰</button>
   <a href="index.html">ABTI</a>
   <a href="sbti.html">SBTI-AI</a>
   <a href="agents.html">Agents</a>
@@ -219,6 +227,14 @@ function renderAgentCard(a) {
 }
 
 init();
+</script>
+<script>
+(function(){
+  const nav = document.querySelector('nav');
+  const btn = nav.querySelector('.hamburger');
+  btn.addEventListener('click', () => nav.classList.toggle('open'));
+  nav.querySelectorAll('a').forEach(a => a.addEventListener('click', () => nav.classList.remove('open')));
+})();
 </script>
 </body>
 </html>

--- a/compare.html
+++ b/compare.html
@@ -26,6 +26,13 @@ body { font-family: 'DM Sans', system-ui, sans-serif; background: var(--bg); col
 nav { position: fixed; top: 0; left: 0; right: 0; display: flex; align-items: center; justify-content: center; gap: 2rem; padding: .7rem 1rem; background: rgba(250,250,249,.88); backdrop-filter: blur(12px); -webkit-backdrop-filter: blur(12px); border-bottom: 1px solid var(--border); z-index: 100; font-size: .82rem; letter-spacing: .08em; }
 nav a { color: var(--text2); text-decoration: none; font-weight: 500; transition: color .2s; }
 nav a:hover, nav a.active { color: var(--accent); }
+.hamburger { display: none; background: none; border: none; font-size: 1.4rem; cursor: pointer; color: var(--text); padding: .2rem .5rem; position: absolute; right: 1rem; }
+@media (max-width: 600px) {
+  nav { flex-wrap: wrap; justify-content: flex-start; gap: 0; padding: .7rem 1rem; }
+  nav a { display: none; width: 100%; padding: .5rem 0; }
+  nav.open a { display: block; }
+  .hamburger { display: block; }
+}
 
 .wrap { max-width: 800px; margin: 0 auto; padding: 5rem 1.25rem 2rem; }
 .header { text-align: center; margin-bottom: 2rem; }
@@ -89,6 +96,7 @@ nav a:hover, nav a.active { color: var(--accent); }
 </head>
 <body>
 <nav>
+  <button class="hamburger" aria-label="Menu">☰</button>
   <a href="index.html">ABTI</a>
   <a href="sbti.html">SBTI-AI</a>
   <a href="agents.html">Agents</a>
@@ -203,6 +211,14 @@ function renderTypeCard(t) {
   h += `</ul><h3>Work Style</h3><div class="work-style">${t.workStyle || ''}</div></div>`;
   return h;
 }
+</script>
+<script>
+(function(){
+  const nav = document.querySelector('nav');
+  const btn = nav.querySelector('.hamburger');
+  btn.addEventListener('click', () => nav.classList.toggle('open'));
+  nav.querySelectorAll('a').forEach(a => a.addEventListener('click', () => nav.classList.remove('open')));
+})();
 </script>
 </body>
 </html>

--- a/compatibility.html
+++ b/compatibility.html
@@ -41,6 +41,15 @@ nav a:hover, nav a.active { color: var(--accent); }
 
 .lang-btn { background: none; border: 1px solid var(--border); border-radius: 4px; padding: .2rem .5rem; font-size: .75rem; font-weight: 600; color: var(--text2); cursor: pointer; letter-spacing: .06em; }
 
+.hamburger { display: none; background: none; border: none; font-size: 1.4rem; cursor: pointer; color: var(--text); padding: .2rem .5rem; position: absolute; right: 1rem; }
+@media (max-width: 600px) {
+  nav { flex-wrap: wrap; justify-content: flex-start; gap: 0; padding: .7rem 1rem; }
+  nav a { display: none; width: 100%; padding: .5rem 0; }
+  nav.open a { display: block; }
+  nav .lang-btn { position: absolute; right: 3rem; top: .55rem; }
+  .hamburger { display: block; }
+}
+
 .selectors { display: flex; gap: 1rem; justify-content: center; align-items: center; flex-wrap: wrap; margin-bottom: 2.5rem; }
 .selectors select { font-family: 'DM Sans', system-ui, sans-serif; font-size: .9rem; padding: .5rem 1rem; border: 1px solid var(--border); border-radius: var(--radius); background: var(--surface); color: var(--text); cursor: pointer; min-width: 220px; }
 .selectors select:focus { outline: none; border-color: var(--accent); }
@@ -117,6 +126,7 @@ nav a:hover, nav a.active { color: var(--accent); }
 </head>
 <body>
 <nav>
+  <button class="hamburger" aria-label="Menu">☰</button>
   <a href="index.html">ABTI</a>
   <a href="sbti.html">SBTI-AI</a>
   <a href="agents.html">Agents</a>
@@ -338,6 +348,14 @@ loadNicknames().then(() => {
   if (params.get('a') && params.get('b')) doCheck();
 });
 loadMatrix();
+</script>
+<script>
+(function(){
+  const nav = document.querySelector('nav');
+  const btn = nav.querySelector('.hamburger');
+  btn.addEventListener('click', () => nav.classList.toggle('open'));
+  nav.querySelectorAll('a').forEach(a => a.addEventListener('click', () => nav.classList.remove('open')));
+})();
 </script>
 </body>
 </html>

--- a/cross-compatibility.html
+++ b/cross-compatibility.html
@@ -43,6 +43,15 @@ nav a:hover, nav a.active { color: var(--accent); }
 
 .lang-btn { background: none; border: 1px solid var(--border); border-radius: 4px; padding: .2rem .5rem; font-size: .75rem; font-weight: 600; color: var(--text2); cursor: pointer; letter-spacing: .06em; }
 
+.hamburger { display: none; background: none; border: none; font-size: 1.4rem; cursor: pointer; color: var(--text); padding: .2rem .5rem; position: absolute; right: 1rem; }
+@media (max-width: 600px) {
+  nav { flex-wrap: wrap; justify-content: flex-start; gap: 0; padding: .7rem 1rem; }
+  nav a { display: none; width: 100%; padding: .5rem 0; }
+  nav.open a { display: block; }
+  nav .lang-btn { position: absolute; right: 3rem; top: .55rem; }
+  .hamburger { display: block; }
+}
+
 /* Dimension mapping table */
 .dim-map { margin: 1.5rem auto 2rem; max-width: 600px; }
 .dim-map table { width: 100%; border-collapse: collapse; font-size: .78rem; }
@@ -132,6 +141,7 @@ nav a:hover, nav a.active { color: var(--accent); }
 </head>
 <body>
 <nav>
+  <button class="hamburger" aria-label="Menu">☰</button>
   <a href="index.html">ABTI</a>
   <a href="sbti.html">SBTI-AI</a>
   <a href="agents.html">Agents</a>
@@ -503,6 +513,14 @@ if (params.get('mbti')) {
   document.getElementById('mbtiSel').value = params.get('mbti').toUpperCase();
   findMatches();
 }
+</script>
+<script>
+(function(){
+  const nav = document.querySelector('nav');
+  const btn = nav.querySelector('.hamburger');
+  btn.addEventListener('click', () => nav.classList.toggle('open'));
+  nav.querySelectorAll('a').forEach(a => a.addEventListener('click', () => nav.classList.remove('open')));
+})();
 </script>
 </body>
 </html>

--- a/families.html
+++ b/families.html
@@ -26,6 +26,13 @@ body { font-family: 'DM Sans', system-ui, sans-serif; background: var(--bg); col
 nav { position: fixed; top: 0; left: 0; right: 0; display: flex; align-items: center; justify-content: center; gap: 2rem; padding: .7rem 1rem; background: rgba(250,250,249,.88); backdrop-filter: blur(12px); -webkit-backdrop-filter: blur(12px); border-bottom: 1px solid var(--border); z-index: 100; font-size: .82rem; letter-spacing: .08em; }
 nav a { color: var(--text2); text-decoration: none; font-weight: 500; transition: color .2s; }
 nav a:hover, nav a.active { color: var(--accent); }
+.hamburger { display: none; background: none; border: none; font-size: 1.4rem; cursor: pointer; color: var(--text); padding: .2rem .5rem; position: absolute; right: 1rem; }
+@media (max-width: 600px) {
+  nav { flex-wrap: wrap; justify-content: flex-start; gap: 0; padding: .7rem 1rem; }
+  nav a { display: none; width: 100%; padding: .5rem 0; }
+  nav.open a { display: block; }
+  .hamburger { display: block; }
+}
 
 .wrap { max-width: 820px; margin: 0 auto; padding: 5rem 1.25rem 2rem; }
 
@@ -69,6 +76,7 @@ nav a:hover, nav a.active { color: var(--accent); }
 </head>
 <body>
 <nav>
+  <button class="hamburger" aria-label="Menu">☰</button>
   <a href="index.html">ABTI</a>
   <a href="sbti.html">SBTI-AI</a>
   <a href="agents.html">Agents</a>
@@ -175,6 +183,14 @@ nav a:hover, nav a.active { color: var(--accent); }
   }
 })();
 function esc(s) { const d = document.createElement('div'); d.textContent = s; return d.innerHTML; }
+</script>
+<script>
+(function(){
+  const nav = document.querySelector('nav');
+  const btn = nav.querySelector('.hamburger');
+  btn.addEventListener('click', () => nav.classList.toggle('open'));
+  nav.querySelectorAll('a').forEach(a => a.addEventListener('click', () => nav.classList.remove('open')));
+})();
 </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -115,6 +115,14 @@
   color: var(--accent);
   box-shadow: var(--shadow-md);
 }
+.hamburger { display: none; background: none; border: none; font-size: 1.4rem; cursor: pointer; color: var(--text); padding: .2rem .5rem; position: absolute; right: 1rem; }
+@media (max-width: 600px) {
+  .nav { flex-wrap: wrap; justify-content: flex-start; gap: 0; padding: .7rem 1rem; }
+  .nav a { display: none; width: 100%; padding: .5rem 0; }
+  .nav.open a { display: block; }
+  .nav .lang-btn { position: absolute; right: 3rem; top: .55rem; }
+  .hamburger { display: block; }
+}
 
 body {
   font-family: 'DM Sans', 'Noto Serif SC', -apple-system, BlinkMacSystemFont, sans-serif;
@@ -716,6 +724,7 @@ body {
 <body>
 
 <nav class="nav">
+  <button class="hamburger" aria-label="Menu">&#9776;</button>
   <a href="index.html" class="active">ABTI</a>
   <a href="sbti.html">SBTI-AI</a>
   <a href="agents.html">Agents</a>
@@ -1768,6 +1777,14 @@ if (resultUrlMatch) {
 } else {
   renderLanding();
 }
+</script>
+<script>
+(function(){
+  const nav = document.querySelector('.nav');
+  const btn = nav.querySelector('.hamburger');
+  btn.addEventListener('click', () => nav.classList.toggle('open'));
+  nav.querySelectorAll('a').forEach(a => a.addEventListener('click', () => nav.classList.remove('open')));
+})();
 </script>
 </body>
 </html>

--- a/leaderboard.html
+++ b/leaderboard.html
@@ -26,6 +26,14 @@ body { font-family: 'DM Sans', system-ui, sans-serif; background: var(--bg); col
 nav { position: fixed; top: 0; left: 0; right: 0; display: flex; align-items: center; justify-content: center; gap: 2rem; padding: .7rem 1rem; background: rgba(250,249,247,.88); backdrop-filter: blur(12px); -webkit-backdrop-filter: blur(12px); border-bottom: 1px solid var(--border); z-index: 100; font-size: .82rem; letter-spacing: .08em; }
 nav a { color: var(--text2); text-decoration: none; font-weight: 500; transition: color .2s; }
 nav a:hover, nav a.active { color: var(--accent); }
+.hamburger { display: none; background: none; border: none; font-size: 1.4rem; cursor: pointer; color: var(--text); padding: .2rem .5rem; position: absolute; right: 1rem; }
+@media (max-width: 600px) {
+  nav { flex-wrap: wrap; justify-content: flex-start; gap: 0; padding: .7rem 1rem; }
+  nav a { display: none; width: 100%; padding: .5rem 0; }
+  nav.open a { display: block; }
+  .hamburger { display: block; }
+  .lang-btn { right: 3rem !important; }
+}
 
 .wrap { max-width: 760px; margin: 0 auto; padding: 5rem 1.25rem 3rem; }
 
@@ -92,6 +100,7 @@ nav a:hover, nav a.active { color: var(--accent); }
 </head>
 <body>
 <nav>
+  <button class="hamburger" aria-label="Menu">☰</button>
   <a href="index.html">ABTI</a>
   <a href="sbti.html">SBTI-AI</a>
   <a href="agents.html">Agents</a>
@@ -263,6 +272,14 @@ fetch('/api/leaderboard')
   .catch(() => {
     document.getElementById('content').innerHTML = '<div class="empty"><p>Failed to load leaderboard data.</p></div>';
   });
+</script>
+<script>
+(function(){
+  const nav = document.querySelector('nav');
+  const btn = nav.querySelector('.hamburger');
+  btn.addEventListener('click', () => nav.classList.toggle('open'));
+  nav.querySelectorAll('a').forEach(a => a.addEventListener('click', () => nav.classList.remove('open')));
+})();
 </script>
 </body>
 </html>

--- a/sbti.html
+++ b/sbti.html
@@ -59,6 +59,14 @@ body {
   cursor: pointer; transition: all 0.3s; letter-spacing: 0.05em; font-weight: 600;
 }
 .lang-btn:hover { border-color: var(--accent); color: var(--accent); }
+.hamburger { display: none; background: none; border: none; font-size: 1.4rem; cursor: pointer; color: var(--text); padding: .2rem .5rem; position: absolute; right: 1rem; }
+@media (max-width: 600px) {
+  .nav { flex-wrap: wrap; justify-content: flex-start; gap: 0; padding: .7rem 1rem; }
+  .nav a { display: none; width: 100%; padding: .5rem 0; }
+  .nav.open a { display: block; }
+  .nav .lang-btn { position: absolute; right: 3rem; top: .55rem; }
+  .hamburger { display: block; }
+}
 
 .container {
   max-width: 680px; margin: 0 auto; padding: 4rem 1.5rem 2rem;
@@ -238,6 +246,7 @@ body {
 <body>
 
 <nav class="nav">
+  <button class="hamburger" aria-label="Menu">☰</button>
   <a href="index.html">ABTI</a>
   <a href="sbti.html" class="active">SBTI-AI</a>
   <a href="agents.html">Agents</a>
@@ -844,5 +853,13 @@ document.querySelectorAll('[data-en]').forEach(function(el) {
 </script>
 
 <script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
+<script>
+(function(){
+  const nav = document.querySelector('.nav');
+  const btn = nav.querySelector('.hamburger');
+  btn.addEventListener('click', () => nav.classList.toggle('open'));
+  nav.querySelectorAll('a').forEach(a => a.addEventListener('click', () => nav.classList.remove('open')));
+})();
+</script>
 </body>
 </html>

--- a/stats.html
+++ b/stats.html
@@ -37,6 +37,14 @@ nav a { color: var(--text2); text-decoration: none; font-weight: 500; transition
 nav a:hover, nav a.active { color: var(--accent); }
 nav .lang-btn { background: none; border: 1px solid var(--border); color: var(--text2); font-family: inherit; font-size: .75rem; font-weight: 600; padding: .25rem .6rem; border-radius: 6px; cursor: pointer; letter-spacing: .08em; transition: color .2s, border-color .2s; }
 nav .lang-btn:hover { color: var(--accent); border-color: var(--accent); }
+.hamburger { display: none; background: none; border: none; font-size: 1.4rem; cursor: pointer; color: var(--text); padding: .2rem .5rem; position: absolute; right: 1rem; }
+@media (max-width: 600px) {
+  nav { flex-wrap: wrap; justify-content: flex-start; gap: 0; padding: .7rem 1rem; }
+  nav a { display: none; width: 100%; padding: .5rem 0; }
+  nav.open a { display: block; }
+  nav .lang-btn { position: absolute; right: 3rem; top: .55rem; }
+  .hamburger { display: block; }
+}
 
 .wrap { max-width: 720px; margin: 0 auto; padding: 5rem 1.25rem 2rem; }
 .header { text-align: center; margin-bottom: 2.5rem; }
@@ -123,6 +131,7 @@ nav .lang-btn:hover { color: var(--accent); border-color: var(--accent); }
 </head>
 <body>
 <nav>
+  <button class="hamburger" aria-label="Menu">☰</button>
   <a href="index.html">ABTI</a>
   <a href="sbti.html">SBTI-AI</a>
   <a href="agents.html">Agents</a>
@@ -322,6 +331,14 @@ function statCard(value, label, detail) {
 function esc(s) { const d = document.createElement('div'); d.textContent = s; return d.innerHTML; }
 
 init();
+</script>
+<script>
+(function(){
+  const nav = document.querySelector('nav');
+  const btn = nav.querySelector('.hamburger');
+  btn.addEventListener('click', () => nav.classList.toggle('open'));
+  nav.querySelectorAll('a').forEach(a => a.addEventListener('click', () => nav.classList.remove('open')));
+})();
 </script>
 </body>
 </html>

--- a/test-agent.html
+++ b/test-agent.html
@@ -84,6 +84,14 @@
   color: var(--accent);
   box-shadow: var(--shadow-md);
 }
+.hamburger { display: none; background: none; border: none; font-size: 1.4rem; cursor: pointer; color: var(--text); padding: .2rem .5rem; position: absolute; right: 1rem; }
+@media (max-width: 600px) {
+  .nav { flex-wrap: wrap; justify-content: flex-start; gap: 0; padding: .7rem 1rem; }
+  .nav a { display: none; width: 100%; padding: .5rem 0; }
+  .nav.open a { display: block; }
+  .nav .lang-btn { position: absolute; right: 3rem; top: .55rem; }
+  .hamburger { display: block; }
+}
 
 body {
   font-family: 'DM Sans', 'Noto Serif SC', -apple-system, BlinkMacSystemFont, sans-serif;
@@ -493,6 +501,7 @@ textarea { resize: vertical; min-height: 80px; }
 <body>
 
 <nav class="nav">
+  <button class="hamburger" aria-label="Menu">&#9776;</button>
   <a href="index.html">ABTI</a>
   <a href="sbti.html">SBTI-AI</a>
   <a href="agents.html">Agents</a>
@@ -1434,6 +1443,14 @@ applyLang();
 // Restore key from sessionStorage
 const savedKey = sessionStorage.getItem('abti_api_key');
 if (savedKey) document.getElementById('apiKeyInput').value = savedKey;
+</script>
+<script>
+(function(){
+  const nav = document.querySelector('.nav');
+  const btn = nav.querySelector('.hamburger');
+  btn.addEventListener('click', () => nav.classList.toggle('open'));
+  nav.querySelectorAll('a').forEach(a => a.addEventListener('click', () => nav.classList.remove('open')));
+})();
 </script>
 </body>
 </html>

--- a/types.html
+++ b/types.html
@@ -56,6 +56,14 @@ nav a { color: var(--text2); text-decoration: none; font-weight: 500; transition
 nav a:hover, nav a.active { color: var(--accent); }
 nav .lang-btn { background: none; border: 1px solid var(--border); color: var(--text2); font-family: inherit; font-size: .75rem; font-weight: 600; padding: .25rem .6rem; border-radius: 6px; cursor: pointer; letter-spacing: .08em; transition: color .2s, border-color .2s; }
 nav .lang-btn:hover { color: var(--accent); border-color: var(--accent); }
+.hamburger { display: none; background: none; border: none; font-size: 1.4rem; cursor: pointer; color: var(--text); padding: .2rem .5rem; position: absolute; right: 1rem; }
+@media (max-width: 600px) {
+  nav { flex-wrap: wrap; justify-content: flex-start; gap: 0; padding: .7rem 1rem; }
+  nav a { display: none; width: 100%; padding: .5rem 0; }
+  nav.open a { display: block; }
+  nav .lang-btn { position: absolute; right: 3rem; top: .55rem; }
+  .hamburger { display: block; }
+}
 
 .wrap { max-width: 720px; margin: 0 auto; padding: 5rem 1.25rem 2rem; }
 .header { text-align: center; margin-bottom: 2.5rem; }
@@ -82,6 +90,7 @@ nav .lang-btn:hover { color: var(--accent); border-color: var(--accent); }
 </head>
 <body>
 <nav>
+  <button class="hamburger" aria-label="Menu">☰</button>
   <a href="index.html">ABTI</a>
   <a href="sbti.html">SBTI-AI</a>
   <a href="agents.html">Agents</a>
@@ -149,6 +158,14 @@ function render() {
 
 function esc(s) { const d = document.createElement('div'); d.textContent = s; return d.innerHTML; }
 init();
+</script>
+<script>
+(function(){
+  const nav = document.querySelector('nav');
+  const btn = nav.querySelector('.hamburger');
+  btn.addEventListener('click', () => nav.classList.toggle('open'));
+  nav.querySelectorAll('a').forEach(a => a.addEventListener('click', () => nav.classList.remove('open')));
+})();
 </script>
 </body>
 </html>


### PR DESCRIPTION
Fixes #346

## What

On mobile viewports (≤600px), collapses the 13-link navigation bar into a ☰ hamburger toggle.

## Changes

- Added `.hamburger` button as first child of each `<nav>` across all 14 HTML pages
- CSS: hamburger hidden on desktop, visible on mobile; nav links hidden by default on mobile, shown as vertical list when `.open` class is active
- JS: minimal toggle + close-on-click behavior (~5 lines per page)
- Preserves each page's color scheme and lang-btn positioning

## Testing

- All 195 existing tests pass
- Desktop nav: unchanged (hamburger hidden via `display: none`)
- Mobile 375px: hamburger visible, links hidden until tapped