### PR TITLE
fix(nav): add hamburger menu to type.html (fixes #348)

### DIFF
--- a/type.html
+++ b/type.html
@@ -53,6 +53,13 @@ nav {
   z-index: 100; font-size: .82rem; letter-spacing: .08em;
 }
 nav a { color: var(--text2); text-decoration: none; font-weight: 500; transition: color .2s; }
+.hamburger { display: none; background: none; border: none; font-size: 1.4rem; cursor: pointer; color: var(--text); padding: .2rem .5rem; position: absolute; right: 1rem; }
+@media (max-width: 600px) {
+  nav { flex-wrap: wrap; justify-content: flex-start; gap: 0; padding: .7rem 1rem; }
+  nav a { display: none; width: 100%; padding: .5rem 0; }
+  nav.open a { display: block; }
+  .hamburger { display: block; }
+}
 nav a:hover, nav a.active { color: var(--accent); }
 
 .lang-btn {
@@ -183,12 +190,12 @@ nav a:hover, nav a.active { color: var(--accent); }
   .type-badge { font-size: 2rem; }
   .type-nick { font-size: 1.3rem; }
   .dim-name { width: 64px; font-size: .68rem; }
-  nav { gap: 1.2rem; font-size: .75rem; }
 }
 </style>
 </head>
 <body>
 <nav>
+  <button class="hamburger" aria-label="Menu">☰</button>
   <a href="index.html">ABTI</a>
   <a href="sbti.html">SBTI-AI</a>
   <a href="agents.html">Agents</a>
@@ -358,6 +365,14 @@ nav a:hover, nav a.active { color: var(--accent); }
     document.getElementById('loading').textContent = 'Failed to load type data';
     document.getElementById('loading').className = 'error';
   });
+})();
+</script>
+<script>
+(function(){
+  const nav = document.querySelector('nav');
+  const btn = nav.querySelector('.hamburger');
+  btn.addEventListener('click', () => nav.classList.toggle('open'));
+  nav.querySelectorAll('a').forEach(a => a.addEventListener('click', () => nav.classList.remove('open')));
 })();
 </script>
 </body>


### PR DESCRIPTION
## What

`type.html` was missed when the hamburger mobile navigation was added in #347. This PR adds:

1. **Hamburger button** as first child of nav
2. **Responsive CSS** — hidden by default, shown at ≤600px with flex-wrap collapse
3. **Toggle JS** — click to open/close, close on link click
4. Removed old 500px media query nav rule (superseded by 600px hamburger query)

Pattern matches agents.html exactly.

## Testing
- All 195 tests pass

Fixes #348