### PR TITLE
feat(cli): add --all flag support for remaining providers

### DIFF
--- a/cli/bin/abti.js
+++ b/cli/bin/abti.js
@@ -164,6 +164,13 @@ if (flag('--help') || flag('-h')) {
     npx abti test --provider openrouter --all --filter llama --max-models 5
     npx abti test --provider github --all
     npx abti test --provider anthropic --all --api-key sk-ant-...
+    npx abti test --provider groq --all --api-key gsk_...
+    npx abti test --provider mistral --all --api-key ...
+    npx abti test --provider openai --all --api-key sk-...
+    npx abti test --provider gemini --all --api-key ...
+    npx abti test --provider deepseek --all --api-key ...
+    npx abti test --provider xai --all --api-key ...
+    npx abti test --provider cohere --all --api-key ...
 
   Options:
     --lang zh                Language (default: en)
@@ -173,7 +180,7 @@ if (flag('--help') || flag('-h')) {
     --model <model>          Model name
     --provider <provider>    Provider: openai|anthropic|gemini|deepseek|github|groq|openrouter|mistral|xai|cohere|ollama (default: openai)
     --api-key <key>          API key (or set OPENAI_API_KEY / ANTHROPIC_API_KEY / GOOGLE_AI_API_KEY / DEEPSEEK_API_KEY / GROQ_API_KEY / OPENROUTER_API_KEY / GITHUB_TOKEN / CO_API_KEY)
-    --all                    Test all installed models (ollama, openrouter, github, anthropic)
+    --all                    Test all available models (all providers supported)
     --max-models <N>         Limit number of models to test in --all mode
     --filter <pattern>       Filter models by substring match in --all mode
     --submit                 Submit result to the ABTI registry
@@ -663,55 +670,126 @@ function fetchGitHubModels(apiKey) {
   });
 }
 
+function fetchOpenAICompatModels(baseUrl, apiKey, providerName) {
+  const url = baseUrl.replace(/\/+$/, '') + '/models';
+  return new Promise((resolve, reject) => {
+    const agent = createProxyAgent(url, noProxyFlag);
+    https.get(url, {
+      agent,
+      headers: { 'Authorization': `Bearer ${apiKey}` },
+    }, res => {
+      let data = '';
+      res.on('data', c => data += c);
+      res.on('end', () => {
+        if (res.statusCode !== 200) return reject(new Error(`${providerName} API returned ${res.statusCode}: ${data}`));
+        try {
+          const json = JSON.parse(data);
+          const models = (json.data || [])
+            .map(m => m.id)
+            .sort((a, b) => a.localeCompare(b));
+          resolve(models);
+        } catch (e) { reject(new Error(`Failed to parse ${providerName} response: ${e.message}`)); }
+      });
+    }).on('error', err => {
+      reject(new Error(`Cannot connect to ${providerName} API: ${err.message}`));
+    });
+  });
+}
+
+function fetchGeminiModels(apiKey) {
+  const url = `https://generativelanguage.googleapis.com/v1beta/models?key=${apiKey}&pageSize=1000`;
+  return new Promise((resolve, reject) => {
+    const agent = createProxyAgent(url, noProxyFlag);
+    https.get(url, { agent }, res => {
+      let data = '';
+      res.on('data', c => data += c);
+      res.on('end', () => {
+        if (res.statusCode !== 200) return reject(new Error(`Gemini API returned ${res.statusCode}: ${data}`));
+        try {
+          const json = JSON.parse(data);
+          const models = (json.models || [])
+            .filter(m => m.supportedGenerationMethods && m.supportedGenerationMethods.includes('generateContent'))
+            .map(m => m.name.replace(/^models\//, ''))
+            .sort((a, b) => a.localeCompare(b));
+          resolve(models);
+        } catch (e) { reject(new Error(`Failed to parse Gemini response: ${e.message}`)); }
+      });
+    }).on('error', err => {
+      reject(new Error(`Cannot connect to Gemini API: ${err.message}`));
+    });
+  });
+}
+
+function fetchCohereModels(apiKey) {
+  const url = 'https://api.cohere.com/v2/models';
+  return new Promise((resolve, reject) => {
+    const agent = createProxyAgent(url, noProxyFlag);
+    https.get(url, {
+      agent,
+      headers: { 'Authorization': `Bearer ${apiKey}` },
+    }, res => {
+      let data = '';
+      res.on('data', c => data += c);
+      res.on('end', () => {
+        if (res.statusCode !== 200) return reject(new Error(`Cohere API returned ${res.statusCode}: ${data}`));
+        try {
+          const json = JSON.parse(data);
+          const models = (json.models || [])
+            .map(m => m.name)
+            .sort((a, b) => a.localeCompare(b));
+          resolve(models);
+        } catch (e) { reject(new Error(`Failed to parse Cohere response: ${e.message}`)); }
+      });
+    }).on('error', err => {
+      reject(new Error(`Cannot connect to Cohere API: ${err.message}`));
+    });
+  });
+}
+
 function displayName(modelName) {
   return modelName.replace(/:latest$/, '');
 }
 
 // ── Batch --all mode ────────────────────────────────────────────────────
 async function runAll() {
-  if (autoProvider !== 'ollama' && autoProvider !== 'openrouter' && autoProvider !== 'github' && autoProvider !== 'anthropic') {
-    console.error('  --all is currently only supported with --provider ollama, openrouter, github, or anthropic');
-    process.exit(1);
-  }
+  const openaiCompatProviders = {
+    groq: { baseUrl: 'https://api.groq.com/openai/v1', name: 'Groq' },
+    mistral: { baseUrl: 'https://api.mistral.ai/v1', name: 'Mistral' },
+    openai: { baseUrl: 'https://api.openai.com/v1', name: 'OpenAI' },
+    deepseek: { baseUrl: 'https://api.deepseek.com/v1', name: 'DeepSeek' },
+    xai: { baseUrl: 'https://api.x.ai/v1', name: 'xAI' },
+  };
 
   let modelList;
 
-  if (autoProvider === 'anthropic') {
-    const apiKey = resolveApiKey('anthropic', autoApiKey);
-    process.stderr.write(`  Discovering Anthropic models...\n`);
-    try {
-      modelList = await fetchAnthropicModels(apiKey);
-    } catch (err) {
-      console.error(`  ${err.message}`);
-      process.exit(1);
-    }
-  } else if (autoProvider === 'openrouter') {
-    const apiKey = resolveApiKey('openrouter', autoApiKey);
-    process.stderr.write(`  Discovering OpenRouter models...\n`);
-    try {
-      modelList = await fetchOpenRouterModels(apiKey);
-    } catch (err) {
-      console.error(`  ${err.message}`);
-      process.exit(1);
-    }
-  } else if (autoProvider === 'github') {
-    const apiKey = resolveApiKey('github', autoApiKey);
-    process.stderr.write(`  Discovering GitHub Models...\n`);
-    try {
-      modelList = await fetchGitHubModels(apiKey);
-    } catch (err) {
-      console.error(`  ${err.message}`);
-      process.exit(1);
-    }
-  } else {
-    process.stderr.write(`  Discovering Ollama models...\n`);
-    try {
+  const apiKey = resolveApiKey(autoProvider, autoApiKey);
+  const providerLabel = autoProvider.charAt(0).toUpperCase() + autoProvider.slice(1);
+  process.stderr.write(`  Discovering ${providerLabel} models...\n`);
+
+  try {
+    if (autoProvider === 'ollama') {
       const data = await fetchOllamaModels();
       modelList = (data.models || []).map(m => m.name);
-    } catch (err) {
-      console.error(`  ${err.message}`);
+    } else if (autoProvider === 'anthropic') {
+      modelList = await fetchAnthropicModels(apiKey);
+    } else if (autoProvider === 'openrouter') {
+      modelList = await fetchOpenRouterModels(apiKey);
+    } else if (autoProvider === 'github') {
+      modelList = await fetchGitHubModels(apiKey);
+    } else if (autoProvider === 'gemini') {
+      modelList = await fetchGeminiModels(apiKey);
+    } else if (autoProvider === 'cohere') {
+      modelList = await fetchCohereModels(apiKey);
+    } else if (openaiCompatProviders[autoProvider]) {
+      const cfg = openaiCompatProviders[autoProvider];
+      modelList = await fetchOpenAICompatModels(cfg.baseUrl, apiKey, cfg.name);
+    } else {
+      console.error(`  --all is not supported for provider "${autoProvider}"`);
       process.exit(1);
     }
+  } catch (err) {
+    console.error(`  ${err.message}`);
+    process.exit(1);
   }
 
   if (filterPattern) {
@@ -1261,4 +1339,4 @@ if (require.main === module) {
   }
 }
 
-module.exports = { parseAnswer, callLLM, loadState, saveState, defaultStateFile, formatListTable, RateLimitBailError, fetchOllamaModels, fetchOpenRouterModels, fetchGitHubModels, fetchAnthropicModels, displayName };
+module.exports = { parseAnswer, callLLM, loadState, saveState, defaultStateFile, formatListTable, RateLimitBailError, fetchOllamaModels, fetchOpenRouterModels, fetchGitHubModels, fetchAnthropicModels, fetchOpenAICompatModels, fetchGeminiModels, fetchCohereModels, displayName };

--- a/test/all-flag.test.js
+++ b/test/all-flag.test.js
@@ -1,6 +1,6 @@
 const { describe, it } = require('node:test');
 const assert = require('node:assert');
-const { fetchOllamaModels, fetchOpenRouterModels, fetchGitHubModels, fetchAnthropicModels, displayName } = require('../cli/bin/abti.js');
+const { fetchOllamaModels, fetchOpenRouterModels, fetchGitHubModels, fetchAnthropicModels, fetchOpenAICompatModels, fetchGeminiModels, fetchCohereModels, displayName } = require('../cli/bin/abti.js');
 
 describe('--all flag', () => {
   describe('displayName', () => {
@@ -23,11 +23,8 @@ describe('--all flag', () => {
     });
 
     it('should reject when Ollama is not running', async () => {
-      // This test assumes Ollama is not running on the test machine at port 11434
-      // If it IS running, this test will pass differently but won't fail
       try {
         await fetchOllamaModels();
-        // If we get here, Ollama is running — that's fine, just verify shape
       } catch (err) {
         assert.ok(err.message.includes('Cannot connect to Ollama') || err.message.includes('Ollama API'),
           `Expected Ollama connection error, got: ${err.message}`);
@@ -43,7 +40,6 @@ describe('--all flag', () => {
     it('should reject with invalid API key', async () => {
       try {
         await fetchOpenRouterModels('invalid-key');
-        // If the API happens to accept it, just verify we got an array
       } catch (err) {
         assert.ok(err.message.includes('OpenRouter API') || err.message.includes('Cannot connect'),
           `Expected OpenRouter error, got: ${err.message}`);
@@ -62,6 +58,51 @@ describe('--all flag', () => {
       } catch (err) {
         assert.ok(err.message.includes('Anthropic API') || err.message.includes('Cannot connect'),
           `Expected Anthropic error, got: ${err.message}`);
+      }
+    });
+  });
+
+  describe('fetchOpenAICompatModels', () => {
+    it('should be a function', () => {
+      assert.strictEqual(typeof fetchOpenAICompatModels, 'function');
+    });
+
+    it('should reject with invalid API key', async () => {
+      try {
+        await fetchOpenAICompatModels('https://api.groq.com/openai/v1', 'invalid-key', 'Groq');
+      } catch (err) {
+        assert.ok(err.message.includes('Groq API') || err.message.includes('Cannot connect'),
+          `Expected Groq error, got: ${err.message}`);
+      }
+    });
+  });
+
+  describe('fetchGeminiModels', () => {
+    it('should be a function', () => {
+      assert.strictEqual(typeof fetchGeminiModels, 'function');
+    });
+
+    it('should reject with invalid API key', async () => {
+      try {
+        await fetchGeminiModels('invalid-key');
+      } catch (err) {
+        assert.ok(err.message.includes('Gemini API') || err.message.includes('Cannot connect'),
+          `Expected Gemini error, got: ${err.message}`);
+      }
+    });
+  });
+
+  describe('fetchCohereModels', () => {
+    it('should be a function', () => {
+      assert.strictEqual(typeof fetchCohereModels, 'function');
+    });
+
+    it('should reject with invalid API key', async () => {
+      try {
+        await fetchCohereModels('invalid-key');
+      } catch (err) {
+        assert.ok(err.message.includes('Cohere API') || err.message.includes('Cannot connect'),
+          `Expected Cohere error, got: ${err.message}`);
       }
     });
   });


### PR DESCRIPTION
Add `--all` flag support for groq, mistral, openai, deepseek, xai, gemini, and cohere providers.

## Changes
- **`fetchOpenAICompatModels()`** — shared helper for OpenAI-compatible APIs (groq, mistral, openai, deepseek, xai)
- **`fetchGeminiModels()`** — queries Google's generativelanguage API, filters to generateContent-capable models
- **`fetchCohereModels()`** — queries Cohere v2/models endpoint
- **`runAll()`** refactored from hardcoded provider whitelist to clean dispatch table supporting all 11 providers
- Help text and exports updated
- Tests added for all 3 new fetch functions (217 tests pass)

Fixes #397