### PR TITLE
fix: pass prov parameter to runSinglePass (#414)

### DIFF
--- a/cli/bin/abti.js
+++ b/cli/bin/abti.js
@@ -952,7 +952,7 @@ async function runSingleModel(modelName) {
     const allRuns = [];
     let totalParseFailures = 0;
     for (let r = 0; r < runsN; r++) {
-      const { answers, parseFailures } = await runSinglePass(modelName, apiKey, systemPrompt, questions);
+      const { answers, parseFailures } = await runSinglePass(prov, modelName, apiKey, systemPrompt, questions);
       totalParseFailures += parseFailures;
       const result = score(answers);
       allRuns.push({ answers, code: result.code, scores: result.scores });
@@ -970,11 +970,11 @@ async function runSingleModel(modelName) {
     };
   }
 
-  const { answers, parseFailures } = await runSinglePass(modelName, apiKey, systemPrompt, questions);
+  const { answers, parseFailures } = await runSinglePass(prov, modelName, apiKey, systemPrompt, questions);
   return { answers, _answers: answers, parseFailures };
 }
 
-async function runSinglePass(modelName, apiKey, systemPrompt, questions) {
+async function runSinglePass(prov, modelName, apiKey, systemPrompt, questions) {
   const answers = [];
   let parseFailures = 0;
 


### PR DESCRIPTION
## Summary

Fixes #414 — `--all` flag crashes with `prov is not defined` for all providers.

## Root Cause

`runSinglePass()` uses `prov` variable in the `callLLM()` call, but `prov` is only defined as a local const inside `runSingleModel()`. It was never passed to `runSinglePass()`.

## Fix

- Add `prov` as the first parameter to `runSinglePass()`
- Update both call sites in `runSingleModel()` to pass `prov`

## Testing

All 252 tests pass.