### PR TITLE
feat(cli): add `abti history` subcommand for agent personality drift timeline (fixes #416)

### DIFF
--- a/cli/bin/abti.js
+++ b/cli/bin/abti.js
@@ -108,6 +108,9 @@ const compareSlugs = hasCompareSubcommand ? [args.shift(), args.shift()].filter(
 const hasInfoSubcommand = args.length > 0 && args[0] === 'info';
 if (hasInfoSubcommand) args.shift();
 const infoTarget = hasInfoSubcommand ? (args.shift() || null) : null;
+const hasHistorySubcommand = args.length > 0 && args[0] === 'history';
+if (hasHistorySubcommand) args.shift();
+const historySlug = hasHistorySubcommand ? (args.shift() || null) : null;
 
 function flag(name) { return args.includes(name); }
 function opt(name) { const i = args.indexOf(name); return i >= 0 && i + 1 < args.length ? args[i + 1] : null; }
@@ -165,6 +168,9 @@ if (flag('--help') || flag('-h')) {
     npx abti info gpt-4o                    Show agent profile
     npx abti info RTDN --lang zh            Show type info in Chinese
     npx abti info gpt-4o --json             Output agent info as JSON
+    npx abti history gpt-4o                 Show agent personality drift timeline
+    npx abti history gpt-4o --json          Output history as JSON
+    npx abti history gpt-4o --lang zh       Show history in Chinese
     npx abti                    Interactive mode
 
   Test subcommand (auto mode):
@@ -1400,6 +1406,92 @@ async function runInfo() {
   }
 }
 
+function formatHistoryTable(data, lang, useCol) {
+  const cc = useCol ? c : { reset: '', bold: '', dim: '', cyan: '', boldCyan: '', green: '', yellow: '', red: '', magenta: '' };
+  const dimNames = DIM_NAMES[lang];
+  const agent = data.agent;
+  const history = agent.history || [];
+  const nick = (lang === 'zh' ? NICKS.zh[agent.type] : NICKS.en[agent.type]) || agent.nick || '';
+  const lines = [];
+
+  lines.push('');
+  lines.push(`  ── ${lang === 'zh' ? 'ABTI 人格变迁时间线' : 'ABTI Personality Drift Timeline'} ──`);
+  lines.push('');
+  lines.push(`  ${cc.bold}${agent.name}${cc.reset}  ${lang === 'zh' ? '当前类型' : 'Current'}: ${cc.cyan}${agent.type}${cc.reset}  ${cc.dim}${nick}${cc.reset}`);
+  lines.push('');
+
+  // Header
+  const dateH = lang === 'zh' ? '日期' : 'Date';
+  const typeH = lang === 'zh' ? '类型' : 'Type';
+  const nickH = lang === 'zh' ? '昵称' : 'Nickname';
+  const dimH = dimNames.map(d => d[0]);
+  const header = `  ${dateH.padEnd(12)} ${typeH.padEnd(6)} ${nickH.padEnd(20)} ${dimH.map(d => d.padEnd(6)).join(' ')}`;
+  lines.push(`  ${cc.bold}${header.trim()}${cc.reset}`);
+  lines.push(`  ${'─'.repeat(header.trim().length)}`);
+
+  for (const h of history) {
+    const date = h.testedAt ? h.testedAt.slice(0, 10) : '—';
+    const hNick = (lang === 'zh' ? NICKS.zh[h.type] : NICKS.en[h.type]) || '';
+    const scores = h.scores ? h.scores.map(s => String(s).padEnd(6)).join(' ') : '';
+    lines.push(`  ${date.padEnd(12)} ${cc.cyan}${h.type}${cc.reset}${''.padEnd(6 - h.type.length)} ${cc.dim}${hNick}${cc.reset}${''.padEnd(Math.max(0, 20 - hNick.length))} ${scores}`);
+  }
+
+  // Current as last row
+  const curDate = agent.testedAt ? agent.testedAt.slice(0, 10) : '—';
+  const curScores = agent.scores ? agent.scores.map(s => String(s).padEnd(6)).join(' ') : '';
+  lines.push(`  ${curDate.padEnd(12)} ${cc.bold}${cc.cyan}${agent.type}${cc.reset}${''.padEnd(6 - agent.type.length)} ${cc.bold}${nick}${cc.reset}${''.padEnd(Math.max(0, 20 - nick.length))} ${curScores}  ${cc.green}← ${lang === 'zh' ? '当前' : 'current'}${cc.reset}`);
+
+  // Drift summary
+  const allTypes = [...history.map(h => h.type), agent.type];
+  let changes = 0;
+  for (let i = 1; i < allTypes.length; i++) {
+    if (allTypes[i] !== allTypes[i - 1]) changes++;
+  }
+  lines.push('');
+  if (lang === 'zh') {
+    lines.push(`  ${cc.bold}变迁摘要:${cc.reset} ${allTypes.length} 次测试, ${changes} 次类型变化`);
+  } else {
+    lines.push(`  ${cc.bold}Drift summary:${cc.reset} ${allTypes.length} test(s), ${changes} type change(s)`);
+  }
+  lines.push('');
+
+  return lines.join('\n');
+}
+
+async function runHistory() {
+  if (!historySlug) {
+    console.error('  Usage: abti history <slug>');
+    process.exit(1);
+  }
+
+  let data;
+  try {
+    data = await httpGet(AGENT_API_URL(historySlug) + `?lang=${lang}`);
+  } catch (err) {
+    console.error(`  Failed to fetch agent data: ${err.message}`);
+    process.exit(1);
+  }
+
+  if (jsonMode) {
+    const agent = data.agent;
+    const history = agent.history || [];
+    const allTypes = [...history.map(h => h.type), agent.type];
+    let changes = 0;
+    for (let i = 1; i < allTypes.length; i++) {
+      if (allTypes[i] !== allTypes[i - 1]) changes++;
+    }
+    const output = {
+      agent: { name: agent.name, slug: agent.slug, type: agent.type, nick: (NICKS[lang][agent.type] || agent.nick || ''), scores: agent.scores, testedAt: agent.testedAt },
+      history: history.map(h => ({ date: h.testedAt, type: h.type, nick: (NICKS[lang][h.type] || ''), scores: h.scores })),
+      drift: { totalTests: allTypes.length, typeChanges: changes },
+    };
+    console.log(JSON.stringify(output, null, 2));
+    return;
+  }
+
+  console.log(formatHistoryTable(data, lang, useColor));
+}
+
 async function runCompare() {
   if (compareSlugs.length < 2) {
     console.error('  Usage: abti compare <slug1> <slug2>');
@@ -1733,9 +1825,11 @@ if (require.main === module) {
     runCompare().catch(err => { console.error(err.message); process.exit(1); });
   } else if (hasInfoSubcommand) {
     runInfo().catch(err => { console.error(err.message); process.exit(1); });
+  } else if (hasHistorySubcommand) {
+    runHistory().catch(err => { console.error(err.message); process.exit(1); });
   } else {
     run().catch(err => { console.error(err.message); process.exit(1); });
   }
 }
 
-module.exports = { parseAnswer, score, callLLM, loadState, saveState, defaultStateFile, formatListTable, formatCompare, formatTypeInfo, formatAgentInfo, isTypeCode, runStats, RateLimitBailError, fetchOllamaModels, fetchOpenRouterModels, fetchGitHubModels, fetchAnthropicModels, fetchOpenAICompatModels, fetchGeminiModels, fetchCohereModels, displayName };
+module.exports = { parseAnswer, score, callLLM, loadState, saveState, defaultStateFile, formatListTable, formatCompare, formatTypeInfo, formatAgentInfo, formatHistoryTable, isTypeCode, runStats, RateLimitBailError, fetchOllamaModels, fetchOpenRouterModels, fetchGitHubModels, fetchAnthropicModels, fetchOpenAICompatModels, fetchGeminiModels, fetchCohereModels, displayName };

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "abti",
   "private": true,
   "scripts": {
-    "test": "node --test test/api.test.js test/mcp.test.js test/mcp-http.test.js test/compatibility.test.js test/cross-compatibility.test.js test/auto-reload.test.js test/parseAnswer.test.js test/provider.test.js test/resume.test.js test/list.test.js test/action-drift.test.js test/all-flag.test.js test/feed.test.js test/dynamic-models.test.js test/history.test.js test/shuffle.test.js test/compare.test.js test/info.test.js",
+    "test": "node --test test/api.test.js test/mcp.test.js test/mcp-http.test.js test/compatibility.test.js test/cross-compatibility.test.js test/auto-reload.test.js test/parseAnswer.test.js test/provider.test.js test/resume.test.js test/list.test.js test/action-drift.test.js test/all-flag.test.js test/feed.test.js test/dynamic-models.test.js test/history.test.js test/shuffle.test.js test/compare.test.js test/info.test.js test/history-cli.test.js",
     "generate-og": "node scripts/generate-og-images.js",
     "generate-sitemap": "node scripts/generate-sitemap.js",
     "generate-og-agents": "node scripts/generate-agent-og.js"

--- a/test/history-cli.test.js
+++ b/test/history-cli.test.js
@@ -1,0 +1,104 @@
+const { describe, it, before, after, beforeEach } = require('node:test');
+const assert = require('node:assert/strict');
+const http = require('node:http');
+const os = require('node:os');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'abti-hist-cli-'));
+process.env.ABTI_DATA_DIR = tmpDir;
+
+const server = require('../api-server.js');
+const { rateLimitMap, resetData, stopWatching } = require('../api-server.js');
+const { formatHistoryTable } = require('../cli/bin/abti.js');
+
+let BASE;
+
+function req(urlPath, opts = {}) {
+  return new Promise((resolve, reject) => {
+    const url = new URL(urlPath, BASE);
+    const o = { hostname: url.hostname, port: url.port, path: url.pathname + url.search, method: opts.method || 'GET', headers: opts.headers || {} };
+    if (opts.body) o.headers['Content-Type'] = 'application/json';
+    const r = http.request(o, (res) => {
+      let d = '';
+      res.on('data', c => d += c);
+      res.on('end', () => resolve({ status: res.statusCode, headers: res.headers, body: d, json() { return JSON.parse(d); } }));
+    });
+    r.on('error', reject);
+    if (opts.body) r.write(typeof opts.body === 'string' ? opts.body : JSON.stringify(opts.body));
+    r.end();
+  });
+}
+
+before(() => new Promise((resolve) => {
+  server.listen(0, '127.0.0.1', () => {
+    BASE = `http://127.0.0.1:${server.address().port}`;
+    resolve();
+  });
+}));
+
+beforeEach(() => { rateLimitMap.clear(); });
+
+after(() => new Promise((resolve) => {
+  stopWatching();
+  server.close(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    delete process.env.ABTI_DATA_DIR;
+    resolve();
+  });
+}));
+
+const allA = Array(16).fill(1);
+const allB = Array(16).fill(0);
+
+describe('history CLI — formatHistoryTable', () => {
+  it('formats agent with no history', async () => {
+    await req('/api/agent-test', { method: 'POST', body: { answers: allA, agentName: 'CLIHistNone' } });
+    const r = await req('/api/agent/clihistnone');
+    const data = r.json();
+    const output = formatHistoryTable(data, 'en', false);
+    assert.ok(output.includes('Personality Drift Timeline'));
+    assert.ok(output.includes('CLIHistNone'));
+    assert.ok(output.includes('PTCF'));
+    assert.ok(output.includes('current'));
+    assert.ok(output.includes('1 test(s), 0 type change(s)'));
+  });
+
+  it('shows history entries and drift count', async () => {
+    await req('/api/agent-test', { method: 'POST', body: { answers: allA, agentName: 'CLIHistDrift' } });
+    await req('/api/agent-test', { method: 'POST', body: { answers: allB, agentName: 'CLIHistDrift' } });
+    await req('/api/agent-test', { method: 'POST', body: { answers: allA, agentName: 'CLIHistDrift' } });
+    const r = await req('/api/agent/clihistdrift');
+    const data = r.json();
+    const output = formatHistoryTable(data, 'en', false);
+    assert.ok(output.includes('3 test(s), 2 type change(s)'));
+    assert.ok(output.includes('PTCF'));
+    assert.ok(output.includes('REDN'));
+  });
+
+  it('supports Chinese output', async () => {
+    await req('/api/agent-test', { method: 'POST', body: { answers: allA, agentName: 'CLIHistZh' } });
+    const r = await req('/api/agent/clihistzh');
+    const data = r.json();
+    const output = formatHistoryTable(data, 'zh', false);
+    assert.ok(output.includes('人格变迁时间线'));
+    assert.ok(output.includes('当前'));
+    assert.ok(output.includes('变迁摘要'));
+  });
+});
+
+describe('history CLI — API response format', () => {
+  it('history endpoint returns correct structure for JSON mode', async () => {
+    await req('/api/agent-test', { method: 'POST', body: { answers: allA, agentName: 'CLIHistJSON' } });
+    await req('/api/agent-test', { method: 'POST', body: { answers: allB, agentName: 'CLIHistJSON' } });
+    const r = await req('/api/agent/clihistjson');
+    const j = r.json();
+    assert.ok(j.agent);
+    assert.ok(Array.isArray(j.agent.history));
+    assert.equal(j.agent.history.length, 1);
+    assert.ok(j.agent.history[0].type);
+    assert.ok(j.agent.history[0].scores);
+    assert.ok(j.agent.history[0].testedAt);
+    assert.equal(j.agent.type, 'REDN');
+  });
+});


### PR DESCRIPTION
## Summary

Adds `abti history <slug>` CLI subcommand that displays an agent's test history and personality drift timeline.

Closes #416

## Usage

```bash
npx abti history claude-opus-4        # Table view
npx abti history gpt-4o --json        # JSON output
npx abti history gpt-4o --lang zh     # Chinese
```

## What's included

- **`formatHistoryTable()`** — renders date, type, nickname, per-dimension scores, and drift summary
- **`runHistory()`** — fetches `/api/agent/:slug` and renders table or JSON
- **JSON mode** — structured output with agent info, history array, and drift stats
- **i18n** — full Chinese support (`--lang zh`)
- **Tests** — 4 test cases in `test/history-cli.test.js` covering no-history, drift detection, Chinese output, and API response format

## Test results

All 256 tests pass (including 4 new history-cli tests).