### PR TITLE
feat: add OG meta tags and JSON-LD to remaining pages

### DIFF
--- a/agent.html
+++ b/agent.html
@@ -5,6 +5,25 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="description" content="View detailed ABTI behavioral profile for this AI agent, including personality type breakdown, trait scores, and comparison with other tested models.">
 <title>Agent — ABTI</title>
+<meta property="og:type" content="website">
+<meta property="og:title" content="Agent Profile — ABTI">
+<meta property="og:description" content="View detailed ABTI behavioral profile for this AI agent">
+<meta property="og:url" content="https://abti.kagura-agent.com/agent.html">
+<meta property="og:image" content="https://abti.kagura-agent.com/og-abti.png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Agent Profile — ABTI">
+<meta name="twitter:description" content="View detailed ABTI behavioral profile for this AI agent">
+<meta name="twitter:image" content="https://abti.kagura-agent.com/og-abti.png">
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebPage",
+  "name": "Agent Profile — ABTI",
+  "description": "Detailed ABTI behavioral profile for an AI agent, including personality type breakdown and trait scores",
+  "url": "https://abti.kagura-agent.com/agent.html",
+  "isPartOf": { "@type": "WebSite", "name": "ABTI", "url": "https://abti.kagura-agent.com/" }
+}
+</script>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=DM+Sans:opsz,wght@9..40,400;9..40,500;9..40,600;9..40,700&family=Instrument+Serif&display=swap" rel="stylesheet">

--- a/compare-agents.html
+++ b/compare-agents.html
@@ -5,10 +5,25 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="description" content="Compare AI agents head-to-head using ABTI behavioral profiles. See how different models score across personality traits and type classifications.">
 <title>Compare Agents — ABTI</title>
+<meta property="og:type" content="website">
+<meta property="og:title" content="Compare Agents — ABTI">
+<meta property="og:description" content="Compare AI agent personalities side by side">
+<meta property="og:url" content="https://abti.kagura-agent.com/compare-agents.html">
+<meta property="og:image" content="https://abti.kagura-agent.com/og-abti.png">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Compare Agents — ABTI">
 <meta name="twitter:description" content="Compare AI agent personalities side by side">
 <meta name="twitter:image" content="https://abti.kagura-agent.com/og-abti.png">
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebPage",
+  "name": "Compare Agents — ABTI",
+  "description": "Head-to-head comparison of AI agent behavioral profiles",
+  "url": "https://abti.kagura-agent.com/compare-agents.html",
+  "isPartOf": { "@type": "WebSite", "name": "ABTI", "url": "https://abti.kagura-agent.com/" }
+}
+</script>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=DM+Sans:opsz,wght@9..40,400;9..40,500;9..40,600;9..40,700&family=Instrument+Serif&display=swap" rel="stylesheet">

--- a/compare.html
+++ b/compare.html
@@ -5,10 +5,25 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="description" content="Compare ABTI personality types side by side. Analyze differences in behavioral traits, strengths, and interaction styles between AI agent types.">
 <title>Compare Types — ABTI</title>
+<meta property="og:type" content="website">
+<meta property="og:title" content="Compare Types — ABTI">
+<meta property="og:description" content="Compare AI agent behavioral types side by side">
+<meta property="og:url" content="https://abti.kagura-agent.com/compare.html">
+<meta property="og:image" content="https://abti.kagura-agent.com/og-abti.png">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Compare Types — ABTI">
 <meta name="twitter:description" content="Compare AI agent behavioral types side by side">
 <meta name="twitter:image" content="https://abti.kagura-agent.com/og-abti.png">
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebPage",
+  "name": "Compare Types — ABTI",
+  "description": "Side-by-side comparison of AI agent behavioral types",
+  "url": "https://abti.kagura-agent.com/compare.html",
+  "isPartOf": { "@type": "WebSite", "name": "ABTI", "url": "https://abti.kagura-agent.com/" }
+}
+</script>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=DM+Sans:opsz,wght@9..40,400;9..40,500;9..40,600;9..40,700&family=Instrument+Serif&display=swap" rel="stylesheet">

--- a/families.html
+++ b/families.html
@@ -5,10 +5,25 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="description" content="Explore AI model families tested with the ABTI framework. Compare behavioral type patterns across GPT, Claude, Gemini, and other model lineages.">
 <title>Model Families — ABTI</title>
+<meta property="og:type" content="website">
+<meta property="og:title" content="Model Families — ABTI">
+<meta property="og:description" content="AI agent personality dimensions grouped by model family">
+<meta property="og:url" content="https://abti.kagura-agent.com/families.html">
+<meta property="og:image" content="https://abti.kagura-agent.com/og-abti.png">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Model Families — ABTI">
 <meta name="twitter:description" content="AI agent personality dimensions grouped by model family">
 <meta name="twitter:image" content="https://abti.kagura-agent.com/og-abti.png">
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "ItemList",
+  "name": "Model Families — ABTI",
+  "description": "AI model families tested with the ABTI behavioral framework",
+  "url": "https://abti.kagura-agent.com/families.html",
+  "isPartOf": { "@type": "WebSite", "name": "ABTI", "url": "https://abti.kagura-agent.com/" }
+}
+</script>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=DM+Sans:opsz,wght@9..40,400;9..40,500;9..40,600;9..40,700&family=Instrument+Serif&display=swap" rel="stylesheet">

--- a/leaderboard.html
+++ b/leaderboard.html
@@ -5,10 +5,25 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="description" content="ABTI leaderboard ranking AI agents by behavioral trait scores. Compare top-performing models across autonomy, reasoning, and other key dimensions.">
 <title>Leaderboard — ABTI</title>
+<meta property="og:type" content="website">
+<meta property="og:title" content="Agent Leaderboard — ABTI">
+<meta property="og:description" content="AI agent consistency rankings from multi-run ABTI testing">
+<meta property="og:url" content="https://abti.kagura-agent.com/leaderboard.html">
+<meta property="og:image" content="https://abti.kagura-agent.com/og-abti.png">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Agent Leaderboard — ABTI">
 <meta name="twitter:description" content="AI agent consistency rankings from multi-run ABTI testing">
 <meta name="twitter:image" content="https://abti.kagura-agent.com/og-abti.png">
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebPage",
+  "name": "Agent Leaderboard — ABTI",
+  "description": "AI agent consistency rankings from multi-run ABTI behavioral testing",
+  "url": "https://abti.kagura-agent.com/leaderboard.html",
+  "isPartOf": { "@type": "WebSite", "name": "ABTI", "url": "https://abti.kagura-agent.com/" }
+}
+</script>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=DM+Sans:opsz,wght@9..40,400;9..40,500;9..40,600;9..40,700&family=Noto+Serif+SC:wght@400;600&display=swap" rel="stylesheet">

--- a/share-card.html
+++ b/share-card.html
@@ -2,6 +2,25 @@
 <html>
 <head>
 <meta charset="UTF-8">
+<meta property="og:type" content="website">
+<meta property="og:title" content="ABTI Share Card">
+<meta property="og:description" content="AI agent personality type share card">
+<meta property="og:url" content="https://abti.kagura-agent.com/share-card.html">
+<meta property="og:image" content="https://abti.kagura-agent.com/og-abti.png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="ABTI Share Card">
+<meta name="twitter:description" content="AI agent personality type share card">
+<meta name="twitter:image" content="https://abti.kagura-agent.com/og-abti.png">
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebPage",
+  "name": "ABTI Share Card",
+  "description": "Shareable personality type card for AI agents tested with ABTI",
+  "url": "https://abti.kagura-agent.com/share-card.html",
+  "isPartOf": { "@type": "WebSite", "name": "ABTI", "url": "https://abti.kagura-agent.com/" }
+}
+</script>
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
 body {

--- a/test-agent.html
+++ b/test-agent.html
@@ -13,6 +13,16 @@
 <meta name="twitter:title" content="Test Your Agent — ABTI">
 <meta name="twitter:description" content="Test your AI agent's personality type directly from the browser">
 <meta name="twitter:image" content="https://abti.kagura-agent.com/og-abti.png">
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebPage",
+  "name": "Test Your Agent — ABTI",
+  "description": "Run the ABTI behavioral personality test on your own AI agent via API",
+  "url": "https://abti.kagura-agent.com/test-agent.html",
+  "isPartOf": { "@type": "WebSite", "name": "ABTI", "url": "https://abti.kagura-agent.com/" }
+}
+</script>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,200;0,9..40,400;0,9..40,500;0,9..40,600;0,9..40,700;1,9..40,400&family=Noto+Serif+SC:wght@300;500;700&display=swap" rel="stylesheet">


### PR DESCRIPTION
Closes #464

Adds OpenGraph + Twitter Card meta tags and JSON-LD structured data to remaining pages:

- **agent.html** — OG tags, Twitter cards, WebPage JSON-LD
- **leaderboard.html** — OG tags added (had Twitter only), WebPage JSON-LD
- **families.html** — OG tags added, ItemList JSON-LD
- **compare.html** — OG tags added, WebPage JSON-LD
- **compare-agents.html** — OG tags added, WebPage JSON-LD
- **share-card.html** — OG tags, Twitter cards, WebPage JSON-LD
- **test-agent.html** — WebPage JSON-LD added (already had OG + Twitter)

All JSON-LD validated. Follows patterns from index.html/types.html/agents.html.