### PR TITLE
fix(nav): add missing links to families.html

### DIFF
--- a/families.html
+++ b/families.html
@@ -80,10 +80,15 @@ nav a:hover, nav a.active { color: var(--accent); }
   <a href="index.html">ABTI</a>
   <a href="sbti.html">SBTI-AI</a>
   <a href="agents.html">Agents</a>
-  <a href="families.html" class="active">Families</a>
   <a href="leaderboard.html">Leaderboard</a>
   <a href="stats.html">Stats</a>
+  <a href="types.html">Types</a>
   <a href="compare.html">Compare</a>
+  <a href="compare-agents.html">Compare Agents</a>
+  <a href="families.html" class="active">Families</a>
+  <a href="test-agent.html">Test Agent</a>
+  <a href="compatibility.html">Compatibility</a>
+  <a href="cross-compatibility.html">Cross Match</a>
   <a href="api.html">API</a>
 </nav>
 <div class="wrap">


### PR DESCRIPTION
The `<nav>` in `families.html` was missing several links that all other pages include (Types, Compare Agents, Test Agent, Compatibility, Cross Match). The link order also did not match the standard navigation pattern.

**Changes:**
- Added missing nav links: Types, Compare Agents, Test Agent, Compatibility, Cross Match
- Reordered links to match the standard nav order used in other pages (e.g. `agents.html`)

Fixes #350