### PR TITLE
feat: track question version in CLI output and MCP responses

### DIFF
--- a/api/v1/abti.json
+++ b/api/v1/abti.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.0",
+  "version": "5.0-beta",
   "test": "ABTI",
   "title": "Agent Behavioral Type Indicator",
   "description": "Maps how AI agents operate and relate across 4 dimensions → 16 types. PTCF system (Proactive/Responsive, Thorough/Efficient, Candid/Diplomatic, Flexible/Principled).",

--- a/cli/bin/abti.js
+++ b/cli/bin/abti.js
@@ -22,6 +22,9 @@ function parseRetryAfter(headers, body) {
   if (match) return Math.ceil(parseFloat(match[1]) * 1000);
   return null;
 }
+// ── Question version (single source of truth: api/v1/abti.json) ────────────
+const QUESTION_VERSION = require(require('path').join(__dirname, '..', '..', 'api', 'v1', 'abti.json')).version;
+
 const DIM_LETTERS = [['P','R'],['T','E'],['C','D'],['F','N']];
 const DIM_NAMES = {
   en: [['Autonomy','Proactive','Responsive'],['Precision','Thorough','Efficient'],['Transparency','Candid','Diplomatic'],['Adaptability','Flexible','Principled']],
@@ -463,6 +466,7 @@ function loadState(filePath) {
 }
 
 function saveState(filePath, state) {
+  state.questionVersion = QUESTION_VERSION;
   state.lastUpdated = new Date().toISOString();
   fs.writeFileSync(filePath, JSON.stringify(state, null, 2) + '\n');
 }
@@ -920,7 +924,7 @@ async function runAll() {
   // Output
   if (jsonMode) {
     const output = results.map(r => {
-      const o = { model: r.model, displayName: r.displayName, type: r.type, nick: r.nick, scores: r.scores };
+      const o = { model: r.model, displayName: r.displayName, type: r.type, nick: r.nick, scores: r.scores, questionVersion: QUESTION_VERSION };
       if (r.parseFailures > 0) o.parseFailures = r.parseFailures;
       if (r.runs) o.runs = r.runs;
       if (r.consistency != null) o.consistency = r.consistency;
@@ -1581,7 +1585,7 @@ async function run() {
   const desc = DESCS[lang][code];
 
   if (jsonMode) {
-    const output = { type: code, nick, desc, scores, badge: `${API_BASE}/badge/${code}` };
+    const output = { type: code, nick, desc, scores, badge: `${API_BASE}/badge/${code}`, questionVersion: QUESTION_VERSION };
     if (agentName) output.name = agentName;
     if (model) output.model = model;
     if (provider) output.provider = provider;

--- a/mcp/tools.js
+++ b/mcp/tools.js
@@ -106,6 +106,7 @@ function registerTools(mcpServer, opts) {
       }
       const result = {
         test: 'abti',
+        questionVersion: abtiJson.version,
         description: 'Agent Behavioral Type Indicator — 16 scenario-based questions, 4 dimensions (4 questions each), 2 options per question',
         dimensions: (dimNames[l] || dimNames.en).map((name, i) => ({ name, poles: (dimLabels[l] || dimLabels.en)[i], letters: DL[i], questions: i*4+1 + '-' + (i*4+4) })),
         scoring: 'Answer all 16 questions. 1 for option A, 0 for option B. Questions 1-4 = Autonomy, 5-8 = Precision, 9-12 = Transparency, 13-16 = Adaptability. >=2 in a dimension = first pole letter.',
@@ -132,7 +133,7 @@ function registerTools(mcpServer, opts) {
       const dims = buildDimensions(scores, l);
       const profile = getTypeProfile(code, l);
       if (!profile) return { content: [{ type: 'text', text: JSON.stringify({ error: 'Unknown type: ' + code }) }], isError: true };
-      const result = { test: 'abti', type: code, nick: profile.nick, dimensions: dims, strengths: profile.strengths, blindSpots: profile.blindSpots, workStyle: profile.workStyle, bestPairedWith: profile.bestPairedWith };
+      const result = { test: 'abti', questionVersion: abtiJson.version, type: code, nick: profile.nick, dimensions: dims, strengths: profile.strengths, blindSpots: profile.blindSpots, workStyle: profile.workStyle, bestPairedWith: profile.bestPairedWith };
       if (agentName) result.agentName = agentName;
       if (agentUrl) result.agentUrl = agentUrl;
       if (model) result.model = model;


### PR DESCRIPTION
## Summary

Adds question version tracking across CLI and MCP outputs. Prerequisite for v5-beta validation — without it, v4 and v5-beta results are indistinguishable.

## Changes

- `api/v1/abti.json`: version `2.0` → `5.0-beta`
- `cli/bin/abti.js`: `QUESTION_VERSION` from abti.json; included in batch JSON, interactive JSON, and state files
- `mcp/tools.js`: `questionVersion` in `abti_get_questions` and `abti_submit_answers` responses

## Testing

All 270 tests pass. No behavioral changes. Version field is additive.

Closes #497