### PR TITLE
fix: deploy script preserves data/ across git checkout

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -100,7 +100,7 @@ npx @kagura-agent/abti list --lang zh
 | `--model <model>` | Model name |
 | `--provider <provider>` | Provider: `openai`, `anthropic`, `gemini`, `deepseek`, `ollama`, `openrouter`, `groq`, `mistral`, `github` (default: `openai`) |
 | `--api-key <key>` | API key (or set env var) |
-| `--submit` | Submit result to the ABTI registry |
+| `--submit` | Submit result to the ABTI registry (persisted server-side in `data/results.json`) |
 | `--runs <N>` | Run the test N times (1-10) and show consistency report |
 | `--help` | Show help |
 

--- a/ops/README.md
+++ b/ops/README.md
@@ -21,6 +21,24 @@ sudo journalctl -u abti-api -f
 
 Manual `nohup` creates orphan processes that hold port 3300, causing systemd `EADDRINUSE` crash loops on restart.
 
+## Deploy Cron
+
+`ops/abti-deploy.sh` pulls the latest master every few minutes and conditionally restarts the API service.
+
+### Setup
+
+```bash
+chmod +x /home/azureuser/abti/ops/abti-deploy.sh
+
+# Add to crontab (every 5 minutes)
+crontab -e
+*/5 * * * * /home/azureuser/abti/ops/abti-deploy.sh >> /var/log/abti-deploy.log 2>&1
+```
+
+### Data persistence
+
+The script uses `git checkout -- . ":(exclude)data/"` instead of a bare `git checkout -- .` so that `data/results.json` (the API submission store) is never overwritten by deploys. Runtime data in `data/` is preserved across every pull.
+
 ## How the safety net works
 
 The service unit includes `ExecStartPre=fuser -k 3300/tcp || true`, which kills any process holding port 3300 before starting. This ensures the service can always bind the port, even if an orphan process was left behind.

--- a/ops/abti-deploy.sh
+++ b/ops/abti-deploy.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# abti-deploy.sh — Pull latest master and conditionally restart the API.
+#
+# Safe for cron: uses ":(exclude)data/" so that git checkout
+# never overwrites data/results.json (API submission store).
+#
+# Suggested crontab entry (every 5 minutes):
+#   */5 * * * * /home/azureuser/abti/ops/abti-deploy.sh >> /var/log/abti-deploy.log 2>&1
+
+set -euo pipefail
+cd /home/azureuser/abti || exit 1
+
+BEFORE=$(git rev-parse HEAD)
+
+# Reset tracked files to match HEAD, but exclude the data/ directory
+# so that runtime-written files (results.json) are never discarded.
+git checkout -- . ":(exclude)data/" 2>/dev/null
+
+git pull origin master --ff-only 2>/dev/null || exit 0
+
+AFTER=$(git rev-parse HEAD)
+
+# Restart the API service only when relevant server files changed.
+if [ "$BEFORE" != "$AFTER" ]; then
+  if git diff --name-only "$BEFORE" "$AFTER" | grep -q "api-server.js\|mcp/"; then
+    sudo systemctl restart abti-api
+  fi
+fi


### PR DESCRIPTION
Fixes #387

## Problem
The VM1 deploy cron runs `git checkout -- .` which resets **all** local changes, including `data/results.json` — wiping API submissions every 5 minutes.

## Fix
- Add `ops/abti-deploy.sh` using `git checkout -- . ":(exclude)data/"` so runtime data is never discarded
- Document deploy cron setup and data persistence in `ops/README.md`
- Note `--submit` persistence behavior in `cli/README.md`

## After merge
Update VM1 crontab to point to `/home/azureuser/abti/ops/abti-deploy.sh` (the in-repo script).