### PR TITLE
fix: remove duplicate codestral-2501 entry + tighten validator

### DIFF
--- a/data/results.json
+++ b/data/results.json
@@ -307,56 +307,6 @@
       "provider": "anthropic"
     },
     {
-      "name": "Codestral-2501",
-      "slug": "codestral-2501",
-      "url": "",
-      "type": "PTCF",
-      "nick": "The Architect",
-      "testedAt": "2026-05-19T01:34:53.705Z",
-      "scores": [
-        4,
-        4,
-        4,
-        3
-      ],
-      "dimensions": [
-        {
-          "poles": [
-            "P",
-            "R"
-          ],
-          "score": 4,
-          "max": 4
-        },
-        {
-          "poles": [
-            "T",
-            "E"
-          ],
-          "score": 4,
-          "max": 4
-        },
-        {
-          "poles": [
-            "C",
-            "D"
-          ],
-          "score": 4,
-          "max": 4
-        },
-        {
-          "poles": [
-            "F",
-            "N"
-          ],
-          "score": 3,
-          "max": 4
-        }
-      ],
-      "model": "",
-      "provider": ""
-    },
-    {
       "name": "Codestral (Mistral)",
       "slug": "codestral-mistral",
       "url": "",

--- a/scripts/validate-results.js
+++ b/scripts/validate-results.js
@@ -24,8 +24,8 @@ function validate(filePath) {
     if (typeof a.name !== 'string' || !a.name) errors.push(`${prefix}: name must be a non-empty string`);
     if (typeof a.slug !== 'string' || !/^[a-z0-9-]+$/.test(a.slug)) errors.push(`${prefix}: slug must match /^[a-z0-9-]+$/`);
     if (typeof a.nick !== 'string' || !a.nick) errors.push(`${prefix}: nick must be a non-empty string`);
-    if (typeof a.model !== 'string') errors.push(`${prefix}: model must be a string`);
-    if (typeof a.provider !== 'string') errors.push(`${prefix}: provider must be a string`);
+    if (typeof a.model !== 'string' || !a.model) errors.push(`${prefix}: model must be a non-empty string`);
+    if (typeof a.provider !== 'string' || !a.provider) errors.push(`${prefix}: provider must be a non-empty string`);
     if (typeof a.testedAt !== 'string' || isNaN(Date.parse(a.testedAt))) errors.push(`${prefix}: testedAt must be a valid ISO date`);
 
     if (typeof a.type !== 'string' || a.type.length !== 4) {


### PR DESCRIPTION
## Problem

1. **Duplicate codestral entry**: `codestral-2501` (slug) had blank `model` and `provider` fields, duplicating the existing `codestral-mistral` entry which has proper data (model: `Codestral-2501`, provider: `github`)
2. **Validator gap**: `validate-results.js` only checked `typeof` for model/provider, allowing empty strings to pass

## Fix

- Remove the duplicate `codestral-2501` entry (60 agents remain)
- Require non-empty `model` and `provider` strings in the validator

## Tests

All 269 tests pass.