### PR TITLE
seo: add meta description tags to all HTML pages

### DIFF
--- a/agent.html
+++ b/agent.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="description" content="View detailed ABTI behavioral profile for this AI agent, including personality type breakdown, trait scores, and comparison with other tested models.">
 <title>Agent — ABTI</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/agents.html
+++ b/agents.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="description" content="Browse all AI agents tested with the ABTI framework. View behavioral profiles, personality types, and test results for leading AI models and agents.">
 <title>Agents — ABTI</title>
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Agents — ABTI">

--- a/api.html
+++ b/api.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="description" content="ABTI API documentation. Access AI agent behavioral type data, test results, and personality profiles programmatically via RESTful JSON endpoints.">
 <title>ABTI — Agent API</title>
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="ABTI — Agent API">

--- a/compare-agents.html
+++ b/compare-agents.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="description" content="Compare AI agents head-to-head using ABTI behavioral profiles. See how different models score across personality traits and type classifications.">
 <title>Compare Agents — ABTI</title>
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Compare Agents — ABTI">

--- a/compare.html
+++ b/compare.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="description" content="Compare ABTI personality types side by side. Analyze differences in behavioral traits, strengths, and interaction styles between AI agent types.">
 <title>Compare Types — ABTI</title>
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Compare Types — ABTI">

--- a/compatibility.html
+++ b/compatibility.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="description" content="Check ABTI type compatibility between AI agents. Discover which behavioral personality types work best together for multi-agent collaboration.">
 <title>Type Compatibility — ABTI</title>
 <meta property="og:title" content="Type Compatibility — ABTI">
 <meta property="og:description" content="Explore how different AI agent behavioral types work together — compatibility matrix for all 16 ABTI types">

--- a/cross-compatibility.html
+++ b/cross-compatibility.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="description" content="Find your ideal AI agent match with ABTI cross-compatibility analysis. Match your personality type with the most compatible AI behavioral profiles.">
 <title>Find Your Agent Match — ABTI</title>
 <meta property="og:title" content="Find Your Agent Match — ABTI">
 <meta property="og:description" content="Discover which AI agent type best complements your MBTI personality — Human × Agent cross-compatibility">

--- a/embed.html
+++ b/embed.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=320,initial-scale=1">
+<meta name="description" content="Embeddable ABTI agent personality card. Display AI agent behavioral type results as a compact widget on your website or documentation pages.">
 <title>ABTI Embed</title>
 <style>
 *{margin:0;padding:0;box-sizing:border-box}

--- a/families.html
+++ b/families.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="description" content="Explore AI model families tested with the ABTI framework. Compare behavioral type patterns across GPT, Claude, Gemini, and other model lineages.">
 <title>Model Families — ABTI</title>
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Model Families — ABTI">

--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="description" content="ABTI — Agent Behavioral Type Indicator. Discover the personality types of AI agents through structured behavioral testing across 16 distinct dimensions.">
 <title>ABTI — Agent Behavioral Type Indicator</title>
 <link rel="alternate" type="application/atom+xml" href="/feed.xml" title="ABTI Agent Feed">
 <meta property="og:type" content="website">

--- a/leaderboard.html
+++ b/leaderboard.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="description" content="ABTI leaderboard ranking AI agents by behavioral trait scores. Compare top-performing models across autonomy, reasoning, and other key dimensions.">
 <title>Leaderboard — ABTI</title>
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Agent Leaderboard — ABTI">

--- a/methodology.html
+++ b/methodology.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="description" content="Learn how the ABTI framework tests AI agent personalities. Understand the methodology behind behavioral type classification and scoring criteria.">
 <title>Methodology — ABTI</title>
 <meta property="og:type" content="website">
 <meta property="og:title" content="Methodology — ABTI">

--- a/sbti.html
+++ b/sbti.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="description" content="SBTI — the silly spin-off of ABTI. Take a humorous behavioral type test for AI agents with playful personality classifications and fun results.">
 <title>SBTI-AI — Silly Behavioral Type Indicator</title>
 <meta property="og:type" content="website">
 <meta property="og:title" content="SBTI-AI 傻大个性格测试 · AI Agent 版 🦞">

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,47 +2,47 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://abti.kagura-agent.com/agent.html</loc>
-    <lastmod>2026-05-26</lastmod>
+    <lastmod>2026-05-29</lastmod>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agents.html</loc>
-    <lastmod>2026-05-26</lastmod>
+    <lastmod>2026-05-29</lastmod>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/api.html</loc>
-    <lastmod>2026-05-26</lastmod>
+    <lastmod>2026-05-29</lastmod>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/compare-agents.html</loc>
-    <lastmod>2026-05-26</lastmod>
+    <lastmod>2026-05-29</lastmod>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/compare.html</loc>
-    <lastmod>2026-05-26</lastmod>
+    <lastmod>2026-05-29</lastmod>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/compatibility.html</loc>
-    <lastmod>2026-05-26</lastmod>
+    <lastmod>2026-05-29</lastmod>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/cross-compatibility.html</loc>
-    <lastmod>2026-05-26</lastmod>
+    <lastmod>2026-05-29</lastmod>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/families.html</loc>
-    <lastmod>2026-05-26</lastmod>
+    <lastmod>2026-05-29</lastmod>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/</loc>
-    <lastmod>2026-05-26</lastmod>
+    <lastmod>2026-05-29</lastmod>
     <priority>1.0</priority>
   </url>
   <url>
@@ -52,427 +52,427 @@
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/leaderboard.html</loc>
-    <lastmod>2026-05-26</lastmod>
+    <lastmod>2026-05-29</lastmod>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/sbti.html</loc>
-    <lastmod>2026-05-26</lastmod>
+    <lastmod>2026-05-29</lastmod>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/share-card.html</loc>
-    <lastmod>2026-05-26</lastmod>
+    <lastmod>2026-05-29</lastmod>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/stats.html</loc>
-    <lastmod>2026-05-26</lastmod>
+    <lastmod>2026-05-29</lastmod>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/test-agent.html</loc>
-    <lastmod>2026-05-26</lastmod>
+    <lastmod>2026-05-29</lastmod>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/type.html</loc>
-    <lastmod>2026-05-26</lastmod>
+    <lastmod>2026-05-29</lastmod>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/types.html</loc>
-    <lastmod>2026-05-26</lastmod>
+    <lastmod>2026-05-29</lastmod>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/llama-3-2-3b</loc>
-    <lastmod>2026-05-26</lastmod>
+    <lastmod>2026-05-29</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/qwen-2-5-3b</loc>
-    <lastmod>2026-05-26</lastmod>
+    <lastmod>2026-05-29</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/qwen-2-5-7b</loc>
-    <lastmod>2026-05-26</lastmod>
+    <lastmod>2026-05-29</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/kagura-opus-4-7</loc>
-    <lastmod>2026-05-26</lastmod>
+    <lastmod>2026-05-29</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/claude-opus-4-7</loc>
-    <lastmod>2026-05-26</lastmod>
+    <lastmod>2026-05-29</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/gemma-3-4b</loc>
-    <lastmod>2026-05-26</lastmod>
+    <lastmod>2026-05-29</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/phi-4-mini</loc>
-    <lastmod>2026-05-26</lastmod>
+    <lastmod>2026-05-29</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/mistral-7b</loc>
-    <lastmod>2026-05-26</lastmod>
+    <lastmod>2026-05-29</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/deepseek-r1-7b</loc>
-    <lastmod>2026-05-26</lastmod>
+    <lastmod>2026-05-29</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/llama-3-1-8b</loc>
-    <lastmod>2026-05-26</lastmod>
+    <lastmod>2026-05-29</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/gpt-4-1</loc>
-    <lastmod>2026-05-26</lastmod>
+    <lastmod>2026-05-29</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/gpt-5-mini</loc>
-    <lastmod>2026-05-26</lastmod>
+    <lastmod>2026-05-29</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/gpt-4o</loc>
-    <lastmod>2026-05-26</lastmod>
+    <lastmod>2026-05-29</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/gpt-4o-mini</loc>
-    <lastmod>2026-05-26</lastmod>
+    <lastmod>2026-05-29</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/gpt-5-2</loc>
-    <lastmod>2026-05-26</lastmod>
+    <lastmod>2026-05-29</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/claude-sonnet-4-5</loc>
-    <lastmod>2026-05-26</lastmod>
+    <lastmod>2026-05-29</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/claude-sonnet-4-6</loc>
-    <lastmod>2026-05-26</lastmod>
+    <lastmod>2026-05-29</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/claude-haiku-4-5</loc>
-    <lastmod>2026-05-26</lastmod>
+    <lastmod>2026-05-29</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/llama-3-1-405b</loc>
-    <lastmod>2026-05-26</lastmod>
+    <lastmod>2026-05-29</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/llama-4-scout-17b</loc>
-    <lastmod>2026-05-26</lastmod>
+    <lastmod>2026-05-29</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/cohere-command-a</loc>
-    <lastmod>2026-05-26</lastmod>
+    <lastmod>2026-05-29</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/ministral-3b</loc>
-    <lastmod>2026-05-26</lastmod>
+    <lastmod>2026-05-29</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/phi-4</loc>
-    <lastmod>2026-05-26</lastmod>
+    <lastmod>2026-05-29</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/phi-4-multimodal</loc>
-    <lastmod>2026-05-26</lastmod>
+    <lastmod>2026-05-29</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/llama-3-3-70b</loc>
-    <lastmod>2026-05-26</lastmod>
+    <lastmod>2026-05-29</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/llama-4-maverick-17b</loc>
-    <lastmod>2026-05-26</lastmod>
+    <lastmod>2026-05-29</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/mistral-small-3-1</loc>
-    <lastmod>2026-05-26</lastmod>
+    <lastmod>2026-05-29</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/cohere-command-r-plus</loc>
-    <lastmod>2026-05-26</lastmod>
+    <lastmod>2026-05-29</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/mistral-medium-3</loc>
-    <lastmod>2026-05-26</lastmod>
+    <lastmod>2026-05-29</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/llama-3-2-90b-vision</loc>
-    <lastmod>2026-05-26</lastmod>
+    <lastmod>2026-05-29</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/llama-3-2-11b-vision</loc>
-    <lastmod>2026-05-26</lastmod>
+    <lastmod>2026-05-29</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/codestral-mistral</loc>
-    <lastmod>2026-05-26</lastmod>
+    <lastmod>2026-05-29</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/cohere-command-r</loc>
-    <lastmod>2026-05-26</lastmod>
+    <lastmod>2026-05-29</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/granite-3-3-8b</loc>
-    <lastmod>2026-05-26</lastmod>
+    <lastmod>2026-05-29</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/aya-expanse-8b</loc>
-    <lastmod>2026-05-26</lastmod>
+    <lastmod>2026-05-29</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/gemma2-2b</loc>
-    <lastmod>2026-05-26</lastmod>
+    <lastmod>2026-05-29</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/yi-6b</loc>
-    <lastmod>2026-05-26</lastmod>
+    <lastmod>2026-05-29</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/solar-10-7b</loc>
-    <lastmod>2026-05-26</lastmod>
+    <lastmod>2026-05-29</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/dolphin-mistral-7b</loc>
-    <lastmod>2026-05-26</lastmod>
+    <lastmod>2026-05-29</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/gpt-4-1-mini</loc>
-    <lastmod>2026-05-26</lastmod>
+    <lastmod>2026-05-29</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/gpt-4-1-nano</loc>
-    <lastmod>2026-05-26</lastmod>
+    <lastmod>2026-05-29</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/smollm2-1-7b</loc>
-    <lastmod>2026-05-26</lastmod>
+    <lastmod>2026-05-29</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/exaone-3-5-2-4b</loc>
-    <lastmod>2026-05-26</lastmod>
+    <lastmod>2026-05-29</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/falcon-3-3b</loc>
-    <lastmod>2026-05-26</lastmod>
+    <lastmod>2026-05-29</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/qwen-3-4b</loc>
-    <lastmod>2026-05-26</lastmod>
+    <lastmod>2026-05-29</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/qwen-3-1-7b</loc>
-    <lastmod>2026-05-26</lastmod>
+    <lastmod>2026-05-29</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/phi-4-mini-reasoning</loc>
-    <lastmod>2026-05-26</lastmod>
+    <lastmod>2026-05-29</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/internlm2-7b</loc>
-    <lastmod>2026-05-26</lastmod>
+    <lastmod>2026-05-29</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/stablelm-2-1-6b</loc>
-    <lastmod>2026-05-26</lastmod>
+    <lastmod>2026-05-29</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/qwen-3-8b</loc>
-    <lastmod>2026-05-26</lastmod>
+    <lastmod>2026-05-29</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/glm4-9b</loc>
-    <lastmod>2026-05-26</lastmod>
+    <lastmod>2026-05-29</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/gemma-3-12b</loc>
-    <lastmod>2026-05-26</lastmod>
+    <lastmod>2026-05-29</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/tinyllama</loc>
-    <lastmod>2026-05-26</lastmod>
+    <lastmod>2026-05-29</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/mathstral-7b</loc>
-    <lastmod>2026-05-26</lastmod>
+    <lastmod>2026-05-29</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/nemotron-mini-4b</loc>
-    <lastmod>2026-05-26</lastmod>
+    <lastmod>2026-05-29</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/qwen3-32b</loc>
-    <lastmod>2026-05-26</lastmod>
+    <lastmod>2026-05-29</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/deepseek-r1</loc>
-    <lastmod>2026-05-26</lastmod>
+    <lastmod>2026-05-29</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/deepseek-r1-0528</loc>
-    <lastmod>2026-05-26</lastmod>
+    <lastmod>2026-05-29</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/codestral-2501</loc>
-    <lastmod>2026-05-26</lastmod>
+    <lastmod>2026-05-29</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/mistral-medium-2505</loc>
-    <lastmod>2026-05-26</lastmod>
+    <lastmod>2026-05-29</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/mistral-small-2503</loc>
-    <lastmod>2026-05-26</lastmod>
+    <lastmod>2026-05-29</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/claude-opus-4-6</loc>
-    <lastmod>2026-05-26</lastmod>
+    <lastmod>2026-05-29</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/type/PTCF</loc>
-    <lastmod>2026-05-26</lastmod>
+    <lastmod>2026-05-29</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/type/PTCN</loc>
-    <lastmod>2026-05-26</lastmod>
+    <lastmod>2026-05-29</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/type/PTDF</loc>
-    <lastmod>2026-05-26</lastmod>
+    <lastmod>2026-05-29</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/type/PTDN</loc>
-    <lastmod>2026-05-26</lastmod>
+    <lastmod>2026-05-29</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/type/PECF</loc>
-    <lastmod>2026-05-26</lastmod>
+    <lastmod>2026-05-29</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/type/PECN</loc>
-    <lastmod>2026-05-26</lastmod>
+    <lastmod>2026-05-29</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/type/PEDF</loc>
-    <lastmod>2026-05-26</lastmod>
+    <lastmod>2026-05-29</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/type/PEDN</loc>
-    <lastmod>2026-05-26</lastmod>
+    <lastmod>2026-05-29</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/type/RTCF</loc>
-    <lastmod>2026-05-26</lastmod>
+    <lastmod>2026-05-29</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/type/RTCN</loc>
-    <lastmod>2026-05-26</lastmod>
+    <lastmod>2026-05-29</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/type/RTDF</loc>
-    <lastmod>2026-05-26</lastmod>
+    <lastmod>2026-05-29</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/type/RTDN</loc>
-    <lastmod>2026-05-26</lastmod>
+    <lastmod>2026-05-29</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/type/RECF</loc>
-    <lastmod>2026-05-26</lastmod>
+    <lastmod>2026-05-29</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/type/RECN</loc>
-    <lastmod>2026-05-26</lastmod>
+    <lastmod>2026-05-29</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/type/REDF</loc>
-    <lastmod>2026-05-26</lastmod>
+    <lastmod>2026-05-29</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/type/REDN</loc>
-    <lastmod>2026-05-26</lastmod>
+    <lastmod>2026-05-29</lastmod>
     <priority>0.6</priority>
   </url>
 </urlset>

--- a/stats.html
+++ b/stats.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="description" content="ABTI statistics and analytics. Explore aggregate data on AI agent behavioral types, trait distributions, and trends across all tested models.">
 <title>Stats — ABTI</title>
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Stats — ABTI">

--- a/test-agent.html
+++ b/test-agent.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="description" content="Run the ABTI behavioral personality test on your own AI agent. Submit an API key and endpoint to classify your model into one of 16 agent types.">
 <title>Test Your Agent — ABTI</title>
 <meta property="og:type" content="website">
 <meta property="og:title" content="Test Your Agent — ABTI">

--- a/type.html
+++ b/type.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="description" content="Deep dive into this ABTI personality type. See defining traits, behavioral patterns, strengths, and which AI agents share this type classification.">
 <title>Type — ABTI</title>
 <!-- twitter/OG meta tags injected dynamically by api-server.js with type-specific images -->
 <script type="application/ld+json">

--- a/types.html
+++ b/types.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="description" content="Explore all 16 ABTI personality types for AI agents. Learn how each behavioral type is defined by traits like autonomy, reasoning, and creativity.">
 <title>All Types — ABTI</title>
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="All Types — ABTI">


### PR DESCRIPTION
## Summary
Adds `<meta name="description">` tags to all 17 active HTML pages. Each description is unique, English, includes the 'ABTI' keyword, and stays within 150-160 characters.

Also updates sitemap.xml lastmod dates to 2026-05-29.

## Why
All pages were missing meta description tags, which search engines use for result snippets. Without them, Google auto-extracts text (often suboptimal). Better SEO → more organic discovery → more agents tested.

## Pages updated
index, agents, agent, types, type, stats, leaderboard, methodology, api, compare, compare-agents, compatibility, cross-compatibility, families, test-agent, sbti, embed

## Not modified
index-v2, index-v3, index-v4, share-card (legacy/utility pages)

Fixes #457