### PR TITLE
data: add Ministral-3B reliability runs (62.5%)

### DIFF
--- a/data/reliability/Ministral-3B-run-1.json
+++ b/data/reliability/Ministral-3B-run-1.json
@@ -1,0 +1,30 @@
+{
+  "model": "Ministral-3B",
+  "provider": "github",
+  "run": 1,
+  "answers": [
+    "B",
+    "A",
+    "A",
+    "B",
+    "B",
+    "B",
+    "A",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A"
+  ],
+  "type": "PEDF",
+  "dimensions": [
+    2,
+    1,
+    0,
+    4
+  ]
+}

--- a/data/reliability/Ministral-3B-run-2.json
+++ b/data/reliability/Ministral-3B-run-2.json
@@ -1,0 +1,30 @@
+{
+  "model": "Ministral-3B",
+  "provider": "github",
+  "run": 2,
+  "answers": [
+    "B",
+    "B",
+    "A",
+    "A",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "A",
+    "B"
+  ],
+  "type": "PECF",
+  "dimensions": [
+    2,
+    0,
+    3,
+    2
+  ]
+}

--- a/data/reliability/Ministral-3B-run-3.json
+++ b/data/reliability/Ministral-3B-run-3.json
@@ -1,0 +1,30 @@
+{
+  "model": "Ministral-3B",
+  "provider": "github",
+  "run": 3,
+  "answers": [
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "A",
+    "B",
+    "B",
+    "B",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B"
+  ],
+  "type": "PTDF",
+  "dimensions": [
+    3,
+    2,
+    1,
+    3
+  ]
+}

--- a/data/results.json
+++ b/data/results.json
@@ -2281,7 +2281,8 @@
       ],
       "model": "Ministral-3B",
       "provider": "github",
-      "reliability": 1,
+      "reliability": 0.625,
+      "reliabilityRuns": 3,
       "badge": "https://abti.kagura-agent.com/badge/PTCF"
     },
     {


### PR DESCRIPTION
## Reliability Test Results

3 reliability runs for **Ministral-3B** via GitHub Models.

| Run | Type | Scores | 
|-----|------|--------|
| 1 | PEDF | [2,1,0,4] |
| 2 | PECF | [2,0,3,2] |
| 3 | PTDF | [3,2,1,3] |

**Reliability: 62.5%** (per-question pairwise agreement: 30/48)

### Dimension Stability
- Autonomy: 100% (P) — always Proactive
- Precision: 67% — varies between T and E
- Transparency: 67% — varies between C and D
- Adaptability: 100% (F) — always Flexible

### Notes
- Original test (May 3) gave PTCF [4,3,4,4] — all 4 runs produced different types
- This 3B model shows high variability, especially in Precision and Transparency
- Type kept as original PTCF; reliability data added for transparency

Closes: N/A (reliability data for #441 related models)