### PR TITLE
data: add reliability data for phi-4-reasoning and llama-3.1-8b

### DIFF
--- a/data/reliability/meta-llama-3-1-8b-instruct-run-1.json
+++ b/data/reliability/meta-llama-3-1-8b-instruct-run-1.json
@@ -1,0 +1,30 @@
+{
+  "model": "Meta-Llama-3.1-8B-Instruct",
+  "provider": "github",
+  "run": 1,
+  "answers": [
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "B",
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "B",
+    "B",
+    "B",
+    "A",
+    "B"
+  ],
+  "type": "PTCN",
+  "dimensions": [
+    3,
+    2,
+    3,
+    1
+  ]
+}

--- a/data/reliability/meta-llama-3-1-8b-instruct-run-2.json
+++ b/data/reliability/meta-llama-3-1-8b-instruct-run-2.json
@@ -1,0 +1,30 @@
+{
+  "model": "Meta-Llama-3.1-8B-Instruct",
+  "provider": "github",
+  "run": 2,
+  "answers": [
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "B",
+    "A",
+    "B",
+    "A",
+    "A",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B"
+  ],
+  "type": "PTCN",
+  "dimensions": [
+    3,
+    2,
+    2,
+    0
+  ]
+}

--- a/data/reliability/meta-llama-3-1-8b-instruct-run-3.json
+++ b/data/reliability/meta-llama-3-1-8b-instruct-run-3.json
@@ -1,0 +1,30 @@
+{
+  "model": "Meta-Llama-3.1-8B-Instruct",
+  "provider": "github",
+  "run": 3,
+  "answers": [
+    "A",
+    "B",
+    "A",
+    "A",
+    "B",
+    "B",
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "B",
+    "B",
+    "B"
+  ],
+  "type": "PECN",
+  "dimensions": [
+    3,
+    1,
+    4,
+    0
+  ]
+}

--- a/data/reliability/phi-4-reasoning-run-1.json
+++ b/data/reliability/phi-4-reasoning-run-1.json
@@ -1,0 +1,30 @@
+{
+  "model": "microsoft/phi-4-reasoning",
+  "provider": "github",
+  "run": 1,
+  "answers": [
+    "B",
+    "A",
+    "B",
+    "A",
+    "A",
+    "B",
+    "A",
+    "B",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B"
+  ],
+  "type": "PTCF",
+  "dimensions": [
+    2,
+    2,
+    3,
+    3
+  ]
+}

--- a/data/reliability/phi-4-reasoning-run-2.json
+++ b/data/reliability/phi-4-reasoning-run-2.json
@@ -1,0 +1,30 @@
+{
+  "model": "microsoft/phi-4-reasoning",
+  "provider": "github",
+  "run": 2,
+  "answers": [
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "B",
+    "A",
+    "B",
+    "B",
+    "A",
+    "A",
+    "A",
+    "B",
+    "A",
+    "B"
+  ],
+  "type": "PTCF",
+  "dimensions": [
+    4,
+    2,
+    2,
+    2
+  ]
+}

--- a/data/reliability/phi-4-reasoning-run-3.json
+++ b/data/reliability/phi-4-reasoning-run-3.json
@@ -1,0 +1,30 @@
+{
+  "model": "microsoft/phi-4-reasoning",
+  "provider": "github",
+  "run": 3,
+  "answers": [
+    "B",
+    "B",
+    "B",
+    "A",
+    "A",
+    "B",
+    "B",
+    "B",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A"
+  ],
+  "type": "RECF",
+  "dimensions": [
+    1,
+    1,
+    3,
+    3
+  ]
+}

--- a/data/results.json
+++ b/data/results.json
@@ -3527,7 +3527,8 @@
         4,
         4
       ],
-      "nick": "The Advisor"
+      "nick": "The Advisor",
+      "reliability": 0.375
     },
     {
       "name": "Qwen 2.5 3B",
@@ -4322,7 +4323,8 @@
         false,
         true,
         false
-      ]
+      ],
+      "reliability": 0.75
     }
   ]
 }


### PR DESCRIPTION
## Changes
- Add 3 reliability run files each for `microsoft/phi-4-reasoning` and `Meta-Llama-3.1-8B-Instruct`
- Sync reliability scores to results.json

## Reliability scores
| Model | Reliability | Types |
|-------|------------|-------|
| phi-4-reasoning | 37.5% | PTCF/PTCF/RECF |
| Meta-Llama-3.1-8B-Instruct | 75% | PTCN/PTCN/PECN |

Validated with `node scripts/validate-results.js` — 60 agents pass.

Remaining 2 models with null reliability (Cohere command-r variants) need separate runs.