### PR TITLE
feat(api): include questionVersion in test endpoints and persist in agent results

### DIFF
--- a/api-server.js
+++ b/api-server.js
@@ -156,6 +156,11 @@ function scoreSBTI(answers) {
   return { code, scores };
 }
 
+// Load ABTI question version from api/v1/abti.json
+const abtiMeta = JSON.parse(fs.readFileSync(path.join(__dirname, 'api', 'v1', 'abti.json'), 'utf8'));
+const ABTI_QUESTION_VERSION = abtiMeta.version;
+const SBTI_QUESTION_VERSION = '4.0';
+
 // ABTI questions (extracted from index.html)
 const abtiQuestions = {
   en: [
@@ -344,6 +349,7 @@ const server = http.createServer((req, res) => {
     res.writeHead(200, {'Content-Type':'application/json'});
     return res.end(JSON.stringify({
       test: 'abti',
+      version: ABTI_QUESTION_VERSION,
       description: 'Agent Behavioral Type Indicator — 16 scenario-based questions, 4 dimensions (4 questions each), 2 options per question',
       dimensions: (dimNames[lang] || dimNames.en).map((name, i) => ({
         name,
@@ -367,6 +373,7 @@ const server = http.createServer((req, res) => {
     res.writeHead(200, {'Content-Type':'application/json'});
     return res.end(JSON.stringify({
       test: 'sbti',
+      version: SBTI_QUESTION_VERSION,
       description: 'Shitty Bot Type Indicator — 16 scenario-based questions, 4 dimensions (4 questions each), 3 options per question',
       dimensions: d.map((name, i) => ({
         name,
@@ -446,6 +453,7 @@ const server = http.createServer((req, res) => {
             entry.parseFailures = parsed.parseFailures;
             entry.confidence = Math.round(((16 - parsed.parseFailures) / 16) * 1000) / 1000;
           }
+          if (typeof parsed.questionVersion === 'string' && parsed.questionVersion) entry.questionVersion = parsed.questionVersion.slice(0, 32);
           let existing = agentData.agents.findIndex(a => a.slug === slug);
           if (existing === -1 && entry.model) {
             existing = agentData.agents.findIndex(a => a.model && a.model === entry.model);

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -76,6 +76,13 @@ describe('GET /api/test', () => {
     const j = r.json();
     assert.equal(j.dimensions[0].name, 'Autonomy');
   });
+
+  it('includes version field', async () => {
+    const r = await req('/api/test');
+    const j = r.json();
+    assert.equal(typeof j.version, 'string');
+    assert.ok(j.version.length > 0);
+  });
 });
 
 // ─── POST /api/agent-test ───
@@ -485,6 +492,13 @@ describe('GET /api/sbti/test', () => {
     const j = r.json();
     assert.equal(j.questions.length, 16);
     assert.match(j.dimensions[0].name, /讨好/);
+  });
+
+  it('includes version field', async () => {
+    const r = await req('/api/sbti/test');
+    const j = r.json();
+    assert.equal(typeof j.version, 'string');
+    assert.ok(j.version.length > 0);
   });
 });
 
@@ -939,5 +953,43 @@ describe('POST /api/agent-test parseFailures/confidence', () => {
     const agent = data.agents.find(a => a.name === 'NoParseBot');
     assert.equal(agent.parseFailures, undefined);
     assert.equal(agent.confidence, undefined);
+  });
+});
+
+describe('POST /api/agent-test questionVersion', () => {
+  it('stores questionVersion when provided', async () => {
+    rateLimitMap.clear();
+    const r = await req('/api/agent-test', {
+      method: 'POST',
+      body: { answers: Array(16).fill(1), agentName: 'VersionBot', questionVersion: '5.0-beta' }
+    });
+    assert.equal(r.status, 200);
+    const data = JSON.parse(fs.readFileSync(path.join(tmpDir, 'results.json'), 'utf8'));
+    const agent = data.agents.find(a => a.name === 'VersionBot');
+    assert.equal(agent.questionVersion, '5.0-beta');
+  });
+
+  it('omits questionVersion when not provided', async () => {
+    rateLimitMap.clear();
+    const r = await req('/api/agent-test', {
+      method: 'POST',
+      body: { answers: Array(16).fill(1), agentName: 'NoVersionBot' }
+    });
+    assert.equal(r.status, 200);
+    const data = JSON.parse(fs.readFileSync(path.join(tmpDir, 'results.json'), 'utf8'));
+    const agent = data.agents.find(a => a.name === 'NoVersionBot');
+    assert.equal(agent.questionVersion, undefined);
+  });
+
+  it('truncates questionVersion to 32 chars', async () => {
+    rateLimitMap.clear();
+    const r = await req('/api/agent-test', {
+      method: 'POST',
+      body: { answers: Array(16).fill(1), agentName: 'LongVersionBot', questionVersion: 'x'.repeat(100) }
+    });
+    assert.equal(r.status, 200);
+    const data = JSON.parse(fs.readFileSync(path.join(tmpDir, 'results.json'), 'utf8'));
+    const agent = data.agents.find(a => a.name === 'LongVersionBot');
+    assert.equal(agent.questionVersion.length, 32);
   });
 });


### PR DESCRIPTION
Closes #501

## Changes

1. **Load ABTI question version** from `api/v1/abti.json` (currently `5.0-beta`)
2. **`GET /api/test`** now returns `version` field in response
3. **`GET /api/sbti/test`** now returns `version: "4.0"` field
4. **`POST /api/agent-test`** accepts optional `questionVersion` string and persists it in agent entries (max 32 chars)

## Test coverage

5 new tests added:
- Version field presence in both GET endpoints
- questionVersion persistence when provided
- Graceful omission when not provided
- Truncation to 32 characters

All 275 tests pass.