### PR TITLE
feat(test-agent): add xAI/Grok provider to browser test page (fixes #373)

### DIFF
--- a/test-agent.html
+++ b/test-agent.html
@@ -553,6 +553,7 @@ nav a:hover, .nav a:hover, nav a.active, .nav a.active { color: var(--accent); }
         <option value="groq">Groq</option>
         <option value="mistral">Mistral</option>
         <option value="github">GitHub Models</option>
+        <option value="xai">xAI (Grok)</option>
         <option value="custom">Custom Endpoint</option>
       </select>
 
@@ -896,6 +897,12 @@ const providers = {
   github: {
     url: 'https://models.inference.ai.azure.com/chat/completions',
     models: ['gpt-4o', 'gpt-4o-mini', 'Phi-4', 'Llama-3.3-70B-Instruct', 'custom'],
+    auth: 'bearer',
+    format: 'openai',
+  },
+  xai: {
+    url: 'https://api.x.ai/v1/chat/completions',
+    models: ['grok-3', 'grok-3-mini', 'grok-2', 'custom'],
     auth: 'bearer',
     format: 'openai',
   },


### PR DESCRIPTION
## What
Add xAI (Grok) as a provider option in the browser test page (`test-agent.html`).

## Why
The CLI already supports xAI/Grok (#372), but the browser test page was missing it. This brings browser parity with the CLI.

## Changes
- Added `<option value="xai">xAI (Grok)</option>` to the provider dropdown
- Added `xai` entry to the `providers` config object with:
  - API endpoint: `https://api.x.ai/v1/chat/completions`
  - Models: grok-3, grok-3-mini, grok-2, custom
  - OpenAI-compatible format with bearer auth

## Testing
- All 197 tests pass
- Follows the exact same pattern as existing providers (groq, mistral, github)

Fixes #373