### PR TITLE
feat: add share buttons to agent profile page

### DIFF
--- a/agent.html
+++ b/agent.html
@@ -169,6 +169,28 @@ nav a:hover, nav a.active { color: var(--accent); }
 .footer { text-align: center; color: var(--text3); font-size: .72rem; margin-top: 2rem; padding-bottom: 1rem; }
 .deprecated-notice { background: hsla(30 100% 50% / 0.1); border: 1px solid hsla(30 100% 50% / 0.3); color: #ffa726; border-radius: var(--radius); padding: 1rem; margin-bottom: 1.5rem; font-size: .88rem; }
 
+.share-row {
+  display: flex; justify-content: center; gap: .5rem;
+  margin-top: .75rem; margin-bottom: .25rem;
+}
+.share-btn {
+  display: inline-flex; align-items: center; gap: .35rem;
+  background: var(--surface2); border: 1px solid var(--border);
+  color: var(--text2); font-size: .75rem; font-weight: 500;
+  padding: .35rem .7rem; border-radius: 20px;
+  cursor: pointer; font-family: 'DM Sans', sans-serif;
+  transition: all .2s; text-decoration: none;
+}
+.share-btn:hover { border-color: var(--accent); color: var(--accent); }
+.share-btn svg { width: 14px; height: 14px; flex-shrink: 0; }
+.copy-toast {
+  position: fixed; bottom: 2rem; left: 50%; transform: translateX(-50%);
+  background: var(--accent); color: #fff; font-size: .82rem; font-weight: 600;
+  padding: .5rem 1.2rem; border-radius: 20px; z-index: 999;
+  opacity: 0; transition: opacity .3s; pointer-events: none;
+}
+.copy-toast.show { opacity: 1; }
+
 @media (max-width: 500px) {
   .wrap { padding: 4rem 1rem 2rem; }
   .agent-name { font-size: 1.6rem; }
@@ -230,8 +252,8 @@ nav a:hover, nav a.active { color: var(--accent); }
     if (a.reliability != null && a.reliability > 1) a.reliability = a.reliability / 100;
     var p = profileData;
     var labels = lang === 'zh'
-      ? { strengths: '优势', blindSpots: '盲区', workStyle: '工作风格', dimensions: '维度分析', bestPaired: '最佳搭档', back: '← 返回 Agents', tuningTips: '💡 调优建议' }
-      : { strengths: 'Strengths', blindSpots: 'Blind Spots', workStyle: 'Work Style', dimensions: 'Dimension Breakdown', bestPaired: 'Best Paired With', back: '← Back to Agents', tuningTips: '💡 Tuning Tips' };
+      ? { strengths: '优势', blindSpots: '盲区', workStyle: '工作风格', dimensions: '维度分析', bestPaired: '最佳搭档', back: '← 返回 Agents', tuningTips: '💡 调优建议', shareX: '分享到 X', shareLI: '分享到 LinkedIn', copyLink: '复制链接', copied: '已复制！' }
+      : { strengths: 'Strengths', blindSpots: 'Blind Spots', workStyle: 'Work Style', dimensions: 'Dimension Breakdown', bestPaired: 'Best Paired With', back: '← Back to Agents', tuningTips: '💡 Tuning Tips', shareX: 'Share on X', shareLI: 'Share on LinkedIn', copyLink: 'Copy Link', copied: 'Copied!' };
 
     // Get localized nick from allTypes
     var localNick = a.nick;
@@ -290,6 +312,11 @@ nav a:hover, nav a.active { color: var(--accent); }
       + (a.confidence != null && a.confidence < 0.5 ? ' <span title="Low parse confidence: ' + Math.round(a.confidence * 100) + '%" style="cursor:help;font-size:1.2rem">⚠️</span>' : '')
       + '<div class="agent-nick">' + esc(localNick) + '</div>'
       + (metaParts.length ? '<div class="agent-meta">' + metaParts.join('<span style="color:var(--text3)">&middot;</span>') + '</div>' : '')
+      + '<div class="share-row">'
+      + '<a class="share-btn" href="https://twitter.com/intent/tweet?text=' + encodeURIComponent(a.name + ' is ' + a.type + ' — ' + localNick + ' | ABTI') + '&url=' + encodeURIComponent(window.location.href) + '" target="_blank" rel="noopener" title="' + esc(labels.shareX) + '"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>' + esc(labels.shareX) + '</a>'
+      + '<a class="share-btn" href="https://www.linkedin.com/sharing/share-offsite/?url=' + encodeURIComponent(window.location.href) + '" target="_blank" rel="noopener" title="' + esc(labels.shareLI) + '"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 01-2.063-2.065 2.064 2.064 0 112.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/></svg>' + esc(labels.shareLI) + '</a>'
+      + '<button class="share-btn" onclick="copyAgentLink()" title="' + esc(labels.copyLink) + '"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/></svg>' + esc(labels.copyLink) + '</button>'
+      + '</div>'
       + '</div>'
 
       + (a.deprecated ? '<div class="deprecated-notice"><strong>Deprecated</strong> — This agent has been deprecated.' + (a.deprecatedReason ? ' ' + esc(a.deprecatedReason) : '') + '</div>' : '')
@@ -339,7 +366,16 @@ nav a:hover, nav a.active { color: var(--accent); }
       + '</div>' : '')
 
       + '<div style="text-align:center;margin-top:1.5rem"><a href="/agents.html" style="color:var(--text3);font-size:.82rem;text-decoration:none;transition:color .2s">' + labels.back + '</a></div>'
-      + '<div class="footer">ABTI &mdash; Agent Behavioral Type Indicator</div>';
+      + '<div class="footer">ABTI &mdash; Agent Behavioral Type Indicator</div>'
+      + '<div class="copy-toast" id="copyToast">' + esc(labels.copied) + '</div>';
+
+    window.copyAgentLink = function() {
+      navigator.clipboard.writeText(window.location.href).then(function() {
+        var toast = document.getElementById('copyToast');
+        toast.classList.add('show');
+        setTimeout(function() { toast.classList.remove('show'); }, 1500);
+      });
+    };
   }
 
   function fetchAgent() {


### PR DESCRIPTION
Fixes #354

Adds share buttons to agent profile pages (`/agent/:slug`) to encourage organic sharing of ABTI results.

**Changes:**
- 3 share buttons: X/Twitter, LinkedIn, Copy Link
- Compact pill-style buttons matching existing dark theme
- Inline SVG icons (no external dependencies)
- Copy-to-clipboard with animated toast notification
- Full i18n support (EN/ZH)

**Tests:** 195/195 pass