### PR TITLE
feat(i18n): add Chinese language toggle to agents.html (fixes #362)

### DIFF
--- a/agents.html
+++ b/agents.html
@@ -193,6 +193,7 @@ nav a:hover, .nav a:hover, nav a.active, .nav a.active { color: var(--accent); }
   </div>
   <a href="api.html">API</a>
   <a href="sbti.html">SBTI-AI</a>
+  <button class="lang-btn" onclick="toggleLang()" id="langBtn">中文</button>
 </nav>
 <div class="wrap">
   <div class="header">
@@ -251,6 +252,132 @@ nav a:hover, .nav a:hover, nav a.active, .nav a.active { color: var(--accent); }
   <div class="footer">ABTI &mdash; Agent Behavioral Type Indicator</div>
 </div>
 <script>
+var lang = localStorage.getItem('abti-lang') || 'en';
+var i18n = {
+  en: {
+    pageTitle: 'Tested <span>Agents</span>',
+    testsTaken: ' tests taken',
+    showing: 'Showing ',
+    of: ' of ',
+    agents: ' agents',
+    loading: 'Loading...',
+    failedLoad: 'Failed to load data',
+    emptyNone: 'No agents have taken the test yet.',
+    emptyFilter: 'No agents match your filters.',
+    searchPlaceholder: 'Search by name…',
+    allTypes: 'All Types',
+    allProviders: 'All Providers',
+    newest: 'Newest first',
+    oldest: 'Oldest first',
+    nameAZ: 'Name A–Z',
+    nameZA: 'Name Z–A',
+    byType: 'By type',
+    dimBreakdown: 'Dimension Breakdown',
+    typeFreq: 'Type Frequency',
+    notableTitle: 'Notable Agents',
+    notableSub: 'Well-known AI agents and their behavioral profiles',
+    ctaTitle: 'Test Your <span>Agent</span>',
+    ctaSub: 'Add yours to the gallery in minutes',
+    ctaGHDesc: 'Add a one-liner to your CI and test your agent on every push.',
+    ctaMCPDesc: 'Connect any MCP-compatible agent for automated personality testing.',
+    ctaAPIDesc: 'Fetch questions, answer them, get your type — all via REST.',
+    getStarted: 'Get started →',
+    dimAutonomy: 'Autonomy', dimPrecision: 'Precision', dimTransparency: 'Transparency', dimAdaptability: 'Adaptability',
+    poleProactive: 'Proactive', poleResponsive: 'Responsive',
+    poleThorough: 'Thorough', poleEfficient: 'Efficient',
+    poleCandid: 'Candid', poleDiplomatic: 'Diplomatic',
+    poleFlexible: 'Flexible', polePrincipled: 'Principled',
+    reliable: 'reliable',
+    runs: 'runs',
+    deprecated: 'Deprecated'
+  },
+  zh: {
+    pageTitle: '已测试的<span>智能体</span>',
+    testsTaken: ' 次测试',
+    showing: '显示 ',
+    of: ' / ',
+    agents: ' 个智能体',
+    loading: '加载中...',
+    failedLoad: '加载失败',
+    emptyNone: '暂无智能体参加测试。',
+    emptyFilter: '没有匹配的智能体。',
+    searchPlaceholder: '按名称搜索…',
+    allTypes: '所有类型',
+    allProviders: '所有提供商',
+    newest: '最新优先',
+    oldest: '最早优先',
+    nameAZ: '名称 A–Z',
+    nameZA: '名称 Z–A',
+    byType: '按类型',
+    dimBreakdown: '维度分布',
+    typeFreq: '类型频率',
+    notableTitle: '知名智能体',
+    notableSub: '知名 AI 智能体及其行为画像',
+    ctaTitle: '测试你的<span>智能体</span>',
+    ctaSub: '几分钟即可加入展示',
+    ctaGHDesc: '在 CI 中添加一行配置，每次推送自动测试你的智能体。',
+    ctaMCPDesc: '连接任何兼容 MCP 的智能体，进行自动化人格测试。',
+    ctaAPIDesc: '获取问题、回答问题、得到类型——全部通过 REST API。',
+    getStarted: '开始使用 →',
+    dimAutonomy: '自主性', dimPrecision: '精确性', dimTransparency: '透明度', dimAdaptability: '适应性',
+    poleProactive: '主动型', poleResponsive: '响应型',
+    poleThorough: '严谨型', poleEfficient: '高效型',
+    poleCandid: '坦率型', poleDiplomatic: '圆融型',
+    poleFlexible: '灵活型', polePrincipled: '原则型',
+    reliable: '可靠',
+    runs: '次测试',
+    deprecated: '已弃用'
+  }
+};
+function t(key) { return i18n[lang][key] || i18n.en[key] || key; }
+function toggleLang() {
+  lang = lang === 'en' ? 'zh' : 'en';
+  localStorage.setItem('abti-lang', lang);
+  applyLang();
+}
+function applyLang() {
+  document.documentElement.lang = lang;
+  var langBtn = document.getElementById('langBtn');
+  if (langBtn) langBtn.textContent = lang === 'en' ? '中文' : 'EN';
+  document.querySelectorAll('[data-en][data-zh]').forEach(function(el) {
+    el.textContent = el.getAttribute('data-' + lang);
+  });
+  var h1 = document.querySelector('.header h1');
+  if (h1) h1.innerHTML = t('pageTitle');
+  var searchEl = document.getElementById('search');
+  if (searchEl) searchEl.placeholder = t('searchPlaceholder');
+  var sortEl = document.getElementById('sort');
+  if (sortEl && sortEl.options.length >= 5) {
+    sortEl.options[0].textContent = t('newest');
+    sortEl.options[1].textContent = t('oldest');
+    sortEl.options[2].textContent = t('nameAZ');
+    sortEl.options[3].textContent = t('nameZA');
+    sortEl.options[4].textContent = t('byType');
+  }
+  var filterType = document.getElementById('filter-type');
+  if (filterType && filterType.options.length > 0) filterType.options[0].textContent = t('allTypes');
+  var filterProvider = document.getElementById('filter-provider');
+  if (filterProvider && filterProvider.options.length > 0) filterProvider.options[0].textContent = t('allProviders');
+  var distTitles = document.querySelectorAll('.dist-title');
+  if (distTitles.length >= 2) { distTitles[0].textContent = t('dimBreakdown'); distTitles[1].textContent = t('typeFreq'); }
+  var notableTitle = document.querySelector('.notable-title');
+  if (notableTitle) notableTitle.textContent = t('notableTitle');
+  var notableSub = document.querySelector('.notable-sub');
+  if (notableSub) notableSub.textContent = t('notableSub');
+  var ctaTitle = document.querySelector('.cta-title');
+  if (ctaTitle) ctaTitle.innerHTML = t('ctaTitle');
+  var ctaSub = document.querySelector('.cta-sub');
+  if (ctaSub) ctaSub.textContent = t('ctaSub');
+  var ctaCards = document.querySelectorAll('.cta-card');
+  if (ctaCards.length >= 3) {
+    ctaCards[0].querySelector('p').textContent = t('ctaGHDesc');
+    ctaCards[1].querySelector('p').textContent = t('ctaMCPDesc');
+    ctaCards[2].querySelector('p').textContent = t('ctaAPIDesc');
+    ctaCards.forEach(function(c) { var link = c.querySelector('.cta-link'); if (link) link.textContent = t('getStarted'); });
+  }
+  if (typeof window._renderCards === 'function') window._renderCards();
+  if (typeof window._renderDims === 'function') window._renderDims();
+}
 (async () => {
   const grid = document.getElementById('grid');
   const totalEl = document.getElementById('total');
@@ -258,9 +385,10 @@ nav a:hover, .nav a:hover, nav a.active, .nav a.active { color: var(--accent); }
     const res = await fetch('/api/agents');
     const data = await res.json();
     if (!data.agents || data.agents.length === 0) {
-      totalEl.innerHTML = '<strong>' + data.total + '</strong> tests taken';
-      grid.innerHTML = '<div class="empty">No agents have taken the test yet.</div>';
+      totalEl.innerHTML = '<strong>' + data.total + '</strong>' + t('testsTaken');
+      grid.innerHTML = '<div class="empty">' + t('emptyNone') + '</div>';
       document.getElementById('cta').style.display = '';
+      applyLang();
       return;
     }
 
@@ -298,10 +426,10 @@ nav a:hover, .nav a:hover, nav a.active, .nav a.active { color: var(--accent); }
       else if (sortMode === 'type') list = list.slice().sort((a, b) => (a.type || '').localeCompare(b.type || '') || a.name.localeCompare(b.name));
 
       totalEl.innerHTML = list.length === allAgents.length
-        ? '<strong>' + data.total + '</strong> tests taken'
-        : 'Showing <strong>' + list.length + '</strong> of ' + allAgents.length + ' agents';
+        ? '<strong>' + data.total + '</strong>' + t('testsTaken')
+        : t('showing') + '<strong>' + list.length + '</strong>' + t('of') + allAgents.length + t('agents');
 
-      if (list.length === 0) { grid.innerHTML = '<div class="empty">No agents match your filters.</div>'; return; }
+      if (list.length === 0) { grid.innerHTML = '<div class="empty">' + t('emptyFilter') + '</div>'; return; }
 
       grid.innerHTML = list.map(a => {
         const slug = a.slug || a.name.toLowerCase().trim().replace(/[^a-z0-9\u4e00-\u9fff\u3040-\u309f\u30a0-\u30ff]+/g, '-').replace(/^-+|-+$/g, '') || 'agent';
@@ -310,20 +438,22 @@ nav a:hover, .nav a:hover, nav a.active, .nav a.active { color: var(--accent); }
         return '<div class="card' + (a.deprecated ? ' card-deprecated' : '') + '">'
           + '<div class="card-name">' + nameHtml + '</div>'
           + '<a class="pill" href="/type/' + esc(a.type) + '" style="text-decoration:none">' + esc(a.type) + '</a>'
-          + (a.deprecated ? ' <span class="badge-deprecated" title="' + esc(a.deprecatedReason || '') + '">Deprecated</span>' : '')
+          + (a.deprecated ? ' <span class="badge-deprecated" title="' + esc(a.deprecatedReason || '') + '">' + t('deprecated') + '</span>' : '')
           + (a.confidence != null && a.confidence < 0.5 ? ' <span title="Low parse confidence: ' + Math.round(a.confidence * 100) + '%" style="cursor:help">⚠️</span>' : '')
           + (a.nick ? ' <span class="card-nick">' + esc(a.nick) + '</span>' : '')
           + (a.model || a.provider ? '<div class="card-model">' + esc([a.model, a.provider].filter(Boolean).join(' · ')) + '</div>' : '')
           + (a.dimensions ? '<div class="card-scores">' + a.dimensions.map(d => {
+              const poleMap = {Proactive:'poleProactive',Responsive:'poleResponsive',Thorough:'poleThorough',Efficient:'poleEfficient',Candid:'poleCandid',Diplomatic:'poleDiplomatic',Flexible:'poleFlexible',Principled:'polePrincipled'};
               const pct = Math.round(d.score / d.max * 100);
-              const winner = d.score >= d.max / 2 ? d.poles[0] : d.poles[1];
+              const winnerRaw = d.score >= d.max / 2 ? d.poles[0] : d.poles[1];
+              const winner = poleMap[winnerRaw] ? t(poleMap[winnerRaw]) : winnerRaw;
               return '<div class="card-score-row">'
                 + '<span class="card-score-label">' + winner + '</span>'
                 + '<div class="card-score-bar"><div class="card-score-fill" style="width:' + pct + '%"></div></div>'
                 + '<span class="card-score-pct">' + pct + '%</span>'
                 + '</div>';
             }).join('') + '</div>' : '')
-          + (a.reliability != null ? '<div class="card-reliability">🔁 ' + Math.round(a.reliability * 100) + '% reliable' + (a.reliabilityRuns ? ' (' + a.reliabilityRuns + ' runs)' : '') + '</div>' : '')
+          + (a.reliability != null ? '<div class="card-reliability">🔁 ' + Math.round(a.reliability * 100) + '% ' + t('reliable') + (a.reliabilityRuns ? ' (' + a.reliabilityRuns + ' ' + t('runs') + ')' : '') + '</div>' : '')
           + (time ? '<div class="card-time">' + time + '</div>' : '')
           + '</div>';
       }).join('');
@@ -333,6 +463,7 @@ nav a:hover, .nav a:hover, nav a.active, .nav a.active { color: var(--accent); }
     filterEl.addEventListener('change', renderCards);
     providerFilterEl.addEventListener('change', renderCards);
     sortEl.addEventListener('change', renderCards);
+    window._renderCards = renderCards;
     renderCards();
 
     // Distribution visualization
@@ -341,23 +472,27 @@ nav a:hover, .nav a:hover, nav a.active, .nav a.active { color: var(--accent); }
     agents.forEach(a => { if (a.reliability != null && a.reliability > 1) a.reliability = a.reliability / 100; });
     const n = agents.length;
     if (n > 0) {
-      const dims = [
-        { name: 'Autonomy', pos: 0, left: 'P', leftFull: 'Proactive', right: 'R', rightFull: 'Responsive' },
-        { name: 'Precision', pos: 1, left: 'T', leftFull: 'Thorough', right: 'E', rightFull: 'Efficient' },
-        { name: 'Transparency', pos: 2, left: 'C', leftFull: 'Candid', right: 'D', rightFull: 'Diplomatic' },
-        { name: 'Adaptability', pos: 3, left: 'F', leftFull: 'Flexible', right: 'N', rightFull: 'Principled' },
+      const dimDefs = [
+        { key: 'dimAutonomy', pos: 0, left: 'P', right: 'R' },
+        { key: 'dimPrecision', pos: 1, left: 'T', right: 'E' },
+        { key: 'dimTransparency', pos: 2, left: 'C', right: 'D' },
+        { key: 'dimAdaptability', pos: 3, left: 'F', right: 'N' },
       ];
-      document.getElementById('dim-bars').innerHTML = dims.map(d => {
-        const lCount = agents.filter(a => a.type && a.type[d.pos] === d.left).length;
-        const lPct = Math.round(lCount / n * 100);
-        const rPct = 100 - lPct;
-        return '<div class="dim-row">'
-          + '<div class="dim-label">' + d.name + '</div>'
-          + '<div class="dim-bar-wrap">'
-          + '<div class="dim-seg dim-seg-l" style="width:' + lPct + '%">' + d.left + ' ' + lPct + '%</div>'
-          + '<div class="dim-seg dim-seg-r" style="width:' + rPct + '%">' + d.right + ' ' + rPct + '%</div>'
-          + '</div></div>';
-      }).join('');
+      function renderDims() {
+        document.getElementById('dim-bars').innerHTML = dimDefs.map(d => {
+          const lCount = agents.filter(a => a.type && a.type[d.pos] === d.left).length;
+          const lPct = Math.round(lCount / n * 100);
+          const rPct = 100 - lPct;
+          return '<div class="dim-row">'
+            + '<div class="dim-label">' + t(d.key) + '</div>'
+            + '<div class="dim-bar-wrap">'
+            + '<div class="dim-seg dim-seg-l" style="width:' + lPct + '%">' + d.left + ' ' + lPct + '%</div>'
+            + '<div class="dim-seg dim-seg-r" style="width:' + rPct + '%">' + d.right + ' ' + rPct + '%</div>'
+            + '</div></div>';
+        }).join('');
+      }
+      window._renderDims = renderDims;
+      renderDims();
 
       const freq = {};
       agents.forEach(a => { if (a.type) freq[a.type] = (freq[a.type] || 0) + 1; });
@@ -398,8 +533,10 @@ nav a:hover, .nav a:hover, nav a.active, .nav a.active { color: var(--accent); }
         document.getElementById('notable').style.display = '';
       }
     } catch (e) { /* silently skip notable agents on error */ }
+    applyLang();
   } catch (e) {
-    totalEl.textContent = 'Failed to load data';
+    totalEl.textContent = t('failedLoad');
+    applyLang();
   }
 })();
 function esc(s) { const d = document.createElement('div'); d.textContent = s; return d.innerHTML; }


### PR DESCRIPTION
## Summary

Add EN/中文 toggle to the agents directory page, matching the i18n pattern used on all other pages.

## Changes

- **Lang toggle button** (EN/中文) in nav bar, stores preference in `localStorage('abti-lang')`
- **Full i18n dict** for all UI strings: title, subtitle, filters, sort labels, empty states, dimension names, pole labels, CTA section, reliability/runs text
- **Dynamic re-render** on toggle: nav spans with `data-en`/`data-zh`, `renderCards()` and `renderDims()` re-invoked
- **Consistent nav** using the dropdown menu pattern from other pages

## Testing

- Verified EN ↔ 中文 toggle persists across reload via localStorage
- All interactive elements (search, filter, sort) work in both languages
- Mobile hamburger menu works with new nav structure

Fixes #362