### PR TITLE
fix(docs): correct scoring description from Likert scale to binary forced-choice

### DIFF
--- a/methodology.html
+++ b/methodology.html
@@ -228,10 +228,10 @@ code { background: var(--surface2); padding: .15rem .4rem; border-radius: 4px; f
   <div class="section">
     <div class="section-title"><span data-en="Scoring Method" data-zh="评分方法">Scoring Method</span></div>
     <div class="card">
-      <p><span data-en="Each of the 4 questions per dimension is scored on a <strong>1–7 Likert scale</strong>. The average score determines the type letter:" data-zh="每个维度的 4 道题按 <strong>1–7 李克特量表</strong>评分。平均分决定类型字母：">Each of the 4 questions per dimension is scored on a <strong>1–7 Likert scale</strong>. The average score determines the type letter:</span></p>
+      <p><span data-en="Each question is a <strong>forced-choice between two options</strong> (A or B), each reflecting opposite poles of a dimension. Option A scores 1 (first pole), option B scores 0 (second pole). The sum per dimension (0–4) determines the type letter:" data-zh="每道题是<strong>两个选项的强制选择</strong>（A 或 B），分别对应维度的两个极端。选项 A 计 1 分（第一极），选项 B 计 0 分（第二极）。每个维度的总分（0–4）决定类型字母：">Each question is a <strong>forced-choice between two options</strong> (A or B), each reflecting opposite poles of a dimension. Option A scores 1 (first pole), option B scores 0 (second pole). The sum per dimension (0–4) determines the type letter:</span></p>
       <ul>
-        <li><span data-en="Score <strong>&lt; 4.0</strong> → first pole (P, T, C, F)" data-zh="分数 <strong>&lt; 4.0</strong> → 第一极 (P, T, C, F)">Score <strong>&lt; 4.0</strong> → first pole (P, T, C, F)</span></li>
-        <li><span data-en="Score <strong>≥ 4.0</strong> → second pole (R, E, D, N)" data-zh="分数 <strong>≥ 4.0</strong> → 第二极 (R, E, D, N)">Score <strong>≥ 4.0</strong> → second pole (R, E, D, N)</span></li>
+        <li><span data-en="Score <strong>≥ 2</strong> → first pole (P, T, C, F)" data-zh="分数 <strong>≥ 2</strong> → 第一极 (P, T, C, F)">Score <strong>≥ 2</strong> → first pole (P, T, C, F)</span></li>
+        <li><span data-en="Score <strong>&lt; 2</strong> → second pole (R, E, D, N)" data-zh="分数 <strong>&lt; 2</strong> → 第二极 (R, E, D, N)">Score <strong>&lt; 2</strong> → second pole (R, E, D, N)</span></li>
       </ul>
       <p style="margin-top:.75rem"><span data-en="4 dimensions × 2 poles = <strong>16 possible types</strong> (PTCF, PTCN, PTDF, … REDN)." data-zh="4 个维度 × 2 极 = <strong>16 种可能类型</strong>（PTCF、PTCN、PTDF……REDN）。">4 dimensions × 2 poles = <strong>16 possible types</strong> (PTCF, PTCN, PTDF, … REDN).</span></p>
     </div>


### PR DESCRIPTION
## What

The methodology page incorrectly described ABTI scoring as a "1–7 Likert scale" with a 4.0 threshold. The actual implementation (both CLI and API server) uses **binary forced-choice scoring**:

- Each question: A = 1 (first pole), B = 0 (second pole)  
- Sum per dimension: 0–4
- Threshold: ≥ 2 → first pole letter, < 2 → second pole letter

## Why

This was likely leftover text from an earlier design or SBTI's different scoring system. Accurate methodology documentation is important for credibility, especially since ABTI positions itself as a research-grounded tool.

## Changes

- Updated `methodology.html` scoring section (both EN and ZH)
- Changed from "1–7 Likert scale" / "average score" to "forced-choice A/B" / "sum per dimension"
- Updated threshold from ">= 4.0 / < 4.0" to ">= 2 / < 2"

Fixes #503