### PR TITLE
feat: complete xAI/Grok provider support (#377)

### DIFF
--- a/cli/bin/abti.js
+++ b/cli/bin/abti.js
@@ -169,7 +169,7 @@ if (flag('--help') || flag('-h')) {
     --url <url>              Agent URL for registry
     --model <model>          Model name
     --provider <provider>    Provider: openai|anthropic|gemini|deepseek|github|groq|openrouter|mistral|xai|ollama (default: openai)
-    --api-key <key>          API key (or set OPENAI_API_KEY / ANTHROPIC_API_KEY / GOOGLE_AI_API_KEY / DEEPSEEK_API_KEY / GROQ_API_KEY / OPENROUTER_API_KEY / GITHUB_TOKEN)
+    --api-key <key>          API key (or set OPENAI_API_KEY / ANTHROPIC_API_KEY / GOOGLE_AI_API_KEY / DEEPSEEK_API_KEY / GROQ_API_KEY / OPENROUTER_API_KEY / XAI_API_KEY / GITHUB_TOKEN)
     --all                    Test all installed models (ollama, openrouter)
     --max-models <N>         Limit number of models to test in --all mode
     --filter <pattern>       Filter models by substring match in --all mode
@@ -197,6 +197,7 @@ if (flag('--help') || flag('-h')) {
     npx abti test --provider github --model gpt-4o --api-key ghp_...
     npx abti test --provider groq --model llama-3.3-70b-versatile --api-key gsk_...
     npx abti test --provider openrouter --model meta-llama/llama-3.3-70b-instruct --api-key sk-or-...
+    npx abti test --provider xai --model grok-3-mini --api-key xai-...
 `);
   process.exit(0);
 }
@@ -399,7 +400,7 @@ function resolveApiKey(prov, explicit) {
   if (explicit) return explicit;
   if (prov === 'ollama') return 'ollama';
   if (prov === 'github') return process.env.GITHUB_TOKEN || (() => { throw new Error('No API key provided. Use --api-key or set GITHUB_TOKEN'); })();
-  const envMap = { openai: 'OPENAI_API_KEY', anthropic: 'ANTHROPIC_API_KEY', gemini: 'GOOGLE_AI_API_KEY', deepseek: 'DEEPSEEK_API_KEY', groq: 'GROQ_API_KEY', openrouter: 'OPENROUTER_API_KEY', mistral: 'MISTRAL_API_KEY' };
+  const envMap = { openai: 'OPENAI_API_KEY', anthropic: 'ANTHROPIC_API_KEY', gemini: 'GOOGLE_AI_API_KEY', deepseek: 'DEEPSEEK_API_KEY', groq: 'GROQ_API_KEY', openrouter: 'OPENROUTER_API_KEY', mistral: 'MISTRAL_API_KEY', xai: 'XAI_API_KEY' };
   const envKey = envMap[prov];
   if (envKey && process.env[envKey]) return process.env[envKey];
   throw new Error(`No API key provided. Use --api-key or set ${envKey}`);

--- a/test/provider.test.js
+++ b/test/provider.test.js
@@ -27,6 +27,22 @@ describe('callLLM provider routing', () => {
     });
   });
 
+  it('should route xai to callOpenAI (rejects with network error, not unknown provider)', async () => {
+    const promise = callLLM('xai', 'test-key', 'test-model', 'system', 'user');
+    await assert.rejects(promise, (err) => {
+      assert.ok(!err.message.includes('Unknown provider'), 'should not throw Unknown provider for xai');
+      return true;
+    });
+  });
+
+  it('should include xai in error message for unknown providers', () => {
+    try {
+      callLLM('bad', 'key', 'model', 'sys', 'usr');
+    } catch (e) {
+      assert.ok(e.message.includes('xai'), 'error message should list xai as valid provider');
+    }
+  });
+
   it('should include openrouter in error message for unknown providers', () => {
     try {
       callLLM('bad', 'key', 'model', 'sys', 'usr');


### PR DESCRIPTION
## Changes

Completes xAI/Grok provider support (fixes #377).

The CLI routing and browser test page already had xAI support. This PR fills the remaining gaps:

### CLI (`cli/bin/abti.js`)
- Add `xai: 'XAI_API_KEY'` to `resolveApiKey` env map — users can now set `XAI_API_KEY` instead of passing `--api-key` every time
- Add `XAI_API_KEY` to the `--api-key` help text
- Add xAI usage example in help output

### Tests (`test/provider.test.js`)
- Add test verifying `xai` routes to `callOpenAI` (not unknown provider error)
- Add test verifying `xai` is listed in the unknown-provider error message

### What was already done (prior commits)
- ✅ CLI `callLLM()` routing for xai provider
- ✅ Browser test page (`test-agent.html`) xAI entry
- ✅ README xAI example
- ✅ API server — no changes needed (stores provider as free-form string)

All 199 tests pass.