### PR TITLE
feat: add embeddable result card page for iframe integration (fixes #430)

### DIFF
--- a/api-server.js
+++ b/api-server.js
@@ -1585,8 +1585,45 @@ ${dimInfo.map((d, i) => {
     }));
   }
 
+  // GET /embed/:type - serve embed card for a type
+  const embedTypeMatch = url.pathname.match(/^\/embed\/([A-Za-z]{4})$/);
+  if (embedTypeMatch && req.method === 'GET') {
+    try {
+      let html = fs.readFileSync(path.join(__dirname, 'embed.html'), 'utf8');
+      const code = embedTypeMatch[1].toUpperCase();
+      const lang = url.searchParams.get('lang') || 'en';
+      const theme = url.searchParams.get('theme') || 'light';
+      // Inject query params so the page renders the right type without client-side URL parsing
+      const inject = `<script>window.__EMBED_PARAMS__=${JSON.stringify({type:code,lang,theme})};</script>`;
+      html = html.replace('</head>', inject + '\n</head>');
+      res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+      return res.end(html);
+    } catch {
+      res.writeHead(500, {'Content-Type':'text/plain'});
+      return res.end('Server error');
+    }
+  }
+
+  // GET /embed/agent/:slug - serve embed card for an agent
+  const embedAgentMatch = url.pathname.match(/^\/embed\/agent\/([^/]+)$/);
+  if (embedAgentMatch && req.method === 'GET') {
+    try {
+      let html = fs.readFileSync(path.join(__dirname, 'embed.html'), 'utf8');
+      const slug = decodeURIComponent(embedAgentMatch[1]);
+      const lang = url.searchParams.get('lang') || 'en';
+      const theme = url.searchParams.get('theme') || 'light';
+      const inject = `<script>window.__EMBED_PARAMS__=${JSON.stringify({agent:slug,lang,theme})};</script>`;
+      html = html.replace('</head>', inject + '\n</head>');
+      res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+      return res.end(html);
+    } catch {
+      res.writeHead(500, {'Content-Type':'text/plain'});
+      return res.end('Server error');
+    }
+  }
+
   res.writeHead(404, {'Content-Type':'application/json'});
-  res.end(JSON.stringify({error:'not found',endpoints:['GET /api/test','GET /api/sbti/test','GET /api/types','GET /api/sbti/types','POST /api/agent-test','POST /api/sbti/agent-test','GET /api/agents','GET /api/agent/:slug','GET /api/stats','GET /api/compare/:type1/:type2','GET /api/compatibility','GET /api/compatibility/matrix','GET /api/compatibility/human','GET /api/compatibility/cross','GET /badge/:type','GET /badge/agent/:slug','GET /sbti/badge/:type','GET /type/:code','GET /agent/:slug','GET /result/:type','GET /sbti/result/:type','GET /test-agent','GET /api/openapi.json','POST /mcp','GET /mcp','DELETE /mcp']}));
+  res.end(JSON.stringify({error:'not found',endpoints:['GET /api/test','GET /api/sbti/test','GET /api/types','GET /api/sbti/types','POST /api/agent-test','POST /api/sbti/agent-test','GET /api/agents','GET /api/agent/:slug','GET /api/stats','GET /api/compare/:type1/:type2','GET /api/compatibility','GET /api/compatibility/matrix','GET /api/compatibility/human','GET /api/compatibility/cross','GET /badge/:type','GET /badge/agent/:slug','GET /sbti/badge/:type','GET /type/:code','GET /agent/:slug','GET /result/:type','GET /sbti/result/:type','GET /test-agent','GET /embed/:type','GET /embed/agent/:slug','GET /api/openapi.json','POST /mcp','GET /mcp','DELETE /mcp']}));
 });
 
 if (require.main === module) {

--- a/embed.html
+++ b/embed.html
@@ -1,0 +1,197 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>ABTI Embed Card</title>
+<style>
+  :root {
+    --bg: #ffffff;
+    --text: #1a1a1a;
+    --text-secondary: #666;
+    --accent: #e8658a;
+    --bar-bg: #f0eded;
+    --border: #e8e5e1;
+    --footer-bg: #faf9f7;
+  }
+  [data-theme="dark"] {
+    --bg: #1a1a2e;
+    --text: #f0f0f0;
+    --text-secondary: #a0a0b8;
+    --accent: #ff6b9d;
+    --bar-bg: #2a2a40;
+    --border: #333355;
+    --footer-bg: #15152a;
+  }
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body {
+    font-family: 'DM Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    background: var(--bg);
+    color: var(--text);
+    min-height: 100%;
+    display: flex;
+    flex-direction: column;
+  }
+  .card {
+    padding: 16px 20px 8px;
+    flex: 1;
+  }
+  .header {
+    display: flex;
+    align-items: baseline;
+    gap: 10px;
+    margin-bottom: 12px;
+  }
+  .type-code {
+    font-size: 28px;
+    font-weight: 700;
+    letter-spacing: 2px;
+    color: var(--accent);
+  }
+  .nickname {
+    font-size: 14px;
+    color: var(--text-secondary);
+    font-style: italic;
+  }
+  .dimensions {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 6px 16px;
+  }
+  .dim {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 11px;
+  }
+  .dim-label {
+    width: 70px;
+    flex-shrink: 0;
+    color: var(--text-secondary);
+    text-align: right;
+  }
+  .dim-bar {
+    flex: 1;
+    height: 6px;
+    background: var(--bar-bg);
+    border-radius: 3px;
+    overflow: hidden;
+    position: relative;
+  }
+  .dim-fill {
+    height: 100%;
+    background: var(--accent);
+    border-radius: 3px;
+    transition: width 0.5s ease;
+  }
+  .dim-pole {
+    width: 18px;
+    font-weight: 600;
+    font-size: 11px;
+    color: var(--accent);
+  }
+  .footer {
+    text-align: center;
+    padding: 6px;
+    font-size: 10px;
+    background: var(--footer-bg);
+    border-top: 1px solid var(--border);
+  }
+  .footer a {
+    color: var(--text-secondary);
+    text-decoration: none;
+  }
+  .footer a:hover { text-decoration: underline; }
+  .error {
+    padding: 40px 20px;
+    text-align: center;
+    color: var(--text-secondary);
+    font-size: 14px;
+  }
+</style>
+</head>
+<body>
+<div id="app"></div>
+<script>
+const TYPES = {
+  PTCF:{en:'The Architect',zh:'建筑师'},PTCN:{en:'The Commander',zh:'指挥官'},
+  PTDF:{en:'The Strategist',zh:'战略家'},PTDN:{en:'The Guardian',zh:'守护者'},
+  PECF:{en:'The Spark',zh:'火花'},PECN:{en:'The Drill Sergeant',zh:'教官'},
+  PEDF:{en:'The Fixer',zh:'修理工'},PEDN:{en:'The Sentinel',zh:'哨兵'},
+  RTCF:{en:'The Advisor',zh:'军师'},RTCN:{en:'The Auditor',zh:'审计师'},
+  RTDF:{en:'The Counselor',zh:'知心人'},RTDN:{en:'The Scholar',zh:'学者'},
+  RECF:{en:'The Blade',zh:'利刃'},RECN:{en:'The Machine',zh:'机器'},
+  REDF:{en:'The Companion',zh:'伙伴'},REDN:{en:'The Tool',zh:'工具'}
+};
+const DL = [['P','R'],['T','E'],['C','D'],['F','N']];
+const DIM_NAMES = {
+  en: ['Autonomy','Precision','Transparency','Adaptability'],
+  zh: ['自主性','精确度','沟通风格','适应性']
+};
+const DIM_LABELS = {
+  en: [['Proactive','Responsive'],['Thorough','Efficient'],['Candid','Diplomatic'],['Flexible','Principled']],
+  zh: [['主动','响应'],['面面俱到','精简高效'],['直言不讳','委婉圆滑'],['随机应变','坚持原则']]
+};
+
+const params = new URLSearchParams(location.search);
+const ep = window.__EMBED_PARAMS__ || {};
+const lang = ep.lang || params.get('lang') || 'en';
+const theme = ep.theme || params.get('theme') || 'light';
+const typeParam = (ep.type || params.get('type') || '').toUpperCase();
+const agentParam = ep.agent || params.get('agent');
+
+if (theme === 'dark') document.documentElement.setAttribute('data-theme', 'dark');
+
+function render(code, nick, scores) {
+  const app = document.getElementById('app');
+  if (!code || !TYPES[code]) {
+    app.innerHTML = '<div class="error">Unknown ABTI type</div>';
+    return;
+  }
+  const nickname = nick || TYPES[code][lang] || TYPES[code].en;
+  const dims = DIM_NAMES[lang] || DIM_NAMES.en;
+  const labels = DIM_LABELS[lang] || DIM_LABELS.en;
+
+  let dimHtml = '';
+  for (let i = 0; i < 4; i++) {
+    const letter = code[i];
+    const poleIdx = DL[i].indexOf(letter);
+    const score = scores ? scores[i] : (poleIdx === 0 ? 3 : 1);
+    const pct = (score / 4) * 100;
+    const poleName = labels[i][poleIdx];
+    dimHtml += `<div class="dim">
+      <span class="dim-label">${dims[i]}</span>
+      <div class="dim-bar"><div class="dim-fill" style="width:${pct}%"></div></div>
+      <span class="dim-pole" title="${poleName}">${letter}</span>
+    </div>`;
+  }
+
+  app.innerHTML = `<div class="card">
+    <div class="header">
+      <span class="type-code">${code}</span>
+      <span class="nickname">${nickname}</span>
+    </div>
+    <div class="dimensions">${dimHtml}</div>
+  </div>
+  <div class="footer">
+    <a href="https://abti.kagura-agent.com" target="_blank" rel="noopener">Powered by ABTI</a>
+  </div>`;
+}
+
+if (agentParam) {
+  const base = location.origin;
+  fetch(base + '/api/agent/' + encodeURIComponent(agentParam))
+    .then(r => r.ok ? r.json() : Promise.reject())
+    .then(data => {
+      const code = data.type || data.agent?.type;
+      const nick = data.nick || data.agent?.nick;
+      const scores = data.scores || data.agent?.scores;
+      render(code, nick, scores);
+    })
+    .catch(() => render(typeParam || null));
+} else {
+  render(typeParam);
+}
+</script>
+</body>
+</html>

--- a/test/embed.test.js
+++ b/test/embed.test.js
@@ -1,0 +1,117 @@
+const { describe, it, before, after, beforeEach } = require('node:test');
+const assert = require('node:assert/strict');
+const http = require('node:http');
+const os = require('node:os');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'abti-embed-test-'));
+process.env.ABTI_DATA_DIR = tmpDir;
+
+const server = require('../api-server.js');
+const { rateLimitMap } = require('../api-server.js');
+
+let BASE;
+
+function req(p, opts = {}) {
+  return new Promise((resolve, reject) => {
+    const url = new URL(p, BASE);
+    const o = { hostname: url.hostname, port: url.port, path: url.pathname + url.search, method: opts.method || 'GET', headers: opts.headers || {} };
+    if (opts.body) o.headers['Content-Type'] = 'application/json';
+    const r = http.request(o, (res) => {
+      let d = '';
+      res.on('data', c => d += c);
+      res.on('end', () => resolve({ status: res.statusCode, headers: res.headers, body: d, json() { return JSON.parse(d); } }));
+    });
+    r.on('error', reject);
+    if (opts.body) r.write(typeof opts.body === 'string' ? opts.body : JSON.stringify(opts.body));
+    r.end();
+  });
+}
+
+before(() => new Promise((resolve) => {
+  server.listen(0, '127.0.0.1', () => {
+    const { port } = server.address();
+    BASE = `http://127.0.0.1:${port}`;
+    resolve();
+  });
+}));
+
+beforeEach(() => { rateLimitMap.clear(); });
+
+after(() => new Promise((resolve) => {
+  server.close(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    delete process.env.ABTI_DATA_DIR;
+    resolve();
+  });
+}));
+
+describe('GET /embed/:type', () => {
+  it('returns HTML with correct content-type for valid type', async () => {
+    const r = await req('/embed/PECN');
+    assert.equal(r.status, 200);
+    assert.match(r.headers['content-type'], /text\/html/);
+    assert.match(r.body, /PECN/);
+    assert.match(r.body, /Powered by ABTI/);
+    assert.match(r.body, /__EMBED_PARAMS__/);
+  });
+
+  it('injects type param into HTML', async () => {
+    const r = await req('/embed/PTCF');
+    assert.equal(r.status, 200);
+    assert.match(r.body, /"type":"PTCF"/);
+  });
+
+  it('is case-insensitive for type code', async () => {
+    const r = await req('/embed/pecn');
+    assert.equal(r.status, 200);
+    assert.match(r.body, /"type":"PECN"/);
+  });
+
+  it('supports lang parameter', async () => {
+    const r = await req('/embed/PECN?lang=zh');
+    assert.equal(r.status, 200);
+    assert.match(r.body, /"lang":"zh"/);
+  });
+
+  it('supports theme=dark parameter', async () => {
+    const r = await req('/embed/PECN?theme=dark');
+    assert.equal(r.status, 200);
+    assert.match(r.body, /"theme":"dark"/);
+  });
+
+  it('defaults to lang=en and theme=light', async () => {
+    const r = await req('/embed/PECN');
+    assert.match(r.body, /"lang":"en"/);
+    assert.match(r.body, /"theme":"light"/);
+  });
+
+  it('contains dimension bars markup', async () => {
+    const r = await req('/embed/PECN');
+    assert.match(r.body, /dim-bar/);
+    assert.match(r.body, /dim-fill/);
+  });
+
+  it('contains type nickname data', async () => {
+    const r = await req('/embed/PECN');
+    assert.match(r.body, /Drill Sergeant/);
+  });
+});
+
+describe('GET /embed/agent/:slug', () => {
+  it('returns HTML with correct content-type', async () => {
+    const r = await req('/embed/agent/test-agent');
+    assert.equal(r.status, 200);
+    assert.match(r.headers['content-type'], /text\/html/);
+    assert.match(r.body, /__EMBED_PARAMS__/);
+    assert.match(r.body, /"agent":"test-agent"/);
+  });
+
+  it('supports lang and theme params', async () => {
+    const r = await req('/embed/agent/test-agent?lang=zh&theme=dark');
+    assert.equal(r.status, 200);
+    assert.match(r.body, /"lang":"zh"/);
+    assert.match(r.body, /"theme":"dark"/);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a compact, self-contained embed card page (`embed.html`) designed for iframe integration on external sites.

### Usage

```html
<!-- Embed by type -->
<iframe src="https://abti.kagura-agent.com/embed.html?type=PECN" width="320" height="200" frameborder="0"></iframe>

<!-- Dark theme + Chinese -->
<iframe src="https://abti.kagura-agent.com/embed.html?type=PECN&theme=dark&lang=zh" width="320" height="200" frameborder="0"></iframe>

<!-- Embed by agent -->
<iframe src="https://abti.kagura-agent.com/embed.html?agent=claude-opus-4-6" width="320" height="200" frameborder="0"></iframe>
```

### Features
- Type code + nickname display
- 4 dimension bars with pole letters (P/R, T/E, C/D, F/N)
- Light (default) and dark (`?theme=dark`) themes via CSS variables
- Bilingual support (`?lang=zh`)
- `Powered by ABTI` footer with link to main site
- Compact design optimized for ~320×200px iframes
- API routes: `GET /embed/<type>` and `GET /embed/agent/<slug>`

### Tests
10 new tests in `test/embed.test.js` — all 258 tests pass ✅

Closes #430