### PR TITLE
feat: auto-generate agent OG images on test submission (fixes #403)

### DIFF
--- a/api-server.js
+++ b/api-server.js
@@ -2,6 +2,7 @@ const http = require('http');
 const fs = require('fs');
 const path = require('path');
 const crypto = require('crypto');
+const { generateAgentOG } = require('./lib/og-gen');
 
 // MCP HTTP transport
 const mcpModules = path.join(__dirname, 'mcp', 'node_modules', '@modelcontextprotocol', 'sdk', 'dist', 'cjs');
@@ -247,6 +248,15 @@ function registerAgent(entry) {
     agentData.agents.push(entry);
   }
   saveData(agentData);
+  if (entry.slug && entry.scores) {
+    setImmediate(() => {
+      try {
+        generateAgentOG(entry, path.join(__dirname, 'og', 'agents'));
+      } catch (e) {
+        console.error(`OG generation failed for ${entry.slug}:`, e.message);
+      }
+    });
+  }
 }
 
 // ─── MCP HTTP handler ─────────────────────────────────────────────────────
@@ -441,6 +451,14 @@ const server = http.createServer((req, res) => {
           } else {
             agentData.agents.push(entry);
           }
+          // Async OG image generation (non-blocking)
+          setImmediate(() => {
+            try {
+              generateAgentOG(entry, path.join(__dirname, 'og', 'agents'));
+            } catch (e) {
+              console.error(`OG generation failed for ${entry.slug}:`, e.message);
+            }
+          });
         }
         saveData(agentData);
 

--- a/lib/og-gen.js
+++ b/lib/og-gen.js
@@ -1,0 +1,82 @@
+// Shared module for generating per-agent OG PNG images (1200x630).
+const { Resvg } = require('@resvg/resvg-js');
+const fs = require('fs');
+const path = require('path');
+
+const dimNames = ['Autonomy', 'Precision', 'Transparency', 'Adaptability'];
+const dimLabels = [['Proactive','Responsive'],['Thorough','Efficient'],['Candid','Diplomatic'],['Flexible','Principled']];
+const DL = [['P','R'],['T','E'],['C','D'],['F','N']];
+
+function escapeXml(s) {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+}
+
+function buildAgentSVG(agent) {
+  const { name, type, nick, scores } = agent;
+  const safeName = escapeXml(name);
+  const safeNick = escapeXml(nick || type);
+
+  // Truncate long names by reducing font size
+  let nameFontSize = 52;
+  if (safeName.length > 30) nameFontSize = 38;
+  else if (safeName.length > 20) nameFontSize = 44;
+
+  // Build dimension bars
+  const dimBars = scores.map((score, i) => {
+    const letter = type[i];
+    const poleIdx = DL[i].indexOf(letter);
+    const pole = dimLabels[i][poleIdx];
+    const dim = dimNames[i];
+    const pct = (score / 4) * 100;
+    const barWidth = 180;
+    const fillWidth = Math.round((score / 4) * barWidth);
+    const y = 380 + i * 56;
+
+    return `  <g transform="translate(160, ${y})">
+    <text x="0" y="14" font-family="system-ui,-apple-system,sans-serif" font-size="13" font-weight="500" fill="#8a8aad">${dim}</text>
+    <text x="880" y="14" text-anchor="end" font-family="system-ui,-apple-system,sans-serif" font-size="13" font-weight="500" fill="#ededed">${pole}</text>
+    <text x="880" y="14" font-family="system-ui,-apple-system,sans-serif" font-size="13" font-weight="700" fill="#ff6b9d" text-anchor="end" dx="50">${letter}</text>
+    <text x="880" y="14" font-family="system-ui,-apple-system,sans-serif" font-size="13" font-weight="400" fill="#8a8aad" text-anchor="end" dx="90">${score}/4</text>
+    <rect x="0" y="24" width="${barWidth * 5}" height="10" rx="5" fill="#1e1e38"/>
+    <rect x="0" y="24" width="${fillWidth * 5}" height="10" rx="5" fill="url(#accent)"/>
+  </g>`;
+  }).join('\n');
+
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0a0a0f"/>
+      <stop offset="100%" stop-color="#12121f"/>
+    </linearGradient>
+    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#ff6b9d"/>
+      <stop offset="100%" stop-color="#c084fc"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <rect x="60" y="60" width="1080" height="510" rx="24" fill="#17172e" stroke="#2a2a4a" stroke-width="1"/>
+  <text x="600" y="130" text-anchor="middle" font-family="system-ui,-apple-system,sans-serif" font-size="22" font-weight="500" fill="#8a8aad" letter-spacing="4">ABTI \u2014 Agent Behavioral Type Indicator</text>
+  <line x1="200" y1="160" x2="1000" y2="160" stroke="#2a2a4a" stroke-width="1"/>
+  <text x="600" y="230" text-anchor="middle" font-family="system-ui,-apple-system,sans-serif" font-size="${nameFontSize}" font-weight="700" fill="#ededed">${safeName}</text>
+  <text x="600" y="295" text-anchor="middle" font-family="system-ui,-apple-system,sans-serif" font-size="64" font-weight="700" fill="url(#accent)" letter-spacing="12">${type}</text>
+  <text x="600" y="340" text-anchor="middle" font-family="system-ui,-apple-system,sans-serif" font-size="24" font-weight="400" fill="#8a8aad">${safeNick}</text>
+  <line x1="200" y1="365" x2="1000" y2="365" stroke="#2a2a4a" stroke-width="1"/>
+${dimBars}
+</svg>`;
+}
+
+/**
+ * Generate an OG PNG image for a single agent.
+ * @param {object} agent - Agent object with name, type, nick, scores, slug
+ * @param {string} outputDir - Directory to write PNG files into
+ */
+function generateAgentOG(agent, outputDir) {
+  if (!agent.slug) return;
+  fs.mkdirSync(outputDir, { recursive: true });
+  const svg = buildAgentSVG(agent);
+  const resvg = new Resvg(svg, { fitTo: { mode: 'width', value: 1200 } });
+  const png = resvg.render().asPng();
+  fs.writeFileSync(path.join(outputDir, `${agent.slug}.png`), png);
+}
+
+module.exports = { buildAgentSVG, generateAgentOG };

--- a/scripts/generate-agent-og.js
+++ b/scripts/generate-agent-og.js
@@ -2,89 +2,21 @@
 // Generate per-agent OG PNG images (1200x630) for social sharing.
 // Reads data/results.json, outputs to og/agents/<slug>.png.
 
-const { Resvg } = require('@resvg/resvg-js');
 const fs = require('fs');
 const path = require('path');
-
-const dimNames = ['Autonomy', 'Precision', 'Transparency', 'Adaptability'];
-const dimLabels = [['Proactive','Responsive'],['Thorough','Efficient'],['Candid','Diplomatic'],['Flexible','Principled']];
-const DL = [['P','R'],['T','E'],['C','D'],['F','N']];
-
-function escapeXml(s) {
-  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
-}
-
-function buildAgentSVG(agent) {
-  const { name, type, nick, scores } = agent;
-  const safeName = escapeXml(name);
-  const safeNick = escapeXml(nick || type);
-
-  // Truncate long names by reducing font size
-  let nameFontSize = 52;
-  if (safeName.length > 30) nameFontSize = 38;
-  else if (safeName.length > 20) nameFontSize = 44;
-
-  // Build dimension bars
-  const dimBars = scores.map((score, i) => {
-    const letter = type[i];
-    const poleIdx = DL[i].indexOf(letter);
-    const pole = dimLabels[i][poleIdx];
-    const dim = dimNames[i];
-    const pct = (score / 4) * 100;
-    const barWidth = 180;
-    const fillWidth = Math.round((score / 4) * barWidth);
-    const y = 380 + i * 56;
-
-    return `  <g transform="translate(160, ${y})">
-    <text x="0" y="14" font-family="system-ui,-apple-system,sans-serif" font-size="13" font-weight="500" fill="#8a8aad">${dim}</text>
-    <text x="880" y="14" text-anchor="end" font-family="system-ui,-apple-system,sans-serif" font-size="13" font-weight="500" fill="#ededed">${pole}</text>
-    <text x="880" y="14" font-family="system-ui,-apple-system,sans-serif" font-size="13" font-weight="700" fill="#ff6b9d" text-anchor="end" dx="50">${letter}</text>
-    <text x="880" y="14" font-family="system-ui,-apple-system,sans-serif" font-size="13" font-weight="400" fill="#8a8aad" text-anchor="end" dx="90">${score}/4</text>
-    <rect x="0" y="24" width="${barWidth * 5}" height="10" rx="5" fill="#1e1e38"/>
-    <rect x="0" y="24" width="${fillWidth * 5}" height="10" rx="5" fill="url(#accent)"/>
-  </g>`;
-  }).join('\n');
-
-  return `<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
-  <defs>
-    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#0a0a0f"/>
-      <stop offset="100%" stop-color="#12121f"/>
-    </linearGradient>
-    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="0">
-      <stop offset="0%" stop-color="#ff6b9d"/>
-      <stop offset="100%" stop-color="#c084fc"/>
-    </linearGradient>
-  </defs>
-  <rect width="1200" height="630" fill="url(#bg)"/>
-  <rect x="60" y="60" width="1080" height="510" rx="24" fill="#17172e" stroke="#2a2a4a" stroke-width="1"/>
-  <text x="600" y="130" text-anchor="middle" font-family="system-ui,-apple-system,sans-serif" font-size="22" font-weight="500" fill="#8a8aad" letter-spacing="4">ABTI \u2014 Agent Behavioral Type Indicator</text>
-  <line x1="200" y1="160" x2="1000" y2="160" stroke="#2a2a4a" stroke-width="1"/>
-  <text x="600" y="230" text-anchor="middle" font-family="system-ui,-apple-system,sans-serif" font-size="${nameFontSize}" font-weight="700" fill="#ededed">${safeName}</text>
-  <text x="600" y="295" text-anchor="middle" font-family="system-ui,-apple-system,sans-serif" font-size="64" font-weight="700" fill="url(#accent)" letter-spacing="12">${type}</text>
-  <text x="600" y="340" text-anchor="middle" font-family="system-ui,-apple-system,sans-serif" font-size="24" font-weight="400" fill="#8a8aad">${safeNick}</text>
-  <line x1="200" y1="365" x2="1000" y2="365" stroke="#2a2a4a" stroke-width="1"/>
-${dimBars}
-</svg>`;
-}
+const { generateAgentOG } = require('../lib/og-gen');
 
 const resultsPath = path.join(__dirname, '..', 'data', 'results.json');
 const results = JSON.parse(fs.readFileSync(resultsPath, 'utf8'));
 const agents = results.agents;
 
 const outDir = path.join(__dirname, '..', 'og', 'agents');
-fs.mkdirSync(outDir, { recursive: true });
 
 let count = 0;
 for (const agent of agents) {
-  const slug = agent.slug;
-  if (!slug) continue;
-  const svg = buildAgentSVG(agent);
-  const resvg = new Resvg(svg, { fitTo: { mode: 'width', value: 1200 } });
-  const png = resvg.render().asPng();
-  const outPath = path.join(outDir, `${slug}.png`);
-  fs.writeFileSync(outPath, png);
-  console.log(`Generated ${outPath}`);
+  if (!agent.slug) continue;
+  generateAgentOG(agent, outDir);
+  console.log(`Generated og/agents/${agent.slug}.png`);
   count++;
 }
 

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -813,11 +813,11 @@ describe('GET /agent/:slug', () => {
     assert.equal(r.headers.location, '/agents.html');
   });
 
-  it('includes OG image pointing to type OG', async () => {
+  it('includes OG image pointing to agent OG', async () => {
     rateLimitMap.clear();
     await req('/api/agent-test', { method: 'POST', body: { answers: Array(16).fill(1), agentName: 'OGBot' } });
     const r = await req('/agent/ogbot');
-    assert.match(r.body, /og:image.*og\/PTCF/);
+    assert.match(r.body, /og:image.*og\/agents\/ogbot\.png/);
   });
 });
 


### PR DESCRIPTION
## Summary

Auto-generate per-agent OG PNG images when new test results are submitted via the API, eliminating the need for manual `npm run generate-og-agents` runs.

## Changes

- **`lib/og-gen.js`** (new): Extracted `buildAgentSVG()` and `generateAgentOG()` into a shared module
- **`api-server.js`**: Call `generateAgentOG()` via `setImmediate()` after saving results in both ABTI and SBTI POST handlers
- **`scripts/generate-agent-og.js`**: Simplified to import from `lib/og-gen.js` instead of duplicating the SVG template
- **`test/api.test.js`**: Updated tests to cover OG generation

## Behavior

- Every newly tested agent immediately gets `og/agents/<slug>.png`
- Generation is async (non-blocking) — errors are logged but never crash the response
- `og/agents/` directory is auto-created if missing
- Existing manual script (`npm run generate-og-agents`) still works for bulk regeneration

## Tests

```
# tests 224, # pass 224, # fail 0
```

Closes #403