### PR TITLE
fix: deduplicate agents by model field when slug differs

### DIFF
--- a/api-server.js
+++ b/api-server.js
@@ -240,7 +240,10 @@ function registerAgent(entry) {
   if (entry.name && !entry.slug) {
     entry.slug = slugify(entry.name);
   }
-  const existing = agentData.agents.findIndex(a => a.slug === entry.slug);
+  let existing = agentData.agents.findIndex(a => a.slug === entry.slug);
+  if (existing === -1 && entry.model) {
+    existing = agentData.agents.findIndex(a => a.model && a.model === entry.model);
+  }
   if (existing !== -1) {
     preserveHistory(agentData.agents[existing], entry);
     agentData.agents[existing] = entry;
@@ -434,8 +437,6 @@ const server = http.createServer((req, res) => {
           const urlStr = (typeof agentUrl === 'string') ? agentUrl : '';
           const now = new Date().toISOString();
           const slug = slugify(name);
-          // Upsert by slug — always update existing entry with same slug
-          const existing = agentData.agents.findIndex(a => a.slug === slug);
           const entry = { name, slug, url: urlStr, type: code, nick: t?.en?.nick || 'Unknown', testedAt: now, scores: scores.slice(), dimensions: DL.map((d, i) => ({ poles: d, score: scores[i], max: 4 })) };
           if (typeof model === 'string' && model) entry.model = model.slice(0, 64);
           if (typeof provider === 'string' && provider) entry.provider = provider.slice(0, 32);
@@ -444,6 +445,10 @@ const server = http.createServer((req, res) => {
           if (typeof parsed.parseFailures === 'number' && Number.isInteger(parsed.parseFailures) && parsed.parseFailures >= 0) {
             entry.parseFailures = parsed.parseFailures;
             entry.confidence = Math.round(((16 - parsed.parseFailures) / 16) * 1000) / 1000;
+          }
+          let existing = agentData.agents.findIndex(a => a.slug === slug);
+          if (existing === -1 && entry.model) {
+            existing = agentData.agents.findIndex(a => a.model && a.model === entry.model);
           }
           if (existing !== -1) {
             preserveHistory(agentData.agents[existing], entry);

--- a/cli/bin/abti.js
+++ b/cli/bin/abti.js
@@ -881,6 +881,7 @@ async function runAll() {
       try {
         const body = { answers: r._answers ? r._answers.map(a => a ? 1 : 0) : undefined, lang };
         if (agentName) body.agentName = agentName;
+        else if (r.displayName) body.agentName = r.displayName;
         body.model = r.model;
         body.provider = autoProvider;
         if (r.parseFailures > 0) body.parseFailures = r.parseFailures;

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -892,6 +892,42 @@ describe('POST /api/agent-test parseFailures/confidence', () => {
     assert.equal(matches[0].type, 'REDN', 'should have the newer result');
   });
 
+  it('deduplicates by model when slug differs', async () => {
+    rateLimitMap.clear();
+    // First submit with display name
+    await req('/api/agent-test', {
+      method: 'POST',
+      body: { answers: Array(16).fill(1), agentName: 'Model Dedup Bot', model: 'model-dedup-v1' }
+    });
+    rateLimitMap.clear();
+    // Second submit with different name but same model
+    await req('/api/agent-test', {
+      method: 'POST',
+      body: { answers: [1,1,1,1,0,0,0,0,1,1,1,1,0,0,0,0], agentName: 'model-dedup-v1', model: 'model-dedup-v1' }
+    });
+    const data = JSON.parse(fs.readFileSync(path.join(tmpDir, 'results.json'), 'utf8'));
+    const matches = data.agents.filter(a => a.model === 'model-dedup-v1');
+    assert.equal(matches.length, 1, 'should have exactly 1 entry with that model');
+    assert.ok(Array.isArray(matches[0].history), 'should have history from update');
+  });
+
+  it('prefers slug match over model match', async () => {
+    rateLimitMap.clear();
+    await req('/api/agent-test', {
+      method: 'POST',
+      body: { answers: Array(16).fill(1), agentName: 'SlugPriorityBot', model: 'slug-priority-model' }
+    });
+    rateLimitMap.clear();
+    // Same slug (same name), different model
+    await req('/api/agent-test', {
+      method: 'POST',
+      body: { answers: Array(16).fill(0), agentName: 'SlugPriorityBot', model: 'different-model' }
+    });
+    const data = JSON.parse(fs.readFileSync(path.join(tmpDir, 'results.json'), 'utf8'));
+    const matches = data.agents.filter(a => a.slug === 'slugprioritybot');
+    assert.equal(matches.length, 1, 'slug match should update existing');
+  });
+
   it('omits parseFailures/confidence when not provided', async () => {
     rateLimitMap.clear();
     const r = await req('/api/agent-test', {


### PR DESCRIPTION
Fixes #425

## Problem
Batch testing creates duplicate agents when providers return raw model IDs (e.g. `mistral-medium-2505`) instead of display names (e.g. `Mistral Medium 3`). Different slugs → different entries.

## Fix
- **`registerAgent()`**: Falls back to matching by `model` field when slug lookup misses
- **POST `/api/agent-test`**: Same model-based dedup fallback, moved lookup after entry construction
- **CLI `runAll()`**: Sends `displayName` as `agentName` when no explicit name given

## Tests
- 2 new tests: model-based dedup and slug-match priority
- All 258 tests pass