### PR TITLE
feat: add Atom feed for agent test results (fixes #383)

### DIFF
--- a/api-server.js
+++ b/api-server.js
@@ -203,6 +203,10 @@ const typesJson = require('./api/v1/types.json');
 const richProfiles = typesJson.abti.types;
 
 // ─── Slug generation ─────────────────────────────────────────────────────
+function escapeXml(s) {
+  return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;').replace(/'/g,'&apos;');
+}
+
 function slugify(name) {
   return name
     .toLowerCase()
@@ -1105,6 +1109,31 @@ ${dimInfo.map((d, i) => {
       res.writeHead(404, { 'Content-Type': 'text/plain' });
       return res.end('Not found');
     }
+  }
+
+  // GET /feed.xml - Atom feed of recent agent test results
+  if (url.pathname === '/feed.xml' && req.method === 'GET') {
+    const BASE = 'https://abti.kagura-agent.com';
+    const agents = (agentData.agents || [])
+      .filter(a => a.testedAt)
+      .sort((a, b) => new Date(b.testedAt) - new Date(a.testedAt))
+      .slice(0, 50);
+    const updated = agents.length > 0 ? new Date(agents[0].testedAt).toISOString() : new Date().toISOString();
+    const entries = agents.map(a => {
+      const slug = a.slug || slugify(a.name);
+      const published = new Date(a.testedAt).toISOString();
+      const dimLabels = ['Autonomy','Precision','Transparency','Adaptability'];
+      const dimDetail = (a.dimensions || []).map((d, i) => {
+        const label = dimLabels[i] || `Dim ${i+1}`;
+        const pole = d.majority || (d.poles ? d.poles[d.score >= 2 ? 0 : 1] : '?');
+        return `${label}: ${pole} (${d.score}/4)`;
+      }).join(', ');
+      const content = `Type: ${a.type || 'Unknown'} — ${a.nick || 'Unknown'}. ${dimDetail}`;
+      return `  <entry>\n    <title>${escapeXml(a.name)} — ${escapeXml(a.type || 'Unknown')} (${escapeXml(a.nick || '')})</title>\n    <link href="${BASE}/agent/${encodeURIComponent(slug)}" rel="alternate"/>\n    <id>${BASE}/agent/${encodeURIComponent(slug)}#${published}</id>\n    <published>${published}</published>\n    <updated>${published}</updated>\n    <summary type="text">${escapeXml(content)}</summary>\n  </entry>`;
+    }).join('\n');
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>\n<feed xmlns="http://www.w3.org/2005/Atom">\n  <title>ABTI — Agent Test Results</title>\n  <subtitle>Recent AI agent personality test results from ABTI</subtitle>\n  <link href="${BASE}/feed.xml" rel="self" type="application/atom+xml"/>\n  <link href="${BASE}" rel="alternate"/>\n  <id>${BASE}/feed.xml</id>\n  <updated>${updated}</updated>\n  <author><name>ABTI</name></author>\n${entries}\n</feed>`;
+    res.writeHead(200, { 'Content-Type': 'application/atom+xml; charset=utf-8' });
+    return res.end(xml);
   }
 
   // GET /sitemap.xml - dynamic sitemap including agent pages

--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>ABTI — Agent Behavioral Type Indicator</title>
+<link rel="alternate" type="application/atom+xml" href="/feed.xml" title="ABTI Agent Feed">
 <meta property="og:type" content="website">
 <meta property="og:title" content="ABTI — AI Agent 人格测试 | 你的AI是什么型？">
 <meta property="og:description" content="4维度16种类型，AI界的MBTI 🌸">
@@ -721,6 +722,7 @@ nav a:hover, .nav a:hover, nav a.active, .nav a.active { color: var(--accent); }
 }
 /* — End nav — */
 </style>
+<link rel="alternate" type="application/atom+xml" title="ABTI Agent Feed" href="/feed.xml">
 </head>
 <body>
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "abti",
   "private": true,
   "scripts": {
-    "test": "node --test test/api.test.js test/mcp.test.js test/mcp-http.test.js test/compatibility.test.js test/cross-compatibility.test.js test/auto-reload.test.js test/parseAnswer.test.js test/provider.test.js test/resume.test.js test/list.test.js test/action-drift.test.js test/all-flag.test.js",
+    "test": "node --test test/api.test.js test/mcp.test.js test/mcp-http.test.js test/compatibility.test.js test/cross-compatibility.test.js test/auto-reload.test.js test/parseAnswer.test.js test/provider.test.js test/resume.test.js test/list.test.js test/action-drift.test.js test/all-flag.test.js test/feed.test.js",
     "generate-og": "node scripts/generate-og-images.js",
     "generate-sitemap": "node scripts/generate-sitemap.js",
     "generate-og-agents": "node scripts/generate-agent-og.js"

--- a/test/feed.test.js
+++ b/test/feed.test.js
@@ -1,0 +1,140 @@
+const { describe, it, before, after, beforeEach } = require('node:test');
+const assert = require('node:assert/strict');
+const http = require('node:http');
+const os = require('node:os');
+const fs = require('node:fs');
+const path = require('node:path');
+
+// Set up isolated data dir BEFORE requiring the server
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'abti-feed-test-'));
+process.env.ABTI_DATA_DIR = tmpDir;
+
+// Seed test data
+const seedData = {
+  agents: [
+    {
+      name: 'Test Agent Alpha',
+      slug: 'test-agent-alpha',
+      type: 'PTCF',
+      nick: 'The Architect',
+      testedAt: '2026-05-20T10:00:00.000Z',
+      scores: [4, 4, 3, 2],
+      dimensions: [
+        { poles: ['P', 'R'], score: 4, majority: 'P' },
+        { poles: ['T', 'E'], score: 4, majority: 'T' },
+        { poles: ['C', 'D'], score: 3, majority: 'C' },
+        { poles: ['F', 'N'], score: 2, majority: 'F' }
+      ]
+    },
+    {
+      name: 'Test Agent Beta',
+      slug: 'test-agent-beta',
+      type: 'RECN',
+      nick: 'The Machine',
+      testedAt: '2026-05-21T12:00:00.000Z',
+      scores: [0, 0, 4, 1],
+      dimensions: [
+        { poles: ['P', 'R'], score: 0, majority: 'R' },
+        { poles: ['T', 'E'], score: 0, majority: 'E' },
+        { poles: ['C', 'D'], score: 4, majority: 'C' },
+        { poles: ['F', 'N'], score: 1, majority: 'N' }
+      ]
+    }
+  ]
+};
+
+fs.writeFileSync(path.join(tmpDir, 'results.json'), JSON.stringify(seedData, null, 2));
+
+const server = require('../api-server.js');
+const { resetData, stopWatching } = require('../api-server.js');
+
+let BASE;
+
+function req(urlPath) {
+  return new Promise((resolve, reject) => {
+    const url = new URL(urlPath, BASE);
+    const o = { hostname: url.hostname, port: url.port, path: url.pathname + url.search, method: 'GET' };
+    const r = http.request(o, (res) => {
+      let d = '';
+      res.on('data', c => d += c);
+      res.on('end', () => resolve({ status: res.statusCode, headers: res.headers, body: d }));
+    });
+    r.on('error', reject);
+    r.end();
+  });
+}
+
+before(() => new Promise((resolve) => {
+  resetData();
+  server.listen(0, '127.0.0.1', () => {
+    const { port } = server.address();
+    BASE = `http://127.0.0.1:${port}`;
+    resolve();
+  });
+}));
+
+after(() => new Promise((resolve) => {
+  stopWatching();
+  server.close(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    delete process.env.ABTI_DATA_DIR;
+    resolve();
+  });
+}));
+
+describe('GET /feed.xml', () => {
+  it('should return valid Atom XML with correct content type', async () => {
+    const r = await req('/feed.xml');
+    assert.equal(r.status, 200);
+    assert.ok(r.headers['content-type'].includes('application/atom+xml'));
+    assert.ok(r.body.includes('<?xml version="1.0"'));
+    assert.ok(r.body.includes('<feed xmlns="http://www.w3.org/2005/Atom">'));
+  });
+
+  it('should contain feed metadata', async () => {
+    const r = await req('/feed.xml');
+    assert.ok(r.body.includes('<title>ABTI'), 'should have ABTI in title');
+    assert.ok(r.body.includes('rel="self"'), 'should have self link');
+    assert.ok(r.body.includes('rel="alternate"'), 'should have alternate link');
+    assert.ok(r.body.includes('<author><name>ABTI</name></author>'), 'should have author');
+    assert.ok(r.body.includes('<updated>'), 'should have updated timestamp');
+  });
+
+  it('should list agents sorted by testedAt desc (newest first)', async () => {
+    const r = await req('/feed.xml');
+    const betaIdx = r.body.indexOf('Test Agent Beta');
+    const alphaIdx = r.body.indexOf('Test Agent Alpha');
+    assert.ok(betaIdx > 0, 'Beta should be in feed');
+    assert.ok(alphaIdx > 0, 'Alpha should be in feed');
+    assert.ok(betaIdx < alphaIdx, 'Beta (newer) should appear before Alpha (older)');
+  });
+
+  it('should include agent type and nickname in entry title', async () => {
+    const r = await req('/feed.xml');
+    assert.ok(r.body.includes('Test Agent Beta'), 'should include agent name');
+    assert.ok(r.body.includes('RECN'), 'should include type code');
+    assert.ok(r.body.includes('The Machine'), 'should include nickname');
+    assert.ok(r.body.includes('PTCF'), 'should include other type code');
+    assert.ok(r.body.includes('The Architect'), 'should include other nickname');
+  });
+
+  it('should include agent profile links', async () => {
+    const r = await req('/feed.xml');
+    assert.ok(r.body.includes('agent/test-agent-beta'), 'should link to beta profile');
+    assert.ok(r.body.includes('agent/test-agent-alpha'), 'should link to alpha profile');
+  });
+
+  it('should include dimension info in summary', async () => {
+    const r = await req('/feed.xml');
+    assert.ok(r.body.includes('Autonomy'), 'should have Autonomy dimension');
+    assert.ok(r.body.includes('Precision'), 'should have Precision dimension');
+    assert.ok(r.body.includes('Transparency'), 'should have Transparency dimension');
+    assert.ok(r.body.includes('Adaptability'), 'should have Adaptability dimension');
+  });
+
+  it('should have published dates from testedAt', async () => {
+    const r = await req('/feed.xml');
+    assert.ok(r.body.includes('<published>2026-05-21T12:00:00.000Z</published>'));
+    assert.ok(r.body.includes('<published>2026-05-20T10:00:00.000Z</published>'));
+  });
+});


### PR DESCRIPTION
## Summary

Adds a `/feed.xml` endpoint that serves an Atom feed of recent agent test results, making ABTI results discoverable through RSS readers and aggregators.

## Changes

- **`api-server.js`**: Add `GET /feed.xml` route with Atom XML generation
  - Lists agents sorted by `testedAt` desc, limited to 50 entries
  - Each entry includes name, ABTI type, nickname, dimension scores
  - Added `escapeXml()` utility for safe XML escaping
- **`index.html`**: Add `<link rel="alternate" type="application/atom+xml">` for feed auto-discovery
- **`test/feed.test.js`**: 7 test cases covering XML structure, metadata, sorting, content, and links
- **`package.json`**: Register feed test in test script

## Testing

```
node --test test/feed.test.js  # 7/7 pass
```

Full suite also passes (39/39).

Fixes #383