### PR TITLE
feat: add xAI/Grok provider support

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ npx @kagura-agent/abti test --provider ollama --model llama3.1
 npx @kagura-agent/abti test --provider github --model gpt-4o
 npx @kagura-agent/abti test --provider groq --model llama-3.3-70b-versatile
 npx @kagura-agent/abti test --provider mistral --model mistral-small-latest
+npx @kagura-agent/abti test --provider xai --model grok-3-mini --api-key xai-...
 ```
 
 Ollama requires no API key — just make sure Ollama is running locally.

--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,7 @@ inputs:
     description: 'Path to file containing the agent system prompt (e.g. AGENTS.md)'
     required: false
   provider:
-    description: 'LLM provider: openai, anthropic, gemini, deepseek, github, groq, openrouter, mistral, or ollama'
+    description: 'LLM provider: openai, anthropic, gemini, deepseek, github, groq, openrouter, mistral, xai, or ollama'
     required: true
   model:
     description: 'Model name (e.g. gpt-4o, claude-sonnet-4-20250514)'

--- a/action/index.js
+++ b/action/index.js
@@ -255,7 +255,8 @@ function callLLM(provider, apiKey, model, systemPrompt, userMessage, baseUrl) {
   if (provider === 'groq') return callOpenAI(apiKey, model, systemPrompt, userMessage, baseUrl || 'https://api.groq.com/openai');
   if (provider === 'openrouter') return callOpenAI(apiKey, model, systemPrompt, userMessage, baseUrl || 'https://openrouter.ai/api/v1');
   if (provider === 'mistral') return callOpenAI(apiKey, model, systemPrompt, userMessage, baseUrl || 'https://api.mistral.ai/v1');
-  throw new Error(`Unknown provider: ${provider}. Must be "openai", "anthropic", "gemini", "github", "groq", "openrouter", or "mistral".`);
+  if (provider === 'xai') return callOpenAI(apiKey, model, systemPrompt, userMessage, baseUrl || 'https://api.x.ai/v1');
+  throw new Error(`Unknown provider: ${provider}. Must be "openai", "anthropic", "gemini", "github", "groq", "openrouter", "mistral", or "xai".`);
 }
 
 // ─── Answer parsing ──────────────────────────────────────────────────────────

--- a/cli/bin/abti.js
+++ b/cli/bin/abti.js
@@ -168,7 +168,7 @@ if (flag('--help') || flag('-h')) {
     --name <name>            Agent name for registry
     --url <url>              Agent URL for registry
     --model <model>          Model name
-    --provider <provider>    Provider: openai|anthropic|gemini|deepseek|github|groq|openrouter|mistral|ollama (default: openai)
+    --provider <provider>    Provider: openai|anthropic|gemini|deepseek|github|groq|openrouter|mistral|xai|ollama (default: openai)
     --api-key <key>          API key (or set OPENAI_API_KEY / ANTHROPIC_API_KEY / GOOGLE_AI_API_KEY / DEEPSEEK_API_KEY / GROQ_API_KEY / OPENROUTER_API_KEY / GITHUB_TOKEN)
     --all                    Test all installed models (ollama, openrouter)
     --max-models <N>         Limit number of models to test in --all mode
@@ -357,8 +357,9 @@ function callLLM(prov, apiKey, mdl, systemPrompt, userMessage, baseUrl, maxToken
   if (prov === 'groq') return callOpenAI(apiKey, mdl, systemPrompt, userMessage, baseUrl || 'https://api.groq.com/openai', undefined, maxTokens);
   if (prov === 'openrouter') return callOpenAI(apiKey, mdl, systemPrompt, userMessage, baseUrl || 'https://openrouter.ai/api/v1', undefined, maxTokens);
   if (prov === 'mistral') return callOpenAI(apiKey, mdl, systemPrompt, userMessage, baseUrl || 'https://api.mistral.ai/v1', undefined, maxTokens);
+  if (prov === 'xai') return callOpenAI(apiKey, mdl, systemPrompt, userMessage, baseUrl || 'https://api.x.ai/v1', undefined, maxTokens);
   if (prov === 'ollama') return callOpenAI(apiKey || 'ollama', mdl, systemPrompt, userMessage, 'http://localhost:11434', isReasoningModel(mdl) ? { think: false } : undefined, maxTokens);
-  throw new Error(`Unknown provider: ${prov}. Must be "openai", "anthropic", "gemini", "deepseek", "github", "groq", "openrouter", "mistral", or "ollama".`);
+  throw new Error(`Unknown provider: ${prov}. Must be "openai", "anthropic", "gemini", "deepseek", "github", "groq", "openrouter", "mistral", "xai", or "ollama".`);
 }
 
 function isReasoningModel(modelName) {


### PR DESCRIPTION
## Summary

Add `xai` as a named provider for both CLI and GitHub Action, using the OpenAI-compatible endpoint at `https://api.x.ai/v1`.

## Changes

- **CLI**: Added `xai` to provider list and `callLLM` dispatch
- **GitHub Action**: Added `xai` provider routing  
- **README**: Added xAI usage example
- **action.yml**: Updated provider description

## Usage

```bash
npx @kagura-agent/abti test --provider xai --model grok-3-mini --api-key xai-...
```

Or in GitHub Actions:
```yaml
- uses: kagura-agent/abti@v1
  with:
    provider: xai
    model: grok-3-mini
    api-key: \${{ secrets.XAI_API_KEY }}
```

## Testing

All 197 tests pass.