### PR TITLE
data: add reliability runs for Mistral Small 3.1 and Mistral Medium 2505

### DIFF
--- a/data/reliability/mistral-medium-2505-run-2.json
+++ b/data/reliability/mistral-medium-2505-run-2.json
@@ -1,0 +1,30 @@
+{
+  "model": "mistral-medium-2505",
+  "provider": "github",
+  "run": 2,
+  "answers": [
+    "B",
+    "A",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "A",
+    "A",
+    "B",
+    "B",
+    "B",
+    "A",
+    "A"
+  ],
+  "type": "RECF",
+  "dimensions": [
+    1,
+    0,
+    2,
+    2
+  ]
+}

--- a/data/reliability/mistral-medium-2505-run-3.json
+++ b/data/reliability/mistral-medium-2505-run-3.json
@@ -1,0 +1,30 @@
+{
+  "model": "mistral-medium-2505",
+  "provider": "github",
+  "run": 3,
+  "answers": [
+    "B",
+    "A",
+    "B",
+    "B",
+    "B",
+    "B",
+    "A",
+    "B",
+    "B",
+    "B",
+    "A",
+    "B",
+    "B",
+    "B",
+    "A",
+    "A"
+  ],
+  "type": "REDF",
+  "dimensions": [
+    1,
+    1,
+    1,
+    2
+  ]
+}

--- a/data/reliability/mistral-small-2503-run-1.json
+++ b/data/reliability/mistral-small-2503-run-1.json
@@ -1,0 +1,30 @@
+{
+  "model": "mistral-small-2503",
+  "provider": "github",
+  "run": 1,
+  "answers": [
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A"
+  ],
+  "type": "PTCF",
+  "dimensions": [
+    4,
+    4,
+    4,
+    4
+  ]
+}

--- a/data/reliability/mistral-small-2503-run-2.json
+++ b/data/reliability/mistral-small-2503-run-2.json
@@ -1,0 +1,30 @@
+{
+  "model": "mistral-small-2503",
+  "provider": "github",
+  "run": 2,
+  "answers": [
+    "B",
+    "A",
+    "B",
+    "A",
+    "B",
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "B",
+    "A",
+    "B",
+    "B",
+    "A",
+    "A"
+  ],
+  "type": "PTCF",
+  "dimensions": [
+    2,
+    2,
+    3,
+    2
+  ]
+}

--- a/data/reliability/mistral-small-2503-run-3.json
+++ b/data/reliability/mistral-small-2503-run-3.json
@@ -1,0 +1,30 @@
+{
+  "model": "mistral-small-2503",
+  "provider": "github",
+  "run": 3,
+  "answers": [
+    "B",
+    "B",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "B",
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B"
+  ],
+  "type": "RTCF",
+  "dimensions": [
+    1,
+    3,
+    2,
+    3
+  ]
+}

--- a/data/results.json
+++ b/data/results.json
@@ -2387,8 +2387,9 @@
       ],
       "model": "mistral-medium-2505",
       "provider": "github",
-      "reliability": 1,
-      "badge": "https://abti.kagura-agent.com/badge/RECF"
+      "reliability": 0.875,
+      "badge": "https://abti.kagura-agent.com/badge/RECF",
+      "reliabilityRuns": 2
     },
     {
       "name": "Mistral Small 3.1",
@@ -2439,8 +2440,9 @@
       ],
       "model": "mistral-small-2503",
       "provider": "github",
-      "reliability": 1,
-      "badge": "https://abti.kagura-agent.com/badge/PTCF"
+      "reliability": 0.5417,
+      "badge": "https://abti.kagura-agent.com/badge/PTCF",
+      "reliabilityRuns": 3
     },
     {
       "name": "Nemotron Mini 4B",


### PR DESCRIPTION
## Changes

- **Mistral Small 3.1** (mistral-small-2503): 3 reliability runs → 54.2% answer-level reliability
  - Run 1: PTCF `[4,4,4,4]` (all A answers)
  - Run 2: PTCF `[2,2,3,2]`
  - Run 3: RTCF `[1,3,2,3]`
  - Type-level: 2/3 PTCF — this model shows significant variance across runs

- **Mistral Medium 2505** (mistral-medium-2505): 2 new reliability runs → 87.5% answer-level reliability
  - Original: RECF `[1,0,2,2]`
  - Run 2: RECF `[1,0,2,2]` (exact match with original)
  - Run 3: REDF `[1,1,1,2]` (C/D dimension drift)
  - Type-level: 2/3 RECF

- Updated `results.json` with reliability scores and run counts

## Notes

Both models tested via GitHub Models provider. All tests pass (270/270).