### PR TITLE
fix(action): add missing expected-type input and update provider list

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,7 @@ inputs:
     description: 'Path to file containing the agent system prompt (e.g. AGENTS.md)'
     required: false
   provider:
-    description: 'LLM provider: openai, anthropic, or gemini'
+    description: 'LLM provider: openai, anthropic, gemini, deepseek, github, groq, openrouter, mistral, or ollama'
     required: true
   model:
     description: 'Model name (e.g. gpt-4o, claude-sonnet-4-20250514)'
@@ -31,6 +31,9 @@ inputs:
     default: 'https://abti.kagura-agent.com'
   agent-name:
     description: 'Display name for the agent in the registry (defaults to "<model> (<provider>)")'
+    required: false
+  expected-type:
+    description: 'Expected ABTI type code (e.g. PTCF). Fails the action on mismatch for personality drift detection.'
     required: false
   lang:
     description: 'Language for questions (en or zh)'


### PR DESCRIPTION
Fixes #360

## Changes
1. **Updated provider description** — was 'openai, anthropic, or gemini', now lists all 9 supported providers
2. **Added expected-type input** — was used in action/index.js and documented in action/README.md but missing from action.yml

## Before
```yaml
provider:
  description: 'LLM provider: openai, anthropic, or gemini'
# expected-type not declared
```

## After
```yaml
provider:
  description: 'LLM provider: openai, anthropic, gemini, deepseek, github, groq, openrouter, mistral, or ollama'
expected-type:
  description: 'Expected ABTI type code (e.g. PTCF). Fails the action on mismatch for personality drift detection.'
  required: false
```