### PR TITLE
feat(test-agent): dynamic OpenRouter free model list (fixes #390)

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "abti",
   "private": true,
   "scripts": {
-    "test": "node --test test/api.test.js test/mcp.test.js test/mcp-http.test.js test/compatibility.test.js test/cross-compatibility.test.js test/auto-reload.test.js test/parseAnswer.test.js test/provider.test.js test/resume.test.js test/list.test.js test/action-drift.test.js test/all-flag.test.js test/feed.test.js",
+    "test": "node --test test/api.test.js test/mcp.test.js test/mcp-http.test.js test/compatibility.test.js test/cross-compatibility.test.js test/auto-reload.test.js test/parseAnswer.test.js test/provider.test.js test/resume.test.js test/list.test.js test/action-drift.test.js test/all-flag.test.js test/feed.test.js test/dynamic-models.test.js",
     "generate-og": "node scripts/generate-og-images.js",
     "generate-sitemap": "node scripts/generate-sitemap.js",
     "generate-og-agents": "node scripts/generate-agent-og.js"

--- a/test-agent.html
+++ b/test-agent.html
@@ -881,6 +881,7 @@ const providers = {
     models: ['openai/gpt-oss-120b:free', 'google/gemma-4-31b-it:free', 'google/gemma-4-26b-a4b-it:free', 'qwen/qwen3-coder:free', 'qwen/qwen3-next-80b-a3b-instruct:free', 'nvidia/nemotron-3-super-120b-a12b:free', 'nvidia/nemotron-3-nano-30b-a3b:free', 'minimax/minimax-m2.5:free', 'custom'],
     auth: 'bearer',
     format: 'openai',
+    dynamicModels: true,
   },
   groq: {
     url: 'https://api.groq.com/openai/v1/chat/completions',
@@ -914,6 +915,47 @@ const providers = {
   }
 };
 
+// Cache for dynamically fetched model lists
+const dynamicModelCache = {};
+
+async function fetchOpenRouterModels() {
+  const cacheKey = 'openrouter-models';
+  // Check sessionStorage first
+  try {
+    const cached = sessionStorage.getItem(cacheKey);
+    if (cached) {
+      const { models, ts } = JSON.parse(cached);
+      if (Date.now() - ts < 3600000) { // 1 hour TTL
+        return models;
+      }
+    }
+  } catch {}
+  try {
+    const resp = await fetch('https://openrouter.ai/api/v1/models');
+    if (!resp.ok) return null;
+    const data = await resp.json();
+    const free = (data.data || [])
+      .filter(m => m.id.endsWith(':free'))
+      .map(m => m.id)
+      .sort();
+    if (free.length > 0) {
+      try { sessionStorage.setItem(cacheKey, JSON.stringify({ models: free, ts: Date.now() })); } catch {}
+      return free;
+    }
+  } catch {}
+  return null;
+}
+
+function populateModelSelect(models, modelSelect, modelInput) {
+  modelSelect.innerHTML = models.map(m => {
+    const label = m === 'custom' ? 'Other (enter model ID)' : m;
+    return `<option value="${m}">${label}</option>`;
+  }).join('');
+  modelSelect.classList.remove('hidden');
+  const showCustomInput = modelSelect.value === 'custom';
+  modelInput.classList.toggle('hidden', !showCustomInput);
+}
+
 function onProviderChange() {
   const p = document.getElementById('providerSelect').value;
   const cfg = providers[p];
@@ -921,15 +963,24 @@ function onProviderChange() {
   const modelInput = document.getElementById('modelInput');
   const customFields = document.getElementById('customFields');
 
-  if (cfg.models) {
-    modelSelect.innerHTML = cfg.models.map(m => {
-      const label = m === 'custom' ? 'Other (enter model ID)' : m;
-      return `<option value="${m}">${label}</option>`;
-    }).join('');
-    modelSelect.classList.remove('hidden');
-    // Show text input only if 'custom' option is selected in the dropdown
-    const showCustomInput = modelSelect.value === 'custom';
-    modelInput.classList.toggle('hidden', !showCustomInput);
+  if (cfg.dynamicModels && !dynamicModelCache[p]) {
+    // Show static list immediately, then fetch dynamic list
+    if (cfg.models) {
+      populateModelSelect(cfg.models, modelSelect, modelInput);
+    }
+    // Fetch dynamic models in background
+    if (p === 'openrouter') {
+      fetchOpenRouterModels().then(models => {
+        if (models && document.getElementById('providerSelect').value === 'openrouter') {
+          dynamicModelCache[p] = [...models, 'custom'];
+          populateModelSelect(dynamicModelCache[p], modelSelect, modelInput);
+        }
+      });
+    }
+  } else if (dynamicModelCache[p]) {
+    populateModelSelect(dynamicModelCache[p], modelSelect, modelInput);
+  } else if (cfg.models) {
+    populateModelSelect(cfg.models, modelSelect, modelInput);
   } else {
     modelSelect.classList.add('hidden');
     modelInput.classList.remove('hidden');

--- a/test/dynamic-models.test.js
+++ b/test/dynamic-models.test.js
@@ -1,0 +1,49 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+const http = require('node:http');
+const fs = require('node:fs');
+const path = require('node:path');
+
+function startServer() {
+  return new Promise((resolve) => {
+    delete require.cache[require.resolve('../api-server.js')];
+    const serverModule = require('../api-server.js');
+    const server = serverModule.server || serverModule;
+    if (server.listening) return resolve(server);
+    server.listen(0, '127.0.0.1', () => resolve(server));
+  });
+}
+
+function fetch(url) {
+  return new Promise((resolve, reject) => {
+    http.get(url, (res) => {
+      let data = '';
+      res.on('data', c => data += c);
+      res.on('end', () => resolve({ status: res.statusCode, body: data }));
+    }).on('error', reject);
+  });
+}
+
+describe('dynamic OpenRouter models', () => {
+  let server;
+  let base;
+
+  it('test-agent.html contains dynamicModels flag for openrouter', async () => {
+    const html = fs.readFileSync(path.join(__dirname, '..', 'test-agent.html'), 'utf8');
+    assert.ok(html.includes('dynamicModels: true'), 'openrouter should have dynamicModels flag');
+    assert.ok(html.includes('fetchOpenRouterModels'), 'should have fetchOpenRouterModels function');
+    assert.ok(html.includes('dynamicModelCache'), 'should have dynamicModelCache');
+    assert.ok(html.includes('sessionStorage'), 'should cache in sessionStorage');
+  });
+
+  it('test-agent.html still has static fallback models for openrouter', () => {
+    const html = fs.readFileSync(path.join(__dirname, '..', 'test-agent.html'), 'utf8');
+    assert.ok(html.includes("'openai/gpt-oss-120b:free'"), 'should have fallback models');
+    assert.ok(html.includes("'custom'"), 'should have custom option');
+  });
+
+  it('fetchOpenRouterModels filters to :free models', () => {
+    const html = fs.readFileSync(path.join(__dirname, '..', 'test-agent.html'), 'utf8');
+    assert.ok(html.includes("m.id.endsWith(':free')"), 'should filter by :free suffix');
+  });
+});


### PR DESCRIPTION
## What

When OpenRouter is selected in the browser test page, dynamically fetch available free models from the OpenRouter API instead of showing a hardcoded list.

## Why

The static list had 8 free models but OpenRouter currently offers 24. The list changes frequently, so a dynamic fetch keeps it always up to date.

## How

- Fetches `https://openrouter.ai/api/v1/models` (CORS-enabled: `access-control-allow-origin: *`)
- Filters to models ending with `:free`
- Caches result in `sessionStorage` with 1-hour TTL
- Falls back to the existing static list on network error
- Shows static list immediately while fetch is in progress (no loading delay)
- Adds `dynamicModels: true` flag to provider config for extensibility

## Tests

3 new tests in `test/dynamic-models.test.js`, full suite passes (210/210).

Fixes #390