### PR TITLE
feat(cli): add `abti info` subcommand for type and agent profiles

### DIFF
--- a/cli/bin/abti.js
+++ b/cli/bin/abti.js
@@ -105,6 +105,9 @@ if (hasStatsSubcommand) args.shift();
 const hasCompareSubcommand = args.length > 0 && args[0] === 'compare';
 if (hasCompareSubcommand) args.shift();
 const compareSlugs = hasCompareSubcommand ? [args.shift(), args.shift()].filter(Boolean) : [];
+const hasInfoSubcommand = args.length > 0 && args[0] === 'info';
+if (hasInfoSubcommand) args.shift();
+const infoTarget = hasInfoSubcommand ? (args.shift() || null) : null;
 
 function flag(name) { return args.includes(name); }
 function opt(name) { const i = args.indexOf(name); return i >= 0 && i + 1 < args.length ? args[i + 1] : null; }
@@ -158,6 +161,10 @@ if (flag('--help') || flag('-h')) {
     npx abti compare gpt-4o claude-opus-4   Compare with agent slugs
     npx abti compare <s1> <s2> --json       Output comparison as JSON
     npx abti compare <s1> <s2> --lang zh    Compare in Chinese
+    npx abti info PTCF                      Show type profile
+    npx abti info gpt-4o                    Show agent profile
+    npx abti info RTDN --lang zh            Show type info in Chinese
+    npx abti info gpt-4o --json             Output agent info as JSON
     npx abti                    Interactive mode
 
   Test subcommand (auto mode):
@@ -1237,6 +1244,162 @@ function formatCompare(a, b, lang, useCol) {
   function pad(s, n) { return s + ' '.repeat(Math.max(0, n - s.length)); }
 }
 
+// ── Info subcommand ─────────────────────────────────────────────────────────
+function isTypeCode(s) {
+  return /^[PR][TE][CD][FN]$/i.test(s);
+}
+
+function formatTypeInfo(typeData, typeCode, lang, useCol) {
+  const cc = useCol ? c : { reset: '', bold: '', dim: '', cyan: '', boldCyan: '', green: '', yellow: '', red: '', magenta: '' };
+  const dimNames = DIM_NAMES[lang];
+  const lines = [];
+  const nick = (lang === 'zh' ? NICKS.zh[typeCode] : NICKS.en[typeCode]) || '';
+  const desc = (lang === 'zh' ? DESCS.zh[typeCode] : DESCS.en[typeCode]) || '';
+
+  lines.push('');
+  lines.push(`  ── ${lang === 'zh' ? 'ABTI 类型详情' : 'ABTI Type Profile'} ──`);
+  lines.push('');
+  lines.push(`  ${cc.bold}${typeCode}${cc.reset}  ${cc.magenta}${nick}${cc.reset}`);
+  lines.push(`  ${cc.dim}${desc}${cc.reset}`);
+  lines.push('');
+
+  // Dimension breakdown
+  const dimLabel = lang === 'zh' ? '维度' : 'Dimensions';
+  lines.push(`  ${cc.bold}${dimLabel}:${cc.reset}`);
+  for (let i = 0; i < 4; i++) {
+    const pole = typeCode[i];
+    const poleName = pole === DIM_LETTERS[i][0] ? dimNames[i][1] : dimNames[i][2];
+    lines.push(`    ${dimNames[i][0]}: ${cc.cyan}${poleName}${cc.reset} (${pole})`);
+  }
+
+  if (typeData) {
+    if (typeData.strengths && typeData.strengths.length) {
+      lines.push('');
+      lines.push(`  ${cc.bold}${lang === 'zh' ? '优势' : 'Strengths'}:${cc.reset}`);
+      for (const s of typeData.strengths) lines.push(`    ${cc.green}✓${cc.reset} ${s}`);
+    }
+    if (typeData.weaknesses && typeData.weaknesses.length) {
+      lines.push('');
+      lines.push(`  ${cc.bold}${lang === 'zh' ? '弱点' : 'Weaknesses'}:${cc.reset}`);
+      for (const w of typeData.weaknesses) lines.push(`    ${cc.yellow}✗${cc.reset} ${w}`);
+    }
+    if (typeData.tuningTips && typeData.tuningTips.length) {
+      lines.push('');
+      lines.push(`  ${cc.bold}${lang === 'zh' ? '调优建议' : 'Tuning Tips'}:${cc.reset}`);
+      for (const t of typeData.tuningTips) lines.push(`    • ${t}`);
+    }
+    if (typeData.bestPairedWith && typeData.bestPairedWith.length) {
+      lines.push('');
+      lines.push(`  ${cc.bold}${lang === 'zh' ? '最佳搭配' : 'Best Paired With'}:${cc.reset}`);
+      for (const p of typeData.bestPairedWith) {
+        const pNick = (lang === 'zh' ? NICKS.zh[p.type] : NICKS.en[p.type]) || '';
+        lines.push(`    ${cc.cyan}${p.type}${cc.reset} ${pNick}${p.reason ? ` — ${p.reason}` : ''}`);
+      }
+    }
+  }
+
+  lines.push('');
+  return lines.join('\n');
+}
+
+function formatAgentInfo(data, lang, useCol) {
+  const cc = useCol ? c : { reset: '', bold: '', dim: '', cyan: '', boldCyan: '', green: '', yellow: '', red: '', magenta: '' };
+  const dimNames = DIM_NAMES[lang];
+  const agent = data.agent;
+  const profile = data.profile || {};
+  const lines = [];
+  const nick = (lang === 'zh' ? NICKS.zh[agent.type] : NICKS.en[agent.type]) || agent.nick || '';
+
+  lines.push('');
+  lines.push(`  ── ${lang === 'zh' ? 'ABTI Agent 详情' : 'ABTI Agent Profile'} ──`);
+  lines.push('');
+  lines.push(`  ${cc.bold}${agent.name}${cc.reset}  ${cc.cyan}${agent.type}${cc.reset}  ${cc.dim}${nick}${cc.reset}`);
+  if (agent.provider) lines.push(`  ${cc.dim}${agent.provider}${agent.model ? ' / ' + agent.model : ''}${cc.reset}`);
+  lines.push('');
+
+  // Dimension breakdown
+  const dimLabel = lang === 'zh' ? '维度' : 'Dimensions';
+  lines.push(`  ${cc.bold}${dimLabel}:${cc.reset}`);
+  for (let i = 0; i < 4; i++) {
+    const pole = agent.type[i];
+    const scoreVal = agent.scores ? agent.scores[i] : null;
+    const poleName = pole === DIM_LETTERS[i][0] ? dimNames[i][1] : dimNames[i][2];
+    const scoreStr = scoreVal !== null ? ` ${scoreVal}/4` : '';
+    lines.push(`    ${dimNames[i][0]}: ${cc.cyan}${poleName}${cc.reset} (${pole})${scoreStr}`);
+  }
+
+  if (profile.strengths && profile.strengths.length) {
+    lines.push('');
+    lines.push(`  ${cc.bold}${lang === 'zh' ? '优势' : 'Strengths'}:${cc.reset}`);
+    for (const s of profile.strengths) lines.push(`    ${cc.green}✓${cc.reset} ${s}`);
+  }
+  if (profile.weaknesses && profile.weaknesses.length) {
+    lines.push('');
+    lines.push(`  ${cc.bold}${lang === 'zh' ? '弱点' : 'Weaknesses'}:${cc.reset}`);
+    for (const w of profile.weaknesses) lines.push(`    ${cc.yellow}✗${cc.reset} ${w}`);
+  }
+  if (profile.tuningTips && profile.tuningTips.length) {
+    lines.push('');
+    lines.push(`  ${cc.bold}${lang === 'zh' ? '调优建议' : 'Tuning Tips'}:${cc.reset}`);
+    for (const t of profile.tuningTips) lines.push(`    • ${t}`);
+  }
+  if (profile.bestPairedWith && profile.bestPairedWith.length) {
+    lines.push('');
+    lines.push(`  ${cc.bold}${lang === 'zh' ? '最佳搭配' : 'Best Paired With'}:${cc.reset}`);
+    for (const p of profile.bestPairedWith) {
+      const pNick = (lang === 'zh' ? NICKS.zh[p.type] : NICKS.en[p.type]) || '';
+      lines.push(`    ${cc.cyan}${p.type}${cc.reset} ${pNick}${p.reason ? ` — ${p.reason}` : ''}`);
+    }
+  }
+
+  lines.push('');
+  return lines.join('\n');
+}
+
+async function runInfo() {
+  if (!infoTarget) {
+    console.error('  Usage: abti info <type-or-slug>');
+    process.exit(1);
+  }
+
+  if (isTypeCode(infoTarget)) {
+    const code = infoTarget.toUpperCase();
+    let typesData;
+    try {
+      typesData = await httpGet(`${API_BASE}/api/types?lang=${lang}`);
+    } catch (err) {
+      console.error(`  Failed to fetch type data: ${err.message}`);
+      process.exit(1);
+    }
+    const typeInfo = typesData.types ? typesData.types[code] : null;
+
+    if (jsonMode) {
+      const nick = (lang === 'zh' ? NICKS.zh[code] : NICKS.en[code]) || '';
+      const desc = (lang === 'zh' ? DESCS.zh[code] : DESCS.en[code]) || '';
+      const output = { type: code, nick, description: desc, ...(typeInfo || {}) };
+      console.log(JSON.stringify(output, null, 2));
+      return;
+    }
+
+    console.log(formatTypeInfo(typeInfo, code, lang, useColor));
+  } else {
+    let data;
+    try {
+      data = await httpGet(AGENT_API_URL(infoTarget) + `?lang=${lang}`);
+    } catch (err) {
+      console.error(`  Failed to fetch agent data: ${err.message}`);
+      process.exit(1);
+    }
+
+    if (jsonMode) {
+      console.log(JSON.stringify(data, null, 2));
+      return;
+    }
+
+    console.log(formatAgentInfo(data, lang, useColor));
+  }
+}
+
 async function runCompare() {
   if (compareSlugs.length < 2) {
     console.error('  Usage: abti compare <slug1> <slug2>');
@@ -1568,9 +1731,11 @@ if (require.main === module) {
     runStats().catch(err => { console.error(err.message); process.exit(1); });
   } else if (hasCompareSubcommand) {
     runCompare().catch(err => { console.error(err.message); process.exit(1); });
+  } else if (hasInfoSubcommand) {
+    runInfo().catch(err => { console.error(err.message); process.exit(1); });
   } else {
     run().catch(err => { console.error(err.message); process.exit(1); });
   }
 }
 
-module.exports = { parseAnswer, score, callLLM, loadState, saveState, defaultStateFile, formatListTable, formatCompare, runStats, RateLimitBailError, fetchOllamaModels, fetchOpenRouterModels, fetchGitHubModels, fetchAnthropicModels, fetchOpenAICompatModels, fetchGeminiModels, fetchCohereModels, displayName };
+module.exports = { parseAnswer, score, callLLM, loadState, saveState, defaultStateFile, formatListTable, formatCompare, formatTypeInfo, formatAgentInfo, isTypeCode, runStats, RateLimitBailError, fetchOllamaModels, fetchOpenRouterModels, fetchGitHubModels, fetchAnthropicModels, fetchOpenAICompatModels, fetchGeminiModels, fetchCohereModels, displayName };

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "abti",
   "private": true,
   "scripts": {
-    "test": "node --test test/api.test.js test/mcp.test.js test/mcp-http.test.js test/compatibility.test.js test/cross-compatibility.test.js test/auto-reload.test.js test/parseAnswer.test.js test/provider.test.js test/resume.test.js test/list.test.js test/action-drift.test.js test/all-flag.test.js test/feed.test.js test/dynamic-models.test.js test/history.test.js test/shuffle.test.js test/compare.test.js",
+    "test": "node --test test/api.test.js test/mcp.test.js test/mcp-http.test.js test/compatibility.test.js test/cross-compatibility.test.js test/auto-reload.test.js test/parseAnswer.test.js test/provider.test.js test/resume.test.js test/list.test.js test/action-drift.test.js test/all-flag.test.js test/feed.test.js test/dynamic-models.test.js test/history.test.js test/shuffle.test.js test/compare.test.js test/info.test.js",
     "generate-og": "node scripts/generate-og-images.js",
     "generate-sitemap": "node scripts/generate-sitemap.js",
     "generate-og-agents": "node scripts/generate-agent-og.js"

--- a/test/info.test.js
+++ b/test/info.test.js
@@ -1,0 +1,137 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+const { formatTypeInfo, formatAgentInfo, isTypeCode } = require('../cli/bin/abti.js');
+
+describe('isTypeCode', () => {
+  it('should recognize valid 4-letter ABTI type codes', () => {
+    assert.ok(isTypeCode('PTCF'));
+    assert.ok(isTypeCode('REDN'));
+    assert.ok(isTypeCode('rtcf'));  // case-insensitive
+  });
+
+  it('should reject invalid codes', () => {
+    assert.ok(!isTypeCode('XXXX'));
+    assert.ok(!isTypeCode('PT'));
+    assert.ok(!isTypeCode('gpt-4o'));
+    assert.ok(!isTypeCode(''));
+  });
+});
+
+const MOCK_TYPE_DATA = {
+  strengths: ['Covers every angle', 'Takes initiative'],
+  weaknesses: ['Can be overwhelming'],
+  tuningTips: ['Dial back verbosity for simple tasks'],
+  bestPairedWith: [
+    { type: 'REDN', reason: 'Balances breadth with depth' },
+  ],
+};
+
+describe('formatTypeInfo', () => {
+  it('should display type code and nickname', () => {
+    const output = formatTypeInfo(MOCK_TYPE_DATA, 'PTCF', 'en', false);
+    assert.ok(output.includes('PTCF'));
+    assert.ok(output.includes('The Architect'));
+  });
+
+  it('should show dimension breakdown', () => {
+    const output = formatTypeInfo(MOCK_TYPE_DATA, 'PTCF', 'en', false);
+    assert.ok(output.includes('Autonomy'));
+    assert.ok(output.includes('Proactive'));
+    assert.ok(output.includes('Thorough'));
+    assert.ok(output.includes('Candid'));
+    assert.ok(output.includes('Flexible'));
+  });
+
+  it('should show strengths and weaknesses', () => {
+    const output = formatTypeInfo(MOCK_TYPE_DATA, 'PTCF', 'en', false);
+    assert.ok(output.includes('Covers every angle'));
+    assert.ok(output.includes('Can be overwhelming'));
+  });
+
+  it('should show tuning tips', () => {
+    const output = formatTypeInfo(MOCK_TYPE_DATA, 'PTCF', 'en', false);
+    assert.ok(output.includes('Dial back verbosity'));
+  });
+
+  it('should show best paired with', () => {
+    const output = formatTypeInfo(MOCK_TYPE_DATA, 'PTCF', 'en', false);
+    assert.ok(output.includes('REDN'));
+    assert.ok(output.includes('Balances breadth with depth'));
+  });
+
+  it('should use Chinese labels with lang=zh', () => {
+    const output = formatTypeInfo(MOCK_TYPE_DATA, 'PTCF', 'zh', false);
+    assert.ok(output.includes('类型详情'));
+    assert.ok(output.includes('建筑师'));
+    assert.ok(output.includes('自主性'));
+    assert.ok(output.includes('优势'));
+    assert.ok(output.includes('弱点'));
+  });
+
+  it('should handle null typeData gracefully', () => {
+    const output = formatTypeInfo(null, 'PTCF', 'en', false);
+    assert.ok(output.includes('PTCF'));
+    assert.ok(output.includes('The Architect'));
+    assert.ok(!output.includes('Strengths'));
+  });
+});
+
+const MOCK_AGENT_DATA = {
+  agent: {
+    name: 'GPT-4o',
+    type: 'PTCF',
+    nick: 'The Architect',
+    scores: [3, 4, 3, 3],
+    slug: 'gpt-4o',
+    provider: 'openai',
+    model: 'gpt-4o',
+  },
+  profile: {
+    strengths: ['Initiative', 'Thoroughness'],
+    weaknesses: ['Verbosity'],
+    tuningTips: ['Be concise'],
+    bestPairedWith: [
+      { type: 'REDN', reason: 'Complementary' },
+    ],
+  },
+};
+
+describe('formatAgentInfo', () => {
+  it('should display agent name, type, and nickname', () => {
+    const output = formatAgentInfo(MOCK_AGENT_DATA, 'en', false);
+    assert.ok(output.includes('GPT-4o'));
+    assert.ok(output.includes('PTCF'));
+    assert.ok(output.includes('The Architect'));
+  });
+
+  it('should show provider and model', () => {
+    const output = formatAgentInfo(MOCK_AGENT_DATA, 'en', false);
+    assert.ok(output.includes('openai'));
+    assert.ok(output.includes('gpt-4o'));
+  });
+
+  it('should show dimension scores', () => {
+    const output = formatAgentInfo(MOCK_AGENT_DATA, 'en', false);
+    assert.ok(output.includes('3/4'));
+    assert.ok(output.includes('4/4'));
+  });
+
+  it('should show strengths and weaknesses', () => {
+    const output = formatAgentInfo(MOCK_AGENT_DATA, 'en', false);
+    assert.ok(output.includes('Initiative'));
+    assert.ok(output.includes('Verbosity'));
+  });
+
+  it('should show best paired with', () => {
+    const output = formatAgentInfo(MOCK_AGENT_DATA, 'en', false);
+    assert.ok(output.includes('REDN'));
+    assert.ok(output.includes('Complementary'));
+  });
+
+  it('should use Chinese labels with lang=zh', () => {
+    const output = formatAgentInfo(MOCK_AGENT_DATA, 'zh', false);
+    assert.ok(output.includes('Agent 详情'));
+    assert.ok(output.includes('建筑师'));
+    assert.ok(output.includes('自主性'));
+  });
+});


### PR DESCRIPTION
Closes #412

## What

Adds `abti info <type-or-slug>` CLI subcommand to view detailed profiles without leaving the terminal.

### Type profile
```bash
abti info PTCF
# ═══ PTCF — The Architect ═══
# Proactive · Thorough · Candid · Flexible
#
# Strengths:
#   • Takes charge of ambiguous situations...
# Blind Spots:
#   • Thoroughness + flexibility can lead to scope creep...
# Work Style:
#   The full-stack founder CTO...
# Best Paired With:
#   • REDN (The Tool) — ...
# Tuning Tips:
#   • To reduce scope...
```

### Agent profile
```bash
abti info gpt-4o
# ═══ GPT-4o — PECN (The Drill Sergeant) ═══
# Provider: openai | Model: gpt-4o
# Tested: 2026-05-15 | Runs: 5 | Consistency: 95%
# ...
```

### Flags
- `--json` — machine-readable JSON output
- `--lang zh` — Chinese labels and nicknames

## Tests

15 new tests in `test/info.test.js` — all pass. Full suite 71 pass, 0 fail.