### PR TITLE
data: add Codestral-2501 reliability runs (54.2%)

### DIFF
--- a/data/reliability/Codestral-2501-run-1.json
+++ b/data/reliability/Codestral-2501-run-1.json
@@ -1,0 +1,10 @@
+{
+  "model": "Codestral-2501",
+  "provider": "github",
+  "run": 1,
+  "answers": ["A","A","B","A","A","A","A","A","A","B","B","A","B","B","A","B"],
+  "type": "PTCN",
+  "dimensions": [
+    3,4,2,1
+  ]
+}

--- a/data/reliability/Codestral-2501-run-2.json
+++ b/data/reliability/Codestral-2501-run-2.json
@@ -1,0 +1,10 @@
+{
+  "model": "Codestral-2501",
+  "provider": "github",
+  "run": 2,
+  "answers": ["A","B","A","A","B","B","B","B","B","A","B","A","B","A","A","B"],
+  "type": "PECF",
+  "dimensions": [
+    3,0,2,2
+  ]
+}

--- a/data/reliability/Codestral-2501-run-3.json
+++ b/data/reliability/Codestral-2501-run-3.json
@@ -1,0 +1,10 @@
+{
+  "model": "Codestral-2501",
+  "provider": "github",
+  "run": 3,
+  "answers": ["A","B","A","B","B","B","A","A","B","B","B","A","B","B","A","A"],
+  "type": "PTDF",
+  "dimensions": [
+    2,2,1,2
+  ]
+}

--- a/data/results.json
+++ b/data/results.json
@@ -355,7 +355,8 @@
       ],
       "model": "Codestral-2501",
       "provider": "github",
-      "reliability": 1,
+      "reliability": 0.5417,
+      "reliabilityRuns": 3,
       "badge": "https://abti.kagura-agent.com/badge/PTCF"
     },
     {


### PR DESCRIPTION
## Reliability Test Results

3 reliability runs for **Codestral-2501** via GitHub Models.

| Run | Type | Scores |
|-----|------|--------|
| 1 | PTCN | [3,4,2,1] |
| 2 | PECF | [3,0,2,2] |
| 3 | PTDF | [2,2,1,2] |

**Reliability: 54.2%** (per-question pairwise agreement: 26/48)

### Dimension Stability
- Autonomy: 100% (P) — always Proactive
- Precision: 67% — varies between T and E
- Transparency: 67% — varies between C and D
- Adaptability: 33% — varies widely (N, F, F)

Original test gave RECF — all 4 recorded types are different, indicating very low personality consistency for this model.