### PR TITLE
feat: complete xAI/Grok provider support

### DIFF
--- a/cli/bin/abti.js
+++ b/cli/bin/abti.js
@@ -399,7 +399,7 @@ function resolveApiKey(prov, explicit) {
   if (explicit) return explicit;
   if (prov === 'ollama') return 'ollama';
   if (prov === 'github') return process.env.GITHUB_TOKEN || (() => { throw new Error('No API key provided. Use --api-key or set GITHUB_TOKEN'); })();
-  const envMap = { openai: 'OPENAI_API_KEY', anthropic: 'ANTHROPIC_API_KEY', gemini: 'GOOGLE_AI_API_KEY', deepseek: 'DEEPSEEK_API_KEY', groq: 'GROQ_API_KEY', openrouter: 'OPENROUTER_API_KEY', mistral: 'MISTRAL_API_KEY' };
+  const envMap = { openai: 'OPENAI_API_KEY', anthropic: 'ANTHROPIC_API_KEY', gemini: 'GOOGLE_AI_API_KEY', deepseek: 'DEEPSEEK_API_KEY', groq: 'GROQ_API_KEY', openrouter: 'OPENROUTER_API_KEY', mistral: 'MISTRAL_API_KEY', xai: 'XAI_API_KEY' };
   const envKey = envMap[prov];
   if (envKey && process.env[envKey]) return process.env[envKey];
   throw new Error(`No API key provided. Use --api-key or set ${envKey}`);

--- a/test/provider.test.js
+++ b/test/provider.test.js
@@ -27,10 +27,19 @@ describe('callLLM provider routing', () => {
     });
   });
 
-  it('should include openrouter in error message for unknown providers', () => {
+  it('should route xai to callOpenAI (rejects with network error, not unknown provider)', async () => {
+    const promise = callLLM('xai', 'test-key', 'grok-3-mini', 'system', 'user');
+    await assert.rejects(promise, (err) => {
+      assert.ok(!err.message.includes('Unknown provider'), 'should not throw Unknown provider for xai');
+      return true;
+    });
+  });
+
+  it('should include xai in error message for unknown providers', () => {
     try {
       callLLM('bad', 'key', 'model', 'sys', 'usr');
     } catch (e) {
+      assert.ok(e.message.includes('xai'), 'error message should list xai as valid provider');
       assert.ok(e.message.includes('openrouter'), 'error message should list openrouter as valid provider');
     }
   });


### PR DESCRIPTION
Closes #377

## Changes

The xAI/Grok provider was already partially wired up (CLI routing in `callLLM` + browser entry in `test-agent.html`), but had two gaps:

### 1. CLI: Missing `XAI_API_KEY` env auto-detection
The `envMap` in `cli/bin/abti.js` didn't include `xai`, so running `abti test --provider xai` with `XAI_API_KEY` set in the environment would fail to auto-detect the key (users had to pass `--api-key` explicitly).

**Fix:** Added `xai: 'XAI_API_KEY'` to `envMap`.

### 2. Tests: No xAI provider routing coverage
`test/provider.test.js` had routing tests for `openrouter` and `groq` but not `xai`.

**Fix:** Added two tests:
- Routing test verifying xAI goes through `callOpenAI` (rejects with network error, not "Unknown provider")
- Error message test verifying `xai` is listed as a valid provider in error output

### Not changed (already working)
- CLI `callLLM` routing for xai — already existed
- Browser `test-agent.html` xAI entry — already existed
- API server — no provider validation to update
- README — already has xAI example

**Tests:** 198 pass, 0 fail
