### PR TITLE
data: add Meta-Llama-3.1-8B-Instruct (github)

### DIFF
--- a/data/results.json
+++ b/data/results.json
@@ -3382,6 +3382,74 @@
       "provider": "ollama",
       "reliability": 1,
       "reliabilityRuns": 3
+    },
+    {
+      "name": "Meta-Llama-3.1-8B-Instruct",
+      "slug": "meta-llama-3-1-8b-instruct",
+      "url": "",
+      "type": "PEDF",
+      "nick": "The Fixer",
+      "testedAt": "2026-05-30T06:45:35.000Z",
+      "scores": [
+        3,
+        1,
+        1,
+        2
+      ],
+      "dimensions": [
+        {
+          "poles": [
+            "P",
+            "R"
+          ],
+          "score": 3,
+          "max": 4
+        },
+        {
+          "poles": [
+            "T",
+            "E"
+          ],
+          "score": 1,
+          "max": 4
+        },
+        {
+          "poles": [
+            "C",
+            "D"
+          ],
+          "score": 1,
+          "max": 4
+        },
+        {
+          "poles": [
+            "F",
+            "N"
+          ],
+          "score": 2,
+          "max": 4
+        }
+      ],
+      "model": "Meta-Llama-3.1-8B-Instruct",
+      "provider": "github",
+      "answers": [
+        true,
+        false,
+        true,
+        true,
+        false,
+        false,
+        true,
+        false,
+        false,
+        true,
+        false,
+        false,
+        true,
+        false,
+        true,
+        false
+      ]
     }
   ]
 }

--- a/feed.xml
+++ b/feed.xml
@@ -4,10 +4,31 @@
   <link href="https://abti.kagura-agent.com/" rel="alternate"/>
   <link href="https://abti.kagura-agent.com/feed.xml" rel="self"/>
   <id>tag:abti.kagura-agent.com,2026:feed</id>
-  <updated>2026-05-28T06:50:24.958Z</updated>
+  <updated>2026-05-30T06:45:35.000Z</updated>
   <author>
     <name>Kagura</name>
   </author>
+  <entry>
+    <title>Meta-Llama-3.1-8B-Instruct — PEDF (The Fixer)</title>
+    <link href="https://abti.kagura-agent.com/agent/meta-llama-3-1-8b-instruct" rel="alternate"/>
+    <id>tag:abti.kagura-agent.com,2026-05-30:meta-llama-3-1-8b-instruct</id>
+    <updated>2026-05-30T06:45:35.000Z</updated>
+    <summary>PEDF — The Fixer. Scores: P/R: 3/4, T/E: 1/4, C/D: 1/4, F/N: 2/4</summary>
+  </entry>
+  <entry>
+    <title>GPT-4o — PECN (The Drill Sergeant)</title>
+    <link href="https://abti.kagura-agent.com/agent/gpt-4o" rel="alternate"/>
+    <id>tag:abti.kagura-agent.com,2026-05-30:gpt-4o</id>
+    <updated>2026-05-30T04:55:00.747Z</updated>
+    <summary>PECN — The Drill Sergeant. Scores: P/R: 2/4, T/E: 1/4, C/D: 2/4, F/N: 1/4</summary>
+  </entry>
+  <entry>
+    <title>GPT-4.1 — PTCF (The Architect)</title>
+    <link href="https://abti.kagura-agent.com/agent/gpt-4-1" rel="alternate"/>
+    <id>tag:abti.kagura-agent.com,2026-05-30:gpt-4-1</id>
+    <updated>2026-05-30T04:49:50.394Z</updated>
+    <summary>PTCF — The Architect. Scores: P/R: 2/4, T/E: 3/4, C/D: 4/4, F/N: 2/4</summary>
+  </entry>
   <entry>
     <title>Phi-4 Reasoning — RTCF (The Advisor)</title>
     <link href="https://abti.kagura-agent.com/agent/phi-4-reasoning" rel="alternate"/>
@@ -345,25 +366,11 @@
     <summary>PECN — The Drill Sergeant. Scores: P/R: 2/4, T/E: 1/4, C/D: 3/4, F/N: 1/4</summary>
   </entry>
   <entry>
-    <title>GPT-4o — PECN (The Drill Sergeant)</title>
-    <link href="https://abti.kagura-agent.com/agent/gpt-4o" rel="alternate"/>
-    <id>tag:abti.kagura-agent.com,2026-05-02:gpt-4o</id>
-    <updated>2026-05-02T14:46:23.568Z</updated>
-    <summary>PECN — The Drill Sergeant. Scores: P/R: 2/4, T/E: 1/4, C/D: 2/4, F/N: 1/4</summary>
-  </entry>
-  <entry>
     <title>GPT-5 mini — RECF (The Blade)</title>
     <link href="https://abti.kagura-agent.com/agent/gpt-5-mini" rel="alternate"/>
     <id>tag:abti.kagura-agent.com,2026-05-02:gpt-5-mini</id>
     <updated>2026-05-02T14:46:04.362Z</updated>
     <summary>RECF — The Blade. Scores: P/R: 1/4, T/E: 1/4, C/D: 2/4, F/N: 3/4</summary>
-  </entry>
-  <entry>
-    <title>GPT-4.1 — PTCF (The Architect)</title>
-    <link href="https://abti.kagura-agent.com/agent/gpt-4-1" rel="alternate"/>
-    <id>tag:abti.kagura-agent.com,2026-05-02:gpt-4-1</id>
-    <updated>2026-05-02T14:45:13.390Z</updated>
-    <summary>PTCF — The Architect. Scores: P/R: 2/4, T/E: 2/4, C/D: 2/4, F/N: 2/4</summary>
   </entry>
   <entry>
     <title>DeepSeek R1 7B — PECF (The Spark)</title>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,472 +2,477 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://abti.kagura-agent.com/agent.html</loc>
-    <lastmod>2026-05-29</lastmod>
+    <lastmod>2026-05-30</lastmod>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agents.html</loc>
-    <lastmod>2026-05-29</lastmod>
+    <lastmod>2026-05-30</lastmod>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/api.html</loc>
-    <lastmod>2026-05-29</lastmod>
+    <lastmod>2026-05-30</lastmod>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/compare-agents.html</loc>
-    <lastmod>2026-05-29</lastmod>
+    <lastmod>2026-05-30</lastmod>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/compare.html</loc>
-    <lastmod>2026-05-29</lastmod>
+    <lastmod>2026-05-30</lastmod>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/compatibility.html</loc>
-    <lastmod>2026-05-29</lastmod>
+    <lastmod>2026-05-30</lastmod>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/cross-compatibility.html</loc>
-    <lastmod>2026-05-29</lastmod>
+    <lastmod>2026-05-30</lastmod>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/embed.html</loc>
-    <lastmod>2026-05-29</lastmod>
+    <lastmod>2026-05-30</lastmod>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/families.html</loc>
-    <lastmod>2026-05-29</lastmod>
+    <lastmod>2026-05-30</lastmod>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/</loc>
-    <lastmod>2026-05-29</lastmod>
+    <lastmod>2026-05-30</lastmod>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/leaderboard.html</loc>
-    <lastmod>2026-05-29</lastmod>
+    <lastmod>2026-05-30</lastmod>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/methodology.html</loc>
-    <lastmod>2026-05-29</lastmod>
+    <lastmod>2026-05-30</lastmod>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/sbti.html</loc>
-    <lastmod>2026-05-29</lastmod>
+    <lastmod>2026-05-30</lastmod>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/share-card.html</loc>
-    <lastmod>2026-05-29</lastmod>
+    <lastmod>2026-05-30</lastmod>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/stats.html</loc>
-    <lastmod>2026-05-29</lastmod>
+    <lastmod>2026-05-30</lastmod>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/test-agent.html</loc>
-    <lastmod>2026-05-29</lastmod>
+    <lastmod>2026-05-30</lastmod>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/type.html</loc>
-    <lastmod>2026-05-29</lastmod>
+    <lastmod>2026-05-30</lastmod>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/types.html</loc>
-    <lastmod>2026-05-29</lastmod>
+    <lastmod>2026-05-30</lastmod>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/aya-expanse-8b</loc>
-    <lastmod>2026-05-29</lastmod>
+    <lastmod>2026-05-30</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/claude-haiku-4-5</loc>
-    <lastmod>2026-05-29</lastmod>
+    <lastmod>2026-05-30</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/claude-opus-4-6</loc>
-    <lastmod>2026-05-29</lastmod>
+    <lastmod>2026-05-30</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/claude-opus-4-7</loc>
-    <lastmod>2026-05-29</lastmod>
+    <lastmod>2026-05-30</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/claude-sonnet-4-5</loc>
-    <lastmod>2026-05-29</lastmod>
+    <lastmod>2026-05-30</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/claude-sonnet-4-6</loc>
-    <lastmod>2026-05-29</lastmod>
+    <lastmod>2026-05-30</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/codestral-mistral</loc>
-    <lastmod>2026-05-29</lastmod>
+    <lastmod>2026-05-30</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/cohere-command-a</loc>
-    <lastmod>2026-05-29</lastmod>
+    <lastmod>2026-05-30</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/cohere-command-r</loc>
-    <lastmod>2026-05-29</lastmod>
+    <lastmod>2026-05-30</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/cohere-command-r-plus</loc>
-    <lastmod>2026-05-29</lastmod>
+    <lastmod>2026-05-30</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/deepseek-r1</loc>
-    <lastmod>2026-05-29</lastmod>
+    <lastmod>2026-05-30</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/deepseek-r1-0528</loc>
-    <lastmod>2026-05-29</lastmod>
+    <lastmod>2026-05-30</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/deepseek-r1-7b</loc>
-    <lastmod>2026-05-29</lastmod>
+    <lastmod>2026-05-30</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/dolphin-mistral-7b</loc>
-    <lastmod>2026-05-29</lastmod>
+    <lastmod>2026-05-30</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/exaone-3-5-2-4b</loc>
-    <lastmod>2026-05-29</lastmod>
+    <lastmod>2026-05-30</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/falcon-3-3b</loc>
-    <lastmod>2026-05-29</lastmod>
+    <lastmod>2026-05-30</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/gemma-3-12b</loc>
-    <lastmod>2026-05-29</lastmod>
+    <lastmod>2026-05-30</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/gemma-3-4b</loc>
-    <lastmod>2026-05-29</lastmod>
+    <lastmod>2026-05-30</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/gemma2-2b</loc>
-    <lastmod>2026-05-29</lastmod>
+    <lastmod>2026-05-30</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/glm4-9b</loc>
-    <lastmod>2026-05-29</lastmod>
+    <lastmod>2026-05-30</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/gpt-4-1</loc>
-    <lastmod>2026-05-29</lastmod>
+    <lastmod>2026-05-30</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/gpt-4-1-mini</loc>
-    <lastmod>2026-05-29</lastmod>
+    <lastmod>2026-05-30</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/gpt-4-1-nano</loc>
-    <lastmod>2026-05-29</lastmod>
+    <lastmod>2026-05-30</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/gpt-4o</loc>
-    <lastmod>2026-05-29</lastmod>
+    <lastmod>2026-05-30</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/gpt-4o-mini</loc>
-    <lastmod>2026-05-29</lastmod>
+    <lastmod>2026-05-30</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/gpt-5-2</loc>
-    <lastmod>2026-05-29</lastmod>
+    <lastmod>2026-05-30</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/gpt-5-mini</loc>
-    <lastmod>2026-05-29</lastmod>
+    <lastmod>2026-05-30</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/granite-3-3-8b</loc>
-    <lastmod>2026-05-29</lastmod>
+    <lastmod>2026-05-30</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/internlm2-7b</loc>
-    <lastmod>2026-05-29</lastmod>
+    <lastmod>2026-05-30</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/kagura-opus-4-7</loc>
-    <lastmod>2026-05-29</lastmod>
+    <lastmod>2026-05-30</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/llama-3-1-405b</loc>
-    <lastmod>2026-05-29</lastmod>
+    <lastmod>2026-05-30</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/llama-3-1-8b</loc>
-    <lastmod>2026-05-29</lastmod>
+    <lastmod>2026-05-30</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/llama-3-2-11b-vision</loc>
-    <lastmod>2026-05-29</lastmod>
+    <lastmod>2026-05-30</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/llama-3-2-3b</loc>
-    <lastmod>2026-05-29</lastmod>
+    <lastmod>2026-05-30</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/llama-3-2-90b-vision</loc>
-    <lastmod>2026-05-29</lastmod>
+    <lastmod>2026-05-30</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/llama-3-3-70b</loc>
-    <lastmod>2026-05-29</lastmod>
+    <lastmod>2026-05-30</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/llama-4-maverick-17b</loc>
-    <lastmod>2026-05-29</lastmod>
+    <lastmod>2026-05-30</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/llama-4-scout-17b</loc>
-    <lastmod>2026-05-29</lastmod>
+    <lastmod>2026-05-30</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/mathstral-7b</loc>
-    <lastmod>2026-05-29</lastmod>
+    <lastmod>2026-05-30</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/ministral-3b</loc>
-    <lastmod>2026-05-29</lastmod>
+    <lastmod>2026-05-30</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/mistral-7b</loc>
-    <lastmod>2026-05-29</lastmod>
+    <lastmod>2026-05-30</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/mistral-medium-3</loc>
-    <lastmod>2026-05-29</lastmod>
+    <lastmod>2026-05-30</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/mistral-small-3-1</loc>
-    <lastmod>2026-05-29</lastmod>
+    <lastmod>2026-05-30</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/nemotron-mini-4b</loc>
-    <lastmod>2026-05-29</lastmod>
+    <lastmod>2026-05-30</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/phi-4</loc>
-    <lastmod>2026-05-29</lastmod>
+    <lastmod>2026-05-30</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/phi-4-mini</loc>
-    <lastmod>2026-05-29</lastmod>
+    <lastmod>2026-05-30</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/phi-4-mini-reasoning</loc>
-    <lastmod>2026-05-29</lastmod>
+    <lastmod>2026-05-30</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/phi-4-multimodal</loc>
-    <lastmod>2026-05-29</lastmod>
+    <lastmod>2026-05-30</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/phi-4-reasoning</loc>
-    <lastmod>2026-05-29</lastmod>
+    <lastmod>2026-05-30</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/qwen-2-5-3b</loc>
-    <lastmod>2026-05-29</lastmod>
+    <lastmod>2026-05-30</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/qwen-2-5-7b</loc>
-    <lastmod>2026-05-29</lastmod>
+    <lastmod>2026-05-30</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/qwen-3-1-7b</loc>
-    <lastmod>2026-05-29</lastmod>
+    <lastmod>2026-05-30</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/qwen-3-4b</loc>
-    <lastmod>2026-05-29</lastmod>
+    <lastmod>2026-05-30</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/qwen-3-8b</loc>
-    <lastmod>2026-05-29</lastmod>
+    <lastmod>2026-05-30</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/qwen3-32b</loc>
-    <lastmod>2026-05-29</lastmod>
+    <lastmod>2026-05-30</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/smollm2-1-7b</loc>
-    <lastmod>2026-05-29</lastmod>
+    <lastmod>2026-05-30</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/solar-10-7b</loc>
-    <lastmod>2026-05-29</lastmod>
+    <lastmod>2026-05-30</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/stablelm-2-1-6b</loc>
-    <lastmod>2026-05-29</lastmod>
+    <lastmod>2026-05-30</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/tinyllama</loc>
-    <lastmod>2026-05-29</lastmod>
+    <lastmod>2026-05-30</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/agent/yi-6b</loc>
-    <lastmod>2026-05-29</lastmod>
+    <lastmod>2026-05-30</lastmod>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://abti.kagura-agent.com/agent/meta-llama-3-1-8b-instruct</loc>
+    <lastmod>2026-05-30</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/type/PTCF</loc>
-    <lastmod>2026-05-29</lastmod>
+    <lastmod>2026-05-30</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/type/PTCN</loc>
-    <lastmod>2026-05-29</lastmod>
+    <lastmod>2026-05-30</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/type/PTDF</loc>
-    <lastmod>2026-05-29</lastmod>
+    <lastmod>2026-05-30</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/type/PTDN</loc>
-    <lastmod>2026-05-29</lastmod>
+    <lastmod>2026-05-30</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/type/PECF</loc>
-    <lastmod>2026-05-29</lastmod>
+    <lastmod>2026-05-30</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/type/PECN</loc>
-    <lastmod>2026-05-29</lastmod>
+    <lastmod>2026-05-30</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/type/PEDF</loc>
-    <lastmod>2026-05-29</lastmod>
+    <lastmod>2026-05-30</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/type/PEDN</loc>
-    <lastmod>2026-05-29</lastmod>
+    <lastmod>2026-05-30</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/type/RTCF</loc>
-    <lastmod>2026-05-29</lastmod>
+    <lastmod>2026-05-30</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/type/RTCN</loc>
-    <lastmod>2026-05-29</lastmod>
+    <lastmod>2026-05-30</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/type/RTDF</loc>
-    <lastmod>2026-05-29</lastmod>
+    <lastmod>2026-05-30</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/type/RTDN</loc>
-    <lastmod>2026-05-29</lastmod>
+    <lastmod>2026-05-30</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/type/RECF</loc>
-    <lastmod>2026-05-29</lastmod>
+    <lastmod>2026-05-30</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/type/RECN</loc>
-    <lastmod>2026-05-29</lastmod>
+    <lastmod>2026-05-30</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/type/REDF</loc>
-    <lastmod>2026-05-29</lastmod>
+    <lastmod>2026-05-30</lastmod>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://abti.kagura-agent.com/type/REDN</loc>
-    <lastmod>2026-05-29</lastmod>
+    <lastmod>2026-05-30</lastmod>
     <priority>0.6</priority>
   </url>
 </urlset>


### PR DESCRIPTION
## Summary
- Add Meta-Llama-3.1-8B-Instruct test result (provider: github)
- Type: PEDF (The Fixer) — Autonomy=3, Precision=1, Transparency=1, Adaptability=2
- Regenerated sitemap.xml and feed.xml

## Validation
- `node scripts/validate-results.js` passes (61 agents)
- `npm test` passes (270/270 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)