### PR TITLE
feat: add results.json schema validation (#449)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,3 +17,4 @@ jobs:
       - run: npm install
       - run: cd mcp && npm install
       - run: npm test
+      - run: npm run validate

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "abti",
   "private": true,
   "scripts": {
-    "test": "node --test test/api.test.js test/mcp.test.js test/mcp-http.test.js test/compatibility.test.js test/cross-compatibility.test.js test/auto-reload.test.js test/parseAnswer.test.js test/provider.test.js test/resume.test.js test/list.test.js test/action-drift.test.js test/all-flag.test.js test/feed.test.js test/dynamic-models.test.js test/history.test.js test/shuffle.test.js test/compare.test.js test/info.test.js test/history-cli.test.js test/skip-existing.test.js",
+    "test": "node --test test/api.test.js test/mcp.test.js test/mcp-http.test.js test/compatibility.test.js test/cross-compatibility.test.js test/auto-reload.test.js test/parseAnswer.test.js test/provider.test.js test/resume.test.js test/list.test.js test/action-drift.test.js test/all-flag.test.js test/feed.test.js test/dynamic-models.test.js test/history.test.js test/shuffle.test.js test/compare.test.js test/info.test.js test/history-cli.test.js test/skip-existing.test.js test/validate-results.test.js",
+    "validate": "node scripts/validate-results.js",
     "generate-og": "node scripts/generate-og-images.js",
     "generate-sitemap": "node scripts/generate-sitemap.js",
     "generate-og-agents": "node scripts/generate-agent-og.js"

--- a/scripts/validate-results.js
+++ b/scripts/validate-results.js
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const EXPECTED_POLES = [['P', 'R'], ['T', 'E'], ['C', 'D'], ['F', 'N']];
+const SLUG_RE = /^[a-z0-9-]+$/;
+
+function validate(data) {
+  const errors = [];
+  const warnings = [];
+
+  if (!data || !Array.isArray(data.agents)) {
+    return { errors: ['Top-level must be { agents: [...] }'], warnings: [] };
+  }
+
+  const slugs = new Set();
+
+  for (let i = 0; i < data.agents.length; i++) {
+    const a = data.agents[i];
+    const prefix = `agents[${i}] (${a.slug || a.name || '?'})`;
+
+    if (typeof a.name !== 'string' || !a.name) {
+      errors.push(`${prefix}: name must be non-empty string`);
+    }
+
+    if (typeof a.slug !== 'string' || !SLUG_RE.test(a.slug)) {
+      errors.push(`${prefix}: slug must match /^[a-z0-9-]+$/`);
+    } else if (slugs.has(a.slug)) {
+      errors.push(`${prefix}: duplicate slug "${a.slug}"`);
+    } else {
+      slugs.add(a.slug);
+    }
+
+    if (typeof a.type !== 'string' || a.type.length !== 4) {
+      errors.push(`${prefix}: type must be 4-char string`);
+    }
+
+    if (typeof a.nick !== 'string' || !a.nick) {
+      errors.push(`${prefix}: nick must be non-empty string`);
+    }
+
+    if (!Array.isArray(a.scores) || a.scores.length !== 4 ||
+        a.scores.some(s => !Number.isInteger(s) || s < 0 || s > 4)) {
+      errors.push(`${prefix}: scores must be array of 4 integers (0-4)`);
+    }
+
+    if (typeof a.testedAt !== 'string' || isNaN(Date.parse(a.testedAt))) {
+      errors.push(`${prefix}: testedAt must be valid ISO-8601 date`);
+    }
+
+    if (!Array.isArray(a.dimensions) || a.dimensions.length !== 4) {
+      errors.push(`${prefix}: dimensions must be array of exactly 4 objects`);
+    } else {
+      for (let d = 0; d < 4; d++) {
+        const dim = a.dimensions[d];
+        const dp = `${prefix} dim[${d}]`;
+
+        if (!Array.isArray(dim.poles) || dim.poles.length !== 2) {
+          errors.push(`${dp}: poles must be array of 2 strings`);
+          continue;
+        }
+
+        if (dim.poles[0] !== EXPECTED_POLES[d][0] || dim.poles[1] !== EXPECTED_POLES[d][1]) {
+          errors.push(`${dp}: poles must be [${EXPECTED_POLES[d]}], got [${dim.poles}]`);
+        }
+
+        if (!Number.isInteger(dim.score) || dim.score < 0 || dim.score > 4) {
+          errors.push(`${dp}: score must be integer 0-4`);
+        }
+
+        if (!Number.isInteger(dim.max) || dim.max < 1) {
+          errors.push(`${dp}: max must be positive integer`);
+        }
+
+      }
+
+      if (typeof a.type === 'string' && a.type.length === 4 &&
+          Array.isArray(a.scores) && a.scores.length === 4 &&
+          a.dimensions.every(dim => Number.isInteger(dim.max))) {
+        const derived = a.dimensions.map((dim, d) =>
+          a.scores[d] >= dim.max / 2 ? dim.poles[0] : dim.poles[1]
+        ).join('');
+        if (derived !== a.type) {
+          warnings.push(`${prefix}: type "${a.type}" doesn't match derived "${derived}"`);
+        }
+      }
+    }
+  }
+
+  return { errors, warnings };
+}
+
+if (require.main === module) {
+  const filePath = process.argv[2] || path.join(__dirname, '..', 'data', 'results.json');
+  const raw = fs.readFileSync(filePath, 'utf8');
+  const data = JSON.parse(raw);
+  const { errors, warnings } = validate(data);
+
+  if (warnings.length) {
+    console.warn(`${warnings.length} warning(s):`);
+    warnings.forEach(w => console.warn(`  ⚠ ${w}`));
+  }
+
+  if (errors.length) {
+    console.error(`Validation failed with ${errors.length} error(s):`);
+    errors.forEach(e => console.error(`  - ${e}`));
+    process.exit(1);
+  }
+
+  console.log(`OK: ${data.agents.length} agents validated`);
+  process.exit(0);
+}
+
+module.exports = { validate };

--- a/test/validate-results.test.js
+++ b/test/validate-results.test.js
@@ -1,0 +1,79 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const { validate } = require('../scripts/validate-results.js');
+
+function makeAgent(overrides = {}) {
+  return {
+    name: 'Test Agent',
+    slug: 'test-agent',
+    type: 'PTCF',
+    nick: 'The Tester',
+    testedAt: '2026-05-04T00:00:00.000Z',
+    scores: [3, 3, 3, 3],
+    dimensions: [
+      { poles: ['P', 'R'], score: 3, max: 4 },
+      { poles: ['T', 'E'], score: 3, max: 4 },
+      { poles: ['C', 'D'], score: 3, max: 4 },
+      { poles: ['F', 'N'], score: 3, max: 4 },
+    ],
+    ...overrides,
+  };
+}
+
+describe('validate-results', () => {
+  it('passes on actual results.json', () => {
+    const data = require(path.join(__dirname, '..', 'data', 'results.json'));
+    const { errors } = validate(data);
+    assert.deepStrictEqual(errors, [], `Unexpected errors:\n${errors.join('\n')}`);
+  });
+
+  it('rejects non-object top level', () => {
+    assert.ok(validate(null).errors.length > 0);
+    assert.ok(validate({ agents: 'nope' }).errors.length > 0);
+  });
+
+  it('rejects missing required fields', () => {
+    const { errors } = validate({ agents: [{ slug: 'x' }] });
+    assert.ok(errors.some(e => e.includes('name')));
+    assert.ok(errors.some(e => e.includes('nick')));
+    assert.ok(errors.some(e => e.includes('type')));
+    assert.ok(errors.some(e => e.includes('scores')));
+  });
+
+  it('rejects invalid slug', () => {
+    const { errors } = validate({ agents: [makeAgent({ slug: 'Bad Slug!' })] });
+    assert.ok(errors.some(e => e.includes('slug')));
+  });
+
+  it('rejects duplicate slugs', () => {
+    const { errors } = validate({
+      agents: [makeAgent({ slug: 'dupe' }), makeAgent({ slug: 'dupe', name: 'Other' })],
+    });
+    assert.ok(errors.some(e => e.includes('duplicate slug')));
+  });
+
+  it('warns on wrong type derivation', () => {
+    const { warnings } = validate({
+      agents: [makeAgent({ type: 'RECN' })],
+    });
+    assert.ok(warnings.some(w => w.includes("doesn't match derived")));
+  });
+
+  it('rejects bad dimensions format', () => {
+    const { errors } = validate({
+      agents: [makeAgent({ dimensions: [{ poles: ['X'] }] })],
+    });
+    assert.ok(errors.length > 0);
+  });
+
+  it('rejects invalid testedAt', () => {
+    const { errors } = validate({ agents: [makeAgent({ testedAt: 'not-a-date' })] });
+    assert.ok(errors.some(e => e.includes('testedAt')));
+  });
+
+  it('accepts valid agent with no errors', () => {
+    const { errors } = validate({ agents: [makeAgent()] });
+    assert.deepStrictEqual(errors, []);
+  });
+});


### PR DESCRIPTION
Closes #449

## What
Adds a validation script and tests for `data/results.json` schema integrity.

### New files
- **`scripts/validate-results.js`** — validates structure (required fields, slug format/uniqueness, dimensions array, scores array, ISO-8601 dates). Type derivation mismatches are reported as warnings.
- **`test/validate-results.test.js`** — 9 tests covering real data + edge cases (bad slug, duplicate slugs, missing fields, wrong type derivation, bad dimensions format, invalid dates)

### Changes
- **`package.json`** — added `validate` script; added test file to test list
- **`.github/workflows/test.yml`** — added `npm run validate` step after `npm test`

## Notes
- Uses `node:test` and `node:assert` (no external deps), matching existing test style
- Found a genuine data issue: `phi-4-mini-reasoning` type says `PTDF` but scores derive `RTCF` — reported as warning, not blocking error
- All 277 tests pass