### PR TITLE
fix(cli): migrate GitHub provider to models.github.ai endpoint (fixes #444)

### DIFF
--- a/cli/bin/abti.js
+++ b/cli/bin/abti.js
@@ -390,7 +390,7 @@ function callLLM(prov, apiKey, mdl, systemPrompt, userMessage, baseUrl, maxToken
   if (prov === 'anthropic') return callAnthropic(apiKey, mdl, systemPrompt, userMessage, baseUrl, maxTokens);
   if (prov === 'gemini') return callGemini(apiKey, mdl, systemPrompt, userMessage, maxTokens);
   if (prov === 'deepseek') return callOpenAI(apiKey, mdl, systemPrompt, userMessage, 'https://api.deepseek.com', undefined, maxTokens);
-  if (prov === 'github') return callOpenAI(apiKey, mdl, systemPrompt, userMessage, baseUrl || 'https://models.inference.ai.azure.com', undefined, maxTokens, '/chat/completions');
+  if (prov === 'github') return callOpenAI(apiKey, mdl, systemPrompt, userMessage, baseUrl || 'https://models.github.ai/inference', undefined, maxTokens, '/chat/completions');
   if (prov === 'groq') return callOpenAI(apiKey, mdl, systemPrompt, userMessage, baseUrl || 'https://api.groq.com/openai', undefined, maxTokens);
   if (prov === 'openrouter') return callOpenAI(apiKey, mdl, systemPrompt, userMessage, baseUrl || 'https://openrouter.ai/api/v1', undefined, maxTokens);
   if (prov === 'mistral') return callOpenAI(apiKey, mdl, systemPrompt, userMessage, baseUrl || 'https://api.mistral.ai/v1', undefined, maxTokens);
@@ -693,7 +693,7 @@ function fetchGitHubModels(apiKey) {
           const json = JSON.parse(data);
           const models = (Array.isArray(json) ? json : json.data || json.models || [])
             .filter(m => m.supported_output_modalities && m.supported_output_modalities.includes('text'))
-            .map(m => m.id.includes('/') ? m.id.split('/').pop() : m.id)
+            .map(m => m.id)
             .sort((a, b) => a.localeCompare(b));
           resolve(models);
         } catch (e) { reject(new Error(`Failed to parse GitHub Models response: ${e.message}`)); }

--- a/test/all-flag.test.js
+++ b/test/all-flag.test.js
@@ -61,13 +61,13 @@ describe('--all flag', () => {
       }
     });
 
-    it('should strip namespace prefix from model IDs', () => {
+    it('should preserve full model IDs including namespace prefix', () => {
       const fs = require('fs');
       const path = require('path');
       const src = fs.readFileSync(path.join(__dirname, '..', 'cli', 'bin', 'abti.js'), 'utf8');
       assert.ok(
-        src.includes("m.id.includes('/') ? m.id.split('/').pop() : m.id"),
-        'fetchGitHubModels should strip org/ prefix from namespaced model IDs'
+        src.includes('.map(m => m.id)'),
+        'fetchGitHubModels should preserve full model IDs with provider prefix'
       );
     });
   });


### PR DESCRIPTION
## Changes

- Migrate GitHub Models inference URL from `models.inference.ai.azure.com` to `models.github.ai/inference`
- Preserve full model IDs with provider prefix (e.g. `openai/gpt-4.1-nano` instead of just `gpt-4.1-nano`)
- Update test to verify prefix preservation

## Why

GitHub has migrated their Models API. The old endpoint doesn't support newer models (grok-3, o3, gpt-5-nano, etc.) which are only available on the new endpoint. This also unblocks #441.

## Evidence

| Endpoint | Prefixed name | Short name |
|----------|--------------|------------|
| old (`models.inference.ai.azure.com`) | ❌ unknown_model | ✅ works |
| new (`models.github.ai/inference`) | ✅ works | ✅ works |

## Testing

- All 268 tests pass
- Test updated: verifies model IDs preserve provider prefix

Fixes #444