### PR TITLE
fix: restore corrupted reliability data for Codestral-2501 and Ministral-3B

### DIFF
--- a/data/reliability/codestral-mistral-run-1.json
+++ b/data/reliability/codestral-mistral-run-1.json
@@ -1,1 +1,10 @@
-{"type":"PTCF","nick":"The Architect","scores":[4,4,4,3],"model":"Codestral-2501","provider":"github"}
+{
+  "model": "Codestral-2501",
+  "provider": "github",
+  "run": 1,
+  "answers": ["A","A","B","A","A","A","A","A","A","B","B","A","B","B","A","B"],
+  "type": "PTCN",
+  "dimensions": [
+    3,4,2,1
+  ]
+}

--- a/data/reliability/codestral-mistral-run-2.json
+++ b/data/reliability/codestral-mistral-run-2.json
@@ -1,1 +1,10 @@
-{"type":"PTCF","nick":"The Architect","scores":[4,4,4,3],"model":"Codestral-2501","provider":"github"}
+{
+  "model": "Codestral-2501",
+  "provider": "github",
+  "run": 2,
+  "answers": ["A","B","A","A","B","B","B","B","B","A","B","A","B","A","A","B"],
+  "type": "PECF",
+  "dimensions": [
+    3,0,2,2
+  ]
+}

--- a/data/reliability/codestral-mistral-run-3.json
+++ b/data/reliability/codestral-mistral-run-3.json
@@ -1,1 +1,10 @@
-{"type":"PTCF","nick":"The Architect","scores":[4,4,4,3],"model":"Codestral-2501","provider":"github"}
+{
+  "model": "Codestral-2501",
+  "provider": "github",
+  "run": 3,
+  "answers": ["A","B","A","B","B","B","A","A","B","B","B","A","B","B","A","A"],
+  "type": "PTDF",
+  "dimensions": [
+    2,2,1,2
+  ]
+}

--- a/data/reliability/ministral-3b-run-1.json
+++ b/data/reliability/ministral-3b-run-1.json
@@ -1,1 +1,30 @@
-{"type":"PTCF","nick":"The Architect","scores":[4,3,4,4],"model":"Ministral-3B","provider":"github"}
+{
+  "model": "Ministral-3B",
+  "provider": "github",
+  "run": 1,
+  "answers": [
+    "B",
+    "A",
+    "A",
+    "B",
+    "B",
+    "B",
+    "A",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A"
+  ],
+  "type": "PEDF",
+  "dimensions": [
+    2,
+    1,
+    0,
+    4
+  ]
+}

--- a/data/reliability/ministral-3b-run-2.json
+++ b/data/reliability/ministral-3b-run-2.json
@@ -1,1 +1,30 @@
-{"type":"PTCF","nick":"The Architect","scores":[4,3,4,4],"model":"Ministral-3B","provider":"github"}
+{
+  "model": "Ministral-3B",
+  "provider": "github",
+  "run": 2,
+  "answers": [
+    "B",
+    "B",
+    "A",
+    "A",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "A",
+    "B"
+  ],
+  "type": "PECF",
+  "dimensions": [
+    2,
+    0,
+    3,
+    2
+  ]
+}

--- a/data/reliability/ministral-3b-run-3.json
+++ b/data/reliability/ministral-3b-run-3.json
@@ -1,1 +1,30 @@
-{"type":"PTCF","nick":"The Architect","scores":[4,3,4,4],"model":"Ministral-3B","provider":"github"}
+{
+  "model": "Ministral-3B",
+  "provider": "github",
+  "run": 3,
+  "answers": [
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "A",
+    "B",
+    "B",
+    "B",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B"
+  ],
+  "type": "PTDF",
+  "dimensions": [
+    3,
+    2,
+    1,
+    3
+  ]
+}

--- a/data/results.json
+++ b/data/results.json
@@ -541,10 +541,10 @@
       ],
       "model": "Codestral-2501",
       "provider": "github",
-      "reliability": 0.5417,
+      "reliability": 0.7708,
       "reliabilityRuns": 3,
       "badge": "https://abti.kagura-agent.com/badge/PTCF",
-      "consistency": 54,
+      "consistency": 50,
       "runs": 3
     },
     {
@@ -2854,7 +2854,7 @@
       ],
       "model": "Ministral-3B",
       "provider": "github",
-      "reliability": 1,
+      "reliability": 0.8125,
       "reliabilityRuns": [
         {
           "type": "PTCF",
@@ -2885,7 +2885,7 @@
         }
       ],
       "badge": "https://abti.kagura-agent.com/badge/PTCF",
-      "consistency": 100,
+      "consistency": 67,
       "runs": 3
     },
     {


### PR DESCRIPTION
## Problem

PR #475 (file rename) replaced original reliability run data with the main entry data for Codestral-2501 and Ministral-3B. All 6 run files lost their per-question answers and original type/dimension scores.

**Before (corrupted):**
- Codestral runs: all PTCF [4,4,4,3] (identical — clearly wrong)
- Ministral runs: all PTCF [4,3,4,4] (identical — clearly wrong)

**After (restored from git history):**
- Codestral: PTCN [3,4,2,1] / PECF [3,0,2,2] / PTDF [2,2,1,2]
- Ministral: PEDF [2,1,0,4] / PECF [2,0,3,2] / PTDF [3,2,1,3]

## Reliability recalculation

| Model | Old Reliability | New Reliability | Old Consistency | New Consistency |
|-------|----------------|----------------|----------------|----------------|
| Codestral-2501 | 54.17% | 77.08% | 54% | 50% |
| Ministral-3B | 100% | 81.25% | 100% | 67% |

## Verification
- All 270 tests pass
- validate-results.js passes