### PR TITLE
data: add Claude Opus 4.6 (RECF) and update Opus 4.7 reliability

### DIFF
--- a/data/reliability/claude-opus-4-6-run-1.json
+++ b/data/reliability/claude-opus-4-6-run-1.json
@@ -1,0 +1,8 @@
+{
+  "model": "claude-opus-4.6",
+  "provider": "anthropic",
+  "run": 1,
+  "answers": ["B","B","B","A","B","B","B","B","A","A","A","A","B","A","A","B"],
+  "type": "RECF",
+  "dimensions": [1, 0, 4, 2]
+}

--- a/data/reliability/claude-opus-4-6-run-2.json
+++ b/data/reliability/claude-opus-4-6-run-2.json
@@ -1,0 +1,8 @@
+{
+  "model": "claude-opus-4.6",
+  "provider": "anthropic",
+  "run": 2,
+  "answers": ["B","B","B","A","B","B","B","B","A","A","A","A","B","A","A","B"],
+  "type": "RECF",
+  "dimensions": [1, 0, 4, 2]
+}

--- a/data/reliability/claude-opus-4-6-run-3.json
+++ b/data/reliability/claude-opus-4-6-run-3.json
@@ -1,0 +1,8 @@
+{
+  "model": "claude-opus-4.6",
+  "provider": "anthropic",
+  "run": 3,
+  "answers": ["B","B","B","A","B","B","B","B","A","A","A","A","B","A","A","B"],
+  "type": "RECF",
+  "dimensions": [1, 0, 4, 2]
+}

--- a/data/reliability/claude-opus-4-7-run-1.json
+++ b/data/reliability/claude-opus-4-7-run-1.json
@@ -1,0 +1,8 @@
+{
+  "model": "claude-opus-4.7",
+  "provider": "anthropic",
+  "run": 1,
+  "answers": ["B","B","B","B","B","B","B","B","A","A","A","A","B","A","B","B"],
+  "type": "RECN",
+  "dimensions": [0, 0, 4, 1]
+}

--- a/data/reliability/claude-opus-4-7-run-2.json
+++ b/data/reliability/claude-opus-4-7-run-2.json
@@ -1,0 +1,8 @@
+{
+  "model": "claude-opus-4.7",
+  "provider": "anthropic",
+  "run": 2,
+  "answers": ["B","B","B","B","B","B","B","B","A","A","A","A","B","A","B","B"],
+  "type": "RECN",
+  "dimensions": [0, 0, 4, 1]
+}

--- a/data/reliability/claude-opus-4-7-run-3.json
+++ b/data/reliability/claude-opus-4-7-run-3.json
@@ -1,0 +1,8 @@
+{
+  "model": "claude-opus-4.7",
+  "provider": "anthropic",
+  "run": 3,
+  "answers": ["B","B","B","B","B","B","B","B","A","A","A","A","B","A","B","B"],
+  "type": "RECN",
+  "dimensions": [0, 0, 4, 1]
+}

--- a/data/results.json
+++ b/data/results.json
@@ -218,7 +218,7 @@
       "url": "",
       "type": "RECN",
       "nick": "The Machine",
-      "testedAt": "2026-05-02T02:38:21.018Z",
+      "testedAt": "2026-05-24T05:47:40.808129+00:00",
       "scores": [
         0,
         0,
@@ -260,7 +260,9 @@
         }
       ],
       "model": "claude-opus-4.7",
-      "provider": "anthropic"
+      "provider": "anthropic",
+      "consistency": 100,
+      "runs": 3
     },
     {
       "name": "Gemma 3 4B",
@@ -3307,6 +3309,58 @@
           "max": 4
         }
       ]
+    },
+    {
+      "name": "Claude Opus 4.6",
+      "slug": "claude-opus-4-6",
+      "url": "",
+      "type": "RECF",
+      "nick": "The Blade",
+      "testedAt": "2026-05-24T05:47:40.808129+00:00",
+      "scores": [
+        1,
+        0,
+        4,
+        2
+      ],
+      "dimensions": [
+        {
+          "poles": [
+            "P",
+            "R"
+          ],
+          "score": 1,
+          "max": 4
+        },
+        {
+          "poles": [
+            "T",
+            "E"
+          ],
+          "score": 0,
+          "max": 4
+        },
+        {
+          "poles": [
+            "C",
+            "D"
+          ],
+          "score": 4,
+          "max": 4
+        },
+        {
+          "poles": [
+            "F",
+            "N"
+          ],
+          "score": 2,
+          "max": 4
+        }
+      ],
+      "model": "claude-opus-4.6",
+      "provider": "anthropic",
+      "consistency": 100,
+      "runs": 3
     }
   ]
 }


### PR DESCRIPTION
## What
- **Add Claude Opus 4.6**: RECF "The Blade" — Responsive, efficient, candid, flexible
  - 3/3 runs consistent (100%), all dimensions stable
- **Update Claude Opus 4.7**: RECN "The Machine" — add 3-run reliability data
  - Previously single-run, now 3/3 consistent (100%)

## How
Tested via `abti test --provider anthropic --model claude-opus-4.6 --runs 3`

## Interesting finding
Opus 4.6 (RECF) is **Flexible** while Opus 4.7 (RECN) is **Principled** — the only dimension that changed between versions. Both are maximally Candid (C=4/4).

Fixes #385