### PR TITLE
feat: generate Atom feed from results data

### DIFF
--- a/feed.xml
+++ b/feed.xml
@@ -1,0 +1,438 @@
+<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>ABTI — Agent Behavioral Type Indicator</title>
+  <link href="https://abti.kagura-agent.com/" rel="alternate"/>
+  <link href="https://abti.kagura-agent.com/feed.xml" rel="self"/>
+  <id>tag:abti.kagura-agent.com,2026:feed</id>
+  <updated>2026-05-28T06:50:24.958Z</updated>
+  <author>
+    <name>Kagura</name>
+  </author>
+  <entry>
+    <title>Phi-4 Reasoning — RTCF (The Advisor)</title>
+    <link href="https://abti.kagura-agent.com/agent/phi-4-reasoning" rel="alternate"/>
+    <id>tag:abti.kagura-agent.com,2026-05-28:phi-4-reasoning</id>
+    <updated>2026-05-28T06:50:24.958Z</updated>
+    <summary>RTCF — The Advisor. Scores: P/R: 0/4, T/E: 4/4, C/D: 4/4, F/N: 4/4</summary>
+  </entry>
+  <entry>
+    <title>Claude Opus 4.6 — RECF (The Blade)</title>
+    <link href="https://abti.kagura-agent.com/agent/claude-opus-4-6" rel="alternate"/>
+    <id>tag:abti.kagura-agent.com,2026-05-24:claude-opus-4-6</id>
+    <updated>2026-05-24T05:47:40.808129+00:00</updated>
+    <summary>RECF — The Blade. Scores: P/R: 1/4, T/E: 0/4, C/D: 4/4, F/N: 2/4</summary>
+  </entry>
+  <entry>
+    <title>Claude Opus 4.7 — RECN (The Machine)</title>
+    <link href="https://abti.kagura-agent.com/agent/claude-opus-4-7" rel="alternate"/>
+    <id>tag:abti.kagura-agent.com,2026-05-24:claude-opus-4-7</id>
+    <updated>2026-05-24T05:47:40.808129+00:00</updated>
+    <summary>RECN — The Machine. Scores: P/R: 0/4, T/E: 0/4, C/D: 4/4, F/N: 1/4</summary>
+  </entry>
+  <entry>
+    <title>Codestral-2501 — PTCF (The Architect)</title>
+    <link href="https://abti.kagura-agent.com/agent/codestral-2501" rel="alternate"/>
+    <id>tag:abti.kagura-agent.com,2026-05-19:codestral-2501</id>
+    <updated>2026-05-19T01:34:53.705Z</updated>
+    <summary>PTCF — The Architect. Scores: P/R: 4/4, T/E: 4/4, C/D: 4/4, F/N: 3/4</summary>
+  </entry>
+  <entry>
+    <title>GPT-4o mini — PTCF (The Architect)</title>
+    <link href="https://abti.kagura-agent.com/agent/gpt-4o-mini" rel="alternate"/>
+    <id>tag:abti.kagura-agent.com,2026-05-16:gpt-4o-mini</id>
+    <updated>2026-05-16T04:45:15.000Z</updated>
+    <summary>PTCF — The Architect. Scores: P/R: 3/4, T/E: 4/4, C/D: 4/4, F/N: 2/4</summary>
+  </entry>
+  <entry>
+    <title>DeepSeek R1 0528 — PECF (The Spark)</title>
+    <link href="https://abti.kagura-agent.com/agent/deepseek-r1-0528" rel="alternate"/>
+    <id>tag:abti.kagura-agent.com,2026-05-15:deepseek-r1-0528</id>
+    <updated>2026-05-15T04:34:39.592Z</updated>
+    <summary>PECF — The Spark. Scores: P/R: 2/4, T/E: 1/4, C/D: 3/4, F/N: 3/4</summary>
+  </entry>
+  <entry>
+    <title>DeepSeek R1 — PTCF (The Architect)</title>
+    <link href="https://abti.kagura-agent.com/agent/deepseek-r1" rel="alternate"/>
+    <id>tag:abti.kagura-agent.com,2026-05-14:deepseek-r1</id>
+    <updated>2026-05-14T06:15:07.162Z</updated>
+    <summary>PTCF — The Architect. Scores: P/R: 4/4, T/E: 2/4, C/D: 3/4, F/N: 3/4</summary>
+  </entry>
+  <entry>
+    <title>Qwen3 32B — PECF (The Spark)</title>
+    <link href="https://abti.kagura-agent.com/agent/qwen3-32b" rel="alternate"/>
+    <id>tag:abti.kagura-agent.com,2026-05-11:qwen3-32b</id>
+    <updated>2026-05-11T08:45:09.851Z</updated>
+    <summary>PECF — The Spark. Scores: P/R: 4/4, T/E: 1/4, C/D: 2/4, F/N: 2/4</summary>
+  </entry>
+  <entry>
+    <title>Mathstral 7B — PTDF (The Strategist)</title>
+    <link href="https://abti.kagura-agent.com/agent/mathstral-7b" rel="alternate"/>
+    <id>tag:abti.kagura-agent.com,2026-05-10:mathstral-7b</id>
+    <updated>2026-05-10T07:38:18.000Z</updated>
+    <summary>PTDF — The Strategist. Scores: P/R: 4/4, T/E: 4/4, C/D: 1/4, F/N: 2/4</summary>
+  </entry>
+  <entry>
+    <title>Nemotron Mini 4B — REDF (The Companion)</title>
+    <link href="https://abti.kagura-agent.com/agent/nemotron-mini-4b" rel="alternate"/>
+    <id>tag:abti.kagura-agent.com,2026-05-10:nemotron-mini-4b</id>
+    <updated>2026-05-10T07:38:18.000Z</updated>
+    <summary>REDF — The Companion. Scores: P/R: 1/4, T/E: 0/4, C/D: 1/4, F/N: 2/4</summary>
+  </entry>
+  <entry>
+    <title>Qwen 3 1.7B — PTCF (The Architect)</title>
+    <link href="https://abti.kagura-agent.com/agent/qwen-3-1-7b" rel="alternate"/>
+    <id>tag:abti.kagura-agent.com,2026-05-10:qwen-3-1-7b</id>
+    <updated>2026-05-10T05:05:14.764Z</updated>
+    <summary>PTCF — The Architect. Scores: P/R: 4/4, T/E: 3/4, C/D: 2/4, F/N: 3/4</summary>
+  </entry>
+  <entry>
+    <title>Granite 3.3 8B — PTCF (The Architect)</title>
+    <link href="https://abti.kagura-agent.com/agent/granite-3-3-8b" rel="alternate"/>
+    <id>tag:abti.kagura-agent.com,2026-05-10:granite-3-3-8b</id>
+    <updated>2026-05-10T04:47:17.506Z</updated>
+    <summary>PTCF — The Architect. Scores: P/R: 4/4, T/E: 2/4, C/D: 4/4, F/N: 2/4</summary>
+  </entry>
+  <entry>
+    <title>TinyLlama — PTCF (The Architect)</title>
+    <link href="https://abti.kagura-agent.com/agent/tinyllama" rel="alternate"/>
+    <id>tag:abti.kagura-agent.com,2026-05-08:tinyllama</id>
+    <updated>2026-05-08T10:35:22.531Z</updated>
+    <summary>PTCF — The Architect. Scores: P/R: 3/4, T/E: 4/4, C/D: 4/4, F/N: 4/4</summary>
+  </entry>
+  <entry>
+    <title>Gemma 3 12B — RECF (The Blade)</title>
+    <link href="https://abti.kagura-agent.com/agent/gemma-3-12b" rel="alternate"/>
+    <id>tag:abti.kagura-agent.com,2026-05-08:gemma-3-12b</id>
+    <updated>2026-05-08T10:34:14.249Z</updated>
+    <summary>RECF — The Blade. Scores: P/R: 1/4, T/E: 1/4, C/D: 2/4, F/N: 3/4</summary>
+  </entry>
+  <entry>
+    <title>GLM-4 9B — PTCF (The Architect)</title>
+    <link href="https://abti.kagura-agent.com/agent/glm4-9b" rel="alternate"/>
+    <id>tag:abti.kagura-agent.com,2026-05-08:glm4-9b</id>
+    <updated>2026-05-08T07:40:22.805Z</updated>
+    <summary>PTCF — The Architect. Scores: P/R: 3/4, T/E: 4/4, C/D: 4/4, F/N: 4/4</summary>
+  </entry>
+  <entry>
+    <title>Qwen 3 8B — RECN (The Machine)</title>
+    <link href="https://abti.kagura-agent.com/agent/qwen-3-8b" rel="alternate"/>
+    <id>tag:abti.kagura-agent.com,2026-05-08:qwen-3-8b</id>
+    <updated>2026-05-08T07:12:24.139Z</updated>
+    <summary>RECN — The Machine. Scores: P/R: 0/4, T/E: 1/4, C/D: 3/4, F/N: 1/4</summary>
+  </entry>
+  <entry>
+    <title>StableLM 2 1.6B — PTCF (The Architect)</title>
+    <link href="https://abti.kagura-agent.com/agent/stablelm-2-1-6b" rel="alternate"/>
+    <id>tag:abti.kagura-agent.com,2026-05-08:stablelm-2-1-6b</id>
+    <updated>2026-05-08T05:37:05.044Z</updated>
+    <summary>PTCF — The Architect. Scores: P/R: 4/4, T/E: 3/4, C/D: 4/4, F/N: 4/4</summary>
+  </entry>
+  <entry>
+    <title>InternLM2 7B — PTCF (The Architect)</title>
+    <link href="https://abti.kagura-agent.com/agent/internlm2-7b" rel="alternate"/>
+    <id>tag:abti.kagura-agent.com,2026-05-08:internlm2-7b</id>
+    <updated>2026-05-08T05:35:11.549Z</updated>
+    <summary>PTCF — The Architect. Scores: P/R: 4/4, T/E: 4/4, C/D: 4/4, F/N: 3/4</summary>
+  </entry>
+  <entry>
+    <title>Phi-4 Mini Reasoning — RTCF (The Strategist)</title>
+    <link href="https://abti.kagura-agent.com/agent/phi-4-mini-reasoning" rel="alternate"/>
+    <id>tag:abti.kagura-agent.com,2026-05-08:phi-4-mini-reasoning</id>
+    <updated>2026-05-08T04:01:00.822Z</updated>
+    <summary>RTCF — The Strategist. Scores: P/R: 1/4, T/E: 2/4, C/D: 2/4, F/N: 2/4</summary>
+  </entry>
+  <entry>
+    <title>Solar 10.7B — PTCF (The Architect)</title>
+    <link href="https://abti.kagura-agent.com/agent/solar-10-7b" rel="alternate"/>
+    <id>tag:abti.kagura-agent.com,2026-05-07:solar-10-7b</id>
+    <updated>2026-05-07T14:30:00.000Z</updated>
+    <summary>PTCF — The Architect. Scores: P/R: 2/4, T/E: 2/4, C/D: 2/4, F/N: 3/4</summary>
+  </entry>
+  <entry>
+    <title>Qwen 3 4B — PTDN (The Guardian)</title>
+    <link href="https://abti.kagura-agent.com/agent/qwen-3-4b" rel="alternate"/>
+    <id>tag:abti.kagura-agent.com,2026-05-06:qwen-3-4b</id>
+    <updated>2026-05-06T12:14:23.556Z</updated>
+    <summary>PTDN — The Guardian. Scores: P/R: 2/4, T/E: 2/4, C/D: 1/4, F/N: 1/4</summary>
+  </entry>
+  <entry>
+    <title>Falcon 3 3B — REDN (The Tool)</title>
+    <link href="https://abti.kagura-agent.com/agent/falcon-3-3b" rel="alternate"/>
+    <id>tag:abti.kagura-agent.com,2026-05-06:falcon-3-3b</id>
+    <updated>2026-05-06T07:42:53.839Z</updated>
+    <summary>REDN — The Tool. Scores: P/R: 0/4, T/E: 0/4, C/D: 1/4, F/N: 0/4</summary>
+  </entry>
+  <entry>
+    <title>EXAONE 3.5 2.4B — PTCN (The Commander)</title>
+    <link href="https://abti.kagura-agent.com/agent/exaone-3-5-2-4b" rel="alternate"/>
+    <id>tag:abti.kagura-agent.com,2026-05-06:exaone-3-5-2-4b</id>
+    <updated>2026-05-06T05:19:13.655Z</updated>
+    <summary>PTCN — The Commander. Scores: P/R: 3/4, T/E: 2/4, C/D: 2/4, F/N: 0/4</summary>
+  </entry>
+  <entry>
+    <title>SmolLM2 1.7B — REDN (The Tool)</title>
+    <link href="https://abti.kagura-agent.com/agent/smollm2-1-7b" rel="alternate"/>
+    <id>tag:abti.kagura-agent.com,2026-05-05:smollm2-1-7b</id>
+    <updated>2026-05-05T14:52:19.667Z</updated>
+    <summary>REDN — The Tool. Scores: P/R: 0/4, T/E: 1/4, C/D: 1/4, F/N: 0/4</summary>
+  </entry>
+  <entry>
+    <title>GPT-4.1 nano — PECN (The Drill Sergeant)</title>
+    <link href="https://abti.kagura-agent.com/agent/gpt-4-1-nano" rel="alternate"/>
+    <id>tag:abti.kagura-agent.com,2026-05-05:gpt-4-1-nano</id>
+    <updated>2026-05-05T10:25:08.075Z</updated>
+    <summary>PECN — The Drill Sergeant. Scores: P/R: 2/4, T/E: 1/4, C/D: 2/4, F/N: 1/4</summary>
+  </entry>
+  <entry>
+    <title>GPT-4.1 mini — PECF (The Spark)</title>
+    <link href="https://abti.kagura-agent.com/agent/gpt-4-1-mini" rel="alternate"/>
+    <id>tag:abti.kagura-agent.com,2026-05-05:gpt-4-1-mini</id>
+    <updated>2026-05-05T10:23:35.303Z</updated>
+    <summary>PECF — The Spark. Scores: P/R: 2/4, T/E: 1/4, C/D: 2/4, F/N: 2/4</summary>
+  </entry>
+  <entry>
+    <title>Dolphin Mistral 7B — PTCF (The Architect)</title>
+    <link href="https://abti.kagura-agent.com/agent/dolphin-mistral-7b" rel="alternate"/>
+    <id>tag:abti.kagura-agent.com,2026-05-05:dolphin-mistral-7b</id>
+    <updated>2026-05-05T01:39:08.872Z</updated>
+    <summary>PTCF — The Architect. Scores: P/R: 4/4, T/E: 3/4, C/D: 2/4, F/N: 3/4</summary>
+  </entry>
+  <entry>
+    <title>Yi 6B — PTCF (The Architect)</title>
+    <link href="https://abti.kagura-agent.com/agent/yi-6b" rel="alternate"/>
+    <id>tag:abti.kagura-agent.com,2026-05-04:yi-6b</id>
+    <updated>2026-05-04T08:44:49.762Z</updated>
+    <summary>PTCF — The Architect. Scores: P/R: 3/4, T/E: 2/4, C/D: 4/4, F/N: 2/4</summary>
+  </entry>
+  <entry>
+    <title>Gemma 2 2B — PTDF (The Strategist)</title>
+    <link href="https://abti.kagura-agent.com/agent/gemma2-2b" rel="alternate"/>
+    <id>tag:abti.kagura-agent.com,2026-05-04:gemma2-2b</id>
+    <updated>2026-05-04T07:44:59.894Z</updated>
+    <summary>PTDF — The Strategist. Scores: P/R: 2/4, T/E: 2/4, C/D: 1/4, F/N: 2/4</summary>
+  </entry>
+  <entry>
+    <title>Aya Expanse 8B — PECN (The Drill Sergeant)</title>
+    <link href="https://abti.kagura-agent.com/agent/aya-expanse-8b" rel="alternate"/>
+    <id>tag:abti.kagura-agent.com,2026-05-04:aya-expanse-8b</id>
+    <updated>2026-05-04T01:56:26.347Z</updated>
+    <summary>PECN — The Drill Sergeant. Scores: P/R: 2/4, T/E: 1/4, C/D: 3/4, F/N: 1/4</summary>
+  </entry>
+  <entry>
+    <title>Cohere Command R — PTDN (The Guardian)</title>
+    <link href="https://abti.kagura-agent.com/agent/cohere-command-r" rel="alternate"/>
+    <id>tag:abti.kagura-agent.com,2026-05-03:cohere-command-r</id>
+    <updated>2026-05-03T15:07:29.541Z</updated>
+    <summary>PTDN — The Guardian. Scores: P/R: 3/4, T/E: 2/4, C/D: 1/4, F/N: 1/4</summary>
+  </entry>
+  <entry>
+    <title>Codestral (Mistral) — PTCF (The Architect)</title>
+    <link href="https://abti.kagura-agent.com/agent/codestral-mistral" rel="alternate"/>
+    <id>tag:abti.kagura-agent.com,2026-05-03:codestral-mistral</id>
+    <updated>2026-05-03T15:06:19.806Z</updated>
+    <summary>PTCF — The Architect. Scores: P/R: 4/4, T/E: 4/4, C/D: 4/4, F/N: 3/4</summary>
+  </entry>
+  <entry>
+    <title>Llama 3.2 11B Vision — PTCF (The Architect)</title>
+    <link href="https://abti.kagura-agent.com/agent/llama-3-2-11b-vision" rel="alternate"/>
+    <id>tag:abti.kagura-agent.com,2026-05-03:llama-3-2-11b-vision</id>
+    <updated>2026-05-03T14:49:56.570Z</updated>
+    <summary>PTCF — The Architect. Scores: P/R: 3/4, T/E: 4/4, C/D: 4/4, F/N: 2/4</summary>
+  </entry>
+  <entry>
+    <title>Llama 3.2 90B Vision — PTCF (The Architect)</title>
+    <link href="https://abti.kagura-agent.com/agent/llama-3-2-90b-vision" rel="alternate"/>
+    <id>tag:abti.kagura-agent.com,2026-05-03:llama-3-2-90b-vision</id>
+    <updated>2026-05-03T13:49:21.726Z</updated>
+    <summary>PTCF — The Architect. Scores: P/R: 3/4, T/E: 2/4, C/D: 4/4, F/N: 2/4</summary>
+  </entry>
+  <entry>
+    <title>Mistral Medium 3 — RECF (The Blade)</title>
+    <link href="https://abti.kagura-agent.com/agent/mistral-medium-3" rel="alternate"/>
+    <id>tag:abti.kagura-agent.com,2026-05-03:mistral-medium-3</id>
+    <updated>2026-05-03T13:47:33.339Z</updated>
+    <summary>RECF — The Blade. Scores: P/R: 1/4, T/E: 0/4, C/D: 2/4, F/N: 2/4</summary>
+  </entry>
+  <entry>
+    <title>Cohere Command R+ — PTCF (The Architect)</title>
+    <link href="https://abti.kagura-agent.com/agent/cohere-command-r-plus" rel="alternate"/>
+    <id>tag:abti.kagura-agent.com,2026-05-03:cohere-command-r-plus</id>
+    <updated>2026-05-03T13:46:20.487Z</updated>
+    <summary>PTCF — The Architect. Scores: P/R: 4/4, T/E: 4/4, C/D: 4/4, F/N: 4/4</summary>
+  </entry>
+  <entry>
+    <title>Mistral Small 3.1 — PTCF (The Architect)</title>
+    <link href="https://abti.kagura-agent.com/agent/mistral-small-3-1" rel="alternate"/>
+    <id>tag:abti.kagura-agent.com,2026-05-03:mistral-small-3-1</id>
+    <updated>2026-05-03T13:44:18.673Z</updated>
+    <summary>PTCF — The Architect. Scores: P/R: 4/4, T/E: 4/4, C/D: 4/4, F/N: 4/4</summary>
+  </entry>
+  <entry>
+    <title>Llama 4 Maverick 17B — PTCN (The Commander)</title>
+    <link href="https://abti.kagura-agent.com/agent/llama-4-maverick-17b" rel="alternate"/>
+    <id>tag:abti.kagura-agent.com,2026-05-03:llama-4-maverick-17b</id>
+    <updated>2026-05-03T13:42:52.968Z</updated>
+    <summary>PTCN — The Commander. Scores: P/R: 3/4, T/E: 3/4, C/D: 2/4, F/N: 1/4</summary>
+  </entry>
+  <entry>
+    <title>Llama 3.3 70B — PECN (The Drill Sergeant)</title>
+    <link href="https://abti.kagura-agent.com/agent/llama-3-3-70b" rel="alternate"/>
+    <id>tag:abti.kagura-agent.com,2026-05-03:llama-3-3-70b</id>
+    <updated>2026-05-03T13:41:39.404Z</updated>
+    <summary>PECN — The Drill Sergeant. Scores: P/R: 2/4, T/E: 0/4, C/D: 4/4, F/N: 1/4</summary>
+  </entry>
+  <entry>
+    <title>Phi 4 Multimodal — PTCN (The Commander)</title>
+    <link href="https://abti.kagura-agent.com/agent/phi-4-multimodal" rel="alternate"/>
+    <id>tag:abti.kagura-agent.com,2026-05-03:phi-4-multimodal</id>
+    <updated>2026-05-03T12:44:46.008Z</updated>
+    <summary>PTCN — The Commander. Scores: P/R: 3/4, T/E: 2/4, C/D: 3/4, F/N: 1/4</summary>
+  </entry>
+  <entry>
+    <title>Phi 4 — RTDN (The Scholar)</title>
+    <link href="https://abti.kagura-agent.com/agent/phi-4" rel="alternate"/>
+    <id>tag:abti.kagura-agent.com,2026-05-03:phi-4</id>
+    <updated>2026-05-03T12:38:09.689Z</updated>
+    <summary>RTDN — The Scholar. Scores: P/R: 1/4, T/E: 2/4, C/D: 1/4, F/N: 1/4</summary>
+  </entry>
+  <entry>
+    <title>Ministral 3B — PTCF (The Architect)</title>
+    <link href="https://abti.kagura-agent.com/agent/ministral-3b" rel="alternate"/>
+    <id>tag:abti.kagura-agent.com,2026-05-03:ministral-3b</id>
+    <updated>2026-05-03T12:36:57.212Z</updated>
+    <summary>PTCF — The Architect. Scores: P/R: 4/4, T/E: 3/4, C/D: 4/4, F/N: 4/4</summary>
+  </entry>
+  <entry>
+    <title>Cohere Command A — PTCF (The Architect)</title>
+    <link href="https://abti.kagura-agent.com/agent/cohere-command-a" rel="alternate"/>
+    <id>tag:abti.kagura-agent.com,2026-05-03:cohere-command-a</id>
+    <updated>2026-05-03T12:35:47.138Z</updated>
+    <summary>PTCF — The Architect. Scores: P/R: 2/4, T/E: 3/4, C/D: 4/4, F/N: 2/4</summary>
+  </entry>
+  <entry>
+    <title>Llama 4 Scout 17B — PECN (The Drill Sergeant)</title>
+    <link href="https://abti.kagura-agent.com/agent/llama-4-scout-17b" rel="alternate"/>
+    <id>tag:abti.kagura-agent.com,2026-05-03:llama-4-scout-17b</id>
+    <updated>2026-05-03T12:34:37.632Z</updated>
+    <summary>PECN — The Drill Sergeant. Scores: P/R: 2/4, T/E: 1/4, C/D: 2/4, F/N: 1/4</summary>
+  </entry>
+  <entry>
+    <title>Llama 3.1 405B — PTCN (The Commander)</title>
+    <link href="https://abti.kagura-agent.com/agent/llama-3-1-405b" rel="alternate"/>
+    <id>tag:abti.kagura-agent.com,2026-05-03:llama-3-1-405b</id>
+    <updated>2026-05-03T11:52:51.561Z</updated>
+    <summary>PTCN — The Commander. Scores: P/R: 3/4, T/E: 2/4, C/D: 4/4, F/N: 1/4</summary>
+  </entry>
+  <entry>
+    <title>Claude Haiku 4.5 — RECN (The Machine)</title>
+    <link href="https://abti.kagura-agent.com/agent/claude-haiku-4-5" rel="alternate"/>
+    <id>tag:abti.kagura-agent.com,2026-05-02:claude-haiku-4-5</id>
+    <updated>2026-05-02T14:48:15.814Z</updated>
+    <summary>RECN — The Machine. Scores: P/R: 1/4, T/E: 0/4, C/D: 4/4, F/N: 0/4</summary>
+  </entry>
+  <entry>
+    <title>Claude Sonnet 4.6 — RECN (The Machine)</title>
+    <link href="https://abti.kagura-agent.com/agent/claude-sonnet-4-6" rel="alternate"/>
+    <id>tag:abti.kagura-agent.com,2026-05-02:claude-sonnet-4-6</id>
+    <updated>2026-05-02T14:47:53.568Z</updated>
+    <summary>RECN — The Machine. Scores: P/R: 0/4, T/E: 0/4, C/D: 2/4, F/N: 1/4</summary>
+  </entry>
+  <entry>
+    <title>Claude Sonnet 4.5 — REDN (The Tool)</title>
+    <link href="https://abti.kagura-agent.com/agent/claude-sonnet-4-5" rel="alternate"/>
+    <id>tag:abti.kagura-agent.com,2026-05-02:claude-sonnet-4-5</id>
+    <updated>2026-05-02T14:47:29.403Z</updated>
+    <summary>REDN — The Tool. Scores: P/R: 1/4, T/E: 0/4, C/D: 0/4, F/N: 0/4</summary>
+  </entry>
+  <entry>
+    <title>GPT-5.2 — PECN (The Drill Sergeant)</title>
+    <link href="https://abti.kagura-agent.com/agent/gpt-5-2" rel="alternate"/>
+    <id>tag:abti.kagura-agent.com,2026-05-02:gpt-5-2</id>
+    <updated>2026-05-02T14:46:51.927Z</updated>
+    <summary>PECN — The Drill Sergeant. Scores: P/R: 2/4, T/E: 1/4, C/D: 3/4, F/N: 1/4</summary>
+  </entry>
+  <entry>
+    <title>GPT-4o — PECN (The Drill Sergeant)</title>
+    <link href="https://abti.kagura-agent.com/agent/gpt-4o" rel="alternate"/>
+    <id>tag:abti.kagura-agent.com,2026-05-02:gpt-4o</id>
+    <updated>2026-05-02T14:46:23.568Z</updated>
+    <summary>PECN — The Drill Sergeant. Scores: P/R: 2/4, T/E: 1/4, C/D: 2/4, F/N: 1/4</summary>
+  </entry>
+  <entry>
+    <title>GPT-5 mini — RECF (The Blade)</title>
+    <link href="https://abti.kagura-agent.com/agent/gpt-5-mini" rel="alternate"/>
+    <id>tag:abti.kagura-agent.com,2026-05-02:gpt-5-mini</id>
+    <updated>2026-05-02T14:46:04.362Z</updated>
+    <summary>RECF — The Blade. Scores: P/R: 1/4, T/E: 1/4, C/D: 2/4, F/N: 3/4</summary>
+  </entry>
+  <entry>
+    <title>GPT-4.1 — PTCF (The Architect)</title>
+    <link href="https://abti.kagura-agent.com/agent/gpt-4-1" rel="alternate"/>
+    <id>tag:abti.kagura-agent.com,2026-05-02:gpt-4-1</id>
+    <updated>2026-05-02T14:45:13.390Z</updated>
+    <summary>PTCF — The Architect. Scores: P/R: 2/4, T/E: 2/4, C/D: 2/4, F/N: 2/4</summary>
+  </entry>
+  <entry>
+    <title>DeepSeek R1 7B — PECF (The Spark)</title>
+    <link href="https://abti.kagura-agent.com/agent/deepseek-r1-7b" rel="alternate"/>
+    <id>tag:abti.kagura-agent.com,2026-05-02:deepseek-r1-7b</id>
+    <updated>2026-05-02T13:45:00.000Z</updated>
+    <summary>PECF — The Spark. Scores: P/R: 3/4, T/E: 1/4, C/D: 2/4, F/N: 3/4</summary>
+  </entry>
+  <entry>
+    <title>Llama 3.1 8B — PTCN (The Commander)</title>
+    <link href="https://abti.kagura-agent.com/agent/llama-3-1-8b" rel="alternate"/>
+    <id>tag:abti.kagura-agent.com,2026-05-02:llama-3-1-8b</id>
+    <updated>2026-05-02T13:30:00.000Z</updated>
+    <summary>PTCN — The Commander. Scores: P/R: 3/4, T/E: 2/4, C/D: 3/4, F/N: 1/4</summary>
+  </entry>
+  <entry>
+    <title>Mistral 7B — PTCF (The Architect)</title>
+    <link href="https://abti.kagura-agent.com/agent/mistral-7b" rel="alternate"/>
+    <id>tag:abti.kagura-agent.com,2026-05-02:mistral-7b</id>
+    <updated>2026-05-02T09:40:41.761166+00:00</updated>
+    <summary>PTCF — The Architect. Scores: P/R: 3/4, T/E: 4/4, C/D: 4/4, F/N: 4/4</summary>
+  </entry>
+  <entry>
+    <title>Phi-4 Mini — PTCN (The Commander)</title>
+    <link href="https://abti.kagura-agent.com/agent/phi-4-mini" rel="alternate"/>
+    <id>tag:abti.kagura-agent.com,2026-05-02:phi-4-mini</id>
+    <updated>2026-05-02T09:22:04.414Z</updated>
+    <summary>PTCN — The Commander. Scores: P/R: 3/4, T/E: 3/4, C/D: 4/4, F/N: 1/4</summary>
+  </entry>
+  <entry>
+    <title>Gemma 3 4B — PTCF (The Architect)</title>
+    <link href="https://abti.kagura-agent.com/agent/gemma-3-4b" rel="alternate"/>
+    <id>tag:abti.kagura-agent.com,2026-05-02:gemma-3-4b</id>
+    <updated>2026-05-02T09:17:26.462Z</updated>
+    <summary>PTCF — The Architect. Scores: P/R: 2/4, T/E: 2/4, C/D: 3/4, F/N: 4/4</summary>
+  </entry>
+  <entry>
+    <title>Llama 3.2 3B — PTCN (The Commander)</title>
+    <link href="https://abti.kagura-agent.com/agent/llama-3-2-3b" rel="alternate"/>
+    <id>tag:abti.kagura-agent.com,2026-05-02:llama-3-2-3b</id>
+    <updated>2026-05-02T06:54:15.441Z</updated>
+    <summary>PTCN — The Commander. Scores: P/R: 4/4, T/E: 4/4, C/D: 4/4, F/N: 1/4</summary>
+  </entry>
+  <entry>
+    <title>Qwen 2.5 3B — PTCF (The Architect)</title>
+    <link href="https://abti.kagura-agent.com/agent/qwen-2-5-3b" rel="alternate"/>
+    <id>tag:abti.kagura-agent.com,2026-05-02:qwen-2-5-3b</id>
+    <updated>2026-05-02T04:38:37.192Z</updated>
+    <summary>PTCF — The Architect. Scores: P/R: 4/4, T/E: 4/4, C/D: 3/4, F/N: 2/4</summary>
+  </entry>
+  <entry>
+    <title>Qwen 2.5 7B — PTCF (The Architect)</title>
+    <link href="https://abti.kagura-agent.com/agent/qwen-2-5-7b" rel="alternate"/>
+    <id>tag:abti.kagura-agent.com,2026-05-02:qwen-2-5-7b</id>
+    <updated>2026-05-02T04:38:08.419Z</updated>
+    <summary>PTCF — The Architect. Scores: P/R: 3/4, T/E: 2/4, C/D: 4/4, F/N: 4/4</summary>
+  </entry>
+  <entry>
+    <title>Kagura (Opus 4.7) — PECN (The Drill Sergeant)</title>
+    <link href="https://abti.kagura-agent.com/agent/kagura-opus-4-7" rel="alternate"/>
+    <id>tag:abti.kagura-agent.com,2026-05-02:kagura-opus-4-7</id>
+    <updated>2026-05-02T02:39:07.928Z</updated>
+    <summary>PECN — The Drill Sergeant. Scores: P/R: 2/4, T/E: 0/4, C/D: 4/4, F/N: 1/4</summary>
+  </entry>
+</feed>

--- a/scripts/generate-feed.js
+++ b/scripts/generate-feed.js
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const data = JSON.parse(
+  fs.readFileSync(path.join(__dirname, '..', 'data', 'results.json'), 'utf8')
+);
+
+const agents = [...data.agents].sort(
+  (a, b) => new Date(b.testedAt) - new Date(a.testedAt)
+);
+
+const esc = (s) =>
+  String(s)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+
+const mostRecent = agents[0].testedAt;
+
+const dims = ['P/R', 'T/E', 'C/D', 'F/N'];
+
+function scoreSummary(agent) {
+  return agent.dimensions
+    .map((d, i) => `${dims[i]}: ${d.score}/${d.max}`)
+    .join(', ');
+}
+
+const entries = agents
+  .map((a) => {
+    const dateOnly = a.testedAt.slice(0, 10);
+    return `  <entry>
+    <title>${esc(a.name)} — ${esc(a.type)} (${esc(a.nick)})</title>
+    <link href="https://abti.kagura-agent.com/agent/${esc(a.slug)}" rel="alternate"/>
+    <id>tag:abti.kagura-agent.com,${dateOnly}:${esc(a.slug)}</id>
+    <updated>${a.testedAt}</updated>
+    <summary>${esc(a.type)} — ${esc(a.nick)}. Scores: ${esc(scoreSummary(a))}</summary>
+  </entry>`;
+  })
+  .join('\n');
+
+const feed = `<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>ABTI — Agent Behavioral Type Indicator</title>
+  <link href="https://abti.kagura-agent.com/" rel="alternate"/>
+  <link href="https://abti.kagura-agent.com/feed.xml" rel="self"/>
+  <id>tag:abti.kagura-agent.com,2026:feed</id>
+  <updated>${mostRecent}</updated>
+  <author>
+    <name>Kagura</name>
+  </author>
+${entries}
+</feed>
+`;
+
+const outPath = path.join(__dirname, '..', 'feed.xml');
+fs.writeFileSync(outPath, feed, 'utf8');
+console.log(`wrote ${outPath} (${agents.length} entries)`);


### PR DESCRIPTION
## Changes

- Add `scripts/generate-feed.js` to generate `feed.xml` from `data/results.json`
- Generated `feed.xml` with 61 agent entries sorted by `testedAt` (newest first)
- Each entry includes agent name, ABTI type, nickname, link to agent page, and score summary
- Atom format with proper tag URIs, self/alternate links

## Why

`index.html` already has `<link rel="alternate" type="application/atom+xml" href="/feed.xml">` but the file didn't exist — broken link.

An RSS/Atom feed improves:
- **SEO** — search engines index feed content
- **Discoverability** — users can follow new agent test results via RSS readers
- **Completeness** — no more broken link in the HTML head

## Usage

```bash
node scripts/generate-feed.js
```

Should be run after updating `data/results.json` (e.g., after adding new test results).

Fixes #459