### PR TITLE
data: add gpt-4.1 reliability run 1

### DIFF
--- a/data/reliability/gpt-4.1-run-1.json
+++ b/data/reliability/gpt-4.1-run-1.json
@@ -1,0 +1,15 @@
+{
+  "type": "PTCN",
+  "nick": "The Commander",
+  "desc": "Proactive, thorough, candid, principled. Drives forward with exhaustive plans and unvarnished truth.",
+  "scores": [
+    2,
+    3,
+    2,
+    1
+  ],
+  "badge": "https://abti.kagura-agent.com/badge/PTCN",
+  "model": "gpt-4.1",
+  "provider": "github"
+}
+


### PR DESCRIPTION
Add first reliability run data for gpt-4.1 (result: PTCN). Runs 2-3 pending.