### PR TITLE
test: add proxy.js sync check between lib/ and cli/lib/ (#330)

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "abti",
   "private": true,
   "scripts": {
-    "test": "node --test test/api.test.js test/mcp.test.js test/mcp-http.test.js test/compatibility.test.js test/cross-compatibility.test.js test/auto-reload.test.js test/parseAnswer.test.js test/provider.test.js test/resume.test.js test/list.test.js test/action-drift.test.js test/all-flag.test.js test/feed.test.js test/dynamic-models.test.js test/history.test.js test/shuffle.test.js test/compare.test.js test/info.test.js test/history-cli.test.js test/skip-existing.test.js test/validate-results.test.js",
+    "test": "node --test test/api.test.js test/mcp.test.js test/mcp-http.test.js test/compatibility.test.js test/cross-compatibility.test.js test/auto-reload.test.js test/parseAnswer.test.js test/provider.test.js test/resume.test.js test/list.test.js test/action-drift.test.js test/all-flag.test.js test/feed.test.js test/dynamic-models.test.js test/history.test.js test/shuffle.test.js test/compare.test.js test/info.test.js test/history-cli.test.js test/skip-existing.test.js test/validate-results.test.js test/proxy-sync.test.js",
     "generate-og": "node scripts/generate-og-images.js",
     "generate-sitemap": "node scripts/generate-sitemap.js",
     "generate-og-agents": "node scripts/generate-agent-og.js",

--- a/test/proxy-sync.test.js
+++ b/test/proxy-sync.test.js
@@ -1,0 +1,13 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+describe('proxy.js sync (issue #330)', () => {
+  it('lib/proxy.js and cli/lib/proxy.js must be identical', () => {
+    const root = path.resolve(__dirname, '..');
+    const a = fs.readFileSync(path.join(root, 'lib', 'proxy.js'), 'utf8');
+    const b = fs.readFileSync(path.join(root, 'cli', 'lib', 'proxy.js'), 'utf8');
+    assert.equal(a, b, 'lib/proxy.js and cli/lib/proxy.js have diverged — copy the updated file to both locations');
+  });
+});


### PR DESCRIPTION
Closes #330

Adds `test/proxy-sync.test.js` that asserts `lib/proxy.js` and `cli/lib/proxy.js` are byte-identical (Option 3 from the issue). If either file is edited without updating the other, the test fails.

Added to the `npm test` script.

- [x] 270 tests pass (269 existing + 1 new)
- [x] No changes to proxy.js files themselves