### PR TITLE
feat(cli): add --skip-existing flag for --all batch testing

### DIFF
--- a/cli/bin/abti.js
+++ b/cli/bin/abti.js
@@ -137,6 +137,7 @@ const noProxyFlag = flag('--no-proxy');
 const resumeFile = opt('--resume') || null;
 const saveStateFlag = flag('--save-state') || !!resumeFile;
 const interQuestionDelay = parseInt(opt('--delay') || '0', 10);
+const skipExisting = flag('--skip-existing');
 
 // Keep backward compat: --model and --provider used for submit metadata too
 const model = autoModel;
@@ -216,6 +217,7 @@ if (flag('--help') || flag('-h')) {
     --resume <file>          Resume from a saved state file (implies --save-state)
     --save-state             Auto-save state after each answer (default file: <model>-state.json)
     --delay <ms>             Inter-question delay in ms for rate limit pacing (default: 0)
+    --skip-existing          Skip models that already have results in the registry (use with --all --submit)
 
   Prompt options:
     --prompt <text>          System prompt for the agent persona (alias: --system-prompt)
@@ -831,6 +833,21 @@ async function runAll() {
 
   if (maxModels && maxModels > 0) {
     modelList = modelList.slice(0, maxModels);
+  }
+
+  // Skip models that already have results in the registry
+  if (skipExisting) {
+    try {
+      const resp = await httpGet(`${API_BASE}/api/agents`);
+      const agents = resp.agents || resp;
+      const { remaining, skipped } = filterExistingModels(modelList, agents);
+      modelList = remaining;
+      if (skipped.length > 0) {
+        process.stderr.write(`  Skipping ${skipped.length} already-tested model(s): ${skipped.map(displayName).join(', ')}\n`);
+      }
+    } catch (err) {
+      process.stderr.write(`  Warning: could not fetch existing agents (${err.message}), proceeding without skip\n`);
+    }
   }
 
   if (modelList.length === 0) {
@@ -1833,4 +1850,11 @@ if (require.main === module) {
   }
 }
 
-module.exports = { parseAnswer, score, callLLM, loadState, saveState, defaultStateFile, formatListTable, formatCompare, formatTypeInfo, formatAgentInfo, formatHistoryTable, isTypeCode, runStats, RateLimitBailError, fetchOllamaModels, fetchOpenRouterModels, fetchGitHubModels, fetchAnthropicModels, fetchOpenAICompatModels, fetchGeminiModels, fetchCohereModels, displayName };
+function filterExistingModels(modelList, agents) {
+  const testedModels = new Set((agents || []).map(a => (a.model || '').toLowerCase()));
+  const skipped = modelList.filter(m => testedModels.has(m.toLowerCase()));
+  const remaining = modelList.filter(m => !testedModels.has(m.toLowerCase()));
+  return { remaining, skipped };
+}
+
+module.exports = { parseAnswer, score, callLLM, loadState, saveState, defaultStateFile, formatListTable, formatCompare, formatTypeInfo, formatAgentInfo, formatHistoryTable, isTypeCode, runStats, RateLimitBailError, fetchOllamaModels, fetchOpenRouterModels, fetchGitHubModels, fetchAnthropicModels, fetchOpenAICompatModels, fetchGeminiModels, fetchCohereModels, displayName, filterExistingModels };

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "abti",
   "private": true,
   "scripts": {
-    "test": "node --test test/api.test.js test/mcp.test.js test/mcp-http.test.js test/compatibility.test.js test/cross-compatibility.test.js test/auto-reload.test.js test/parseAnswer.test.js test/provider.test.js test/resume.test.js test/list.test.js test/action-drift.test.js test/all-flag.test.js test/feed.test.js test/dynamic-models.test.js test/history.test.js test/shuffle.test.js test/compare.test.js test/info.test.js test/history-cli.test.js",
+    "test": "node --test test/api.test.js test/mcp.test.js test/mcp-http.test.js test/compatibility.test.js test/cross-compatibility.test.js test/auto-reload.test.js test/parseAnswer.test.js test/provider.test.js test/resume.test.js test/list.test.js test/action-drift.test.js test/all-flag.test.js test/feed.test.js test/dynamic-models.test.js test/history.test.js test/shuffle.test.js test/compare.test.js test/info.test.js test/history-cli.test.js test/skip-existing.test.js",
     "generate-og": "node scripts/generate-og-images.js",
     "generate-sitemap": "node scripts/generate-sitemap.js",
     "generate-og-agents": "node scripts/generate-agent-og.js"

--- a/test/skip-existing.test.js
+++ b/test/skip-existing.test.js
@@ -1,0 +1,62 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+const { filterExistingModels } = require('../cli/bin/abti.js');
+
+describe('--skip-existing filtering', () => {
+  it('should filter out models that already have results', () => {
+    const modelList = ['gpt-4o', 'gpt-3.5-turbo', 'claude-sonnet-4-20250514'];
+    const agents = [
+      { model: 'gpt-4o', slug: 'gpt-4o' },
+      { model: 'claude-sonnet-4-20250514', slug: 'claude-sonnet-4' },
+    ];
+    const { remaining, skipped } = filterExistingModels(modelList, agents);
+    assert.deepStrictEqual(remaining, ['gpt-3.5-turbo']);
+    assert.deepStrictEqual(skipped, ['gpt-4o', 'claude-sonnet-4-20250514']);
+  });
+
+  it('should match case-insensitively', () => {
+    const modelList = ['GPT-4o', 'Llama-3'];
+    const agents = [{ model: 'gpt-4o' }];
+    const { remaining, skipped } = filterExistingModels(modelList, agents);
+    assert.deepStrictEqual(remaining, ['Llama-3']);
+    assert.deepStrictEqual(skipped, ['GPT-4o']);
+  });
+
+  it('should return all models when no agents exist', () => {
+    const modelList = ['model-a', 'model-b'];
+    const { remaining, skipped } = filterExistingModels(modelList, []);
+    assert.deepStrictEqual(remaining, ['model-a', 'model-b']);
+    assert.deepStrictEqual(skipped, []);
+  });
+
+  it('should handle null/undefined agents gracefully', () => {
+    const modelList = ['model-a'];
+    const { remaining, skipped } = filterExistingModels(modelList, null);
+    assert.deepStrictEqual(remaining, ['model-a']);
+    assert.deepStrictEqual(skipped, []);
+  });
+
+  it('should handle agents with missing model field', () => {
+    const modelList = ['gpt-4o'];
+    const agents = [{ slug: 'some-agent' }, { model: 'gpt-4o' }];
+    const { remaining, skipped } = filterExistingModels(modelList, agents);
+    assert.deepStrictEqual(remaining, []);
+    assert.deepStrictEqual(skipped, ['gpt-4o']);
+  });
+
+  it('should skip nothing when no overlap', () => {
+    const modelList = ['model-x', 'model-y'];
+    const agents = [{ model: 'model-a' }, { model: 'model-b' }];
+    const { remaining, skipped } = filterExistingModels(modelList, agents);
+    assert.deepStrictEqual(remaining, ['model-x', 'model-y']);
+    assert.deepStrictEqual(skipped, []);
+  });
+
+  it('should work when agents is an array (pre-unwrapped)', () => {
+    const modelList = ['gpt-4o', 'llama-3'];
+    const agents = [{ model: 'gpt-4o' }];
+    const { remaining, skipped } = filterExistingModels(modelList, agents);
+    assert.deepStrictEqual(remaining, ['llama-3']);
+    assert.deepStrictEqual(skipped, ['gpt-4o']);
+  });
+});


### PR DESCRIPTION
Fixes #442

## What
Adds `--skip-existing` flag that fetches existing agents from the ABTI registry and skips models that already have results when running `--all` batch tests.

## Usage
```bash
npx abti test --provider github --all --skip-existing --submit
```

## Implementation
- Before batch testing, fetches `GET /api/agents` to get existing models
- Filters discovered models list, skipping already-tested ones (case-insensitive match)
- Reports count of skipped models to stderr
- Gracefully falls back to testing all if registry is unreachable

## Tests
- 7 new unit tests for `filterExistingModels` (case sensitivity, null handling, no overlap, etc.)
- All 268 tests pass