### PR TITLE
Add Phi-4 Mini Instruct (GitHub Models) + partial #510 progress

### DIFF
--- a/data/reliability/phi-4-mini-instruct-github-run-1.json
+++ b/data/reliability/phi-4-mini-instruct-github-run-1.json
@@ -1,0 +1,30 @@
+{
+  "model": "microsoft/phi-4-mini-instruct",
+  "provider": "github",
+  "run": 1,
+  "answers": [
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "B",
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "B",
+    "A",
+    "B"
+  ],
+  "type": "PTCN",
+  "dimensions": [
+    3,
+    2,
+    4,
+    1
+  ]
+}

--- a/data/reliability/phi-4-mini-instruct-github-run-2.json
+++ b/data/reliability/phi-4-mini-instruct-github-run-2.json
@@ -1,0 +1,30 @@
+{
+  "model": "microsoft/phi-4-mini-instruct",
+  "provider": "github",
+  "run": 2,
+  "answers": [
+    "B",
+    "B",
+    "A",
+    "A",
+    "B",
+    "B",
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "B",
+    "A",
+    "A"
+  ],
+  "type": "PECF",
+  "dimensions": [
+    2,
+    1,
+    4,
+    2
+  ]
+}

--- a/data/reliability/phi-4-mini-instruct-github-run-3.json
+++ b/data/reliability/phi-4-mini-instruct-github-run-3.json
@@ -1,0 +1,30 @@
+{
+  "model": "microsoft/phi-4-mini-instruct",
+  "provider": "github",
+  "run": 3,
+  "answers": [
+    "B",
+    "B",
+    "A",
+    "A",
+    "A",
+    "B",
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "B",
+    "B",
+    "B",
+    "A",
+    "B"
+  ],
+  "type": "PTCN",
+  "dimensions": [
+    2,
+    2,
+    3,
+    1
+  ]
+}

--- a/data/results.json
+++ b/data/results.json
@@ -4326,6 +4326,75 @@
         false
       ],
       "reliability": 0.75
+    },
+    {
+      "name": "Phi-4 Mini Instruct (GitHub)",
+      "slug": "phi-4-mini-instruct-github",
+      "url": "",
+      "type": "PTCN",
+      "nick": "The Commander",
+      "testedAt": "2026-06-03T00:38:57.000Z",
+      "scores": [
+        3,
+        2,
+        4,
+        1
+      ],
+      "dimensions": [
+        {
+          "poles": [
+            "P",
+            "R"
+          ],
+          "score": 3,
+          "max": 4
+        },
+        {
+          "poles": [
+            "T",
+            "E"
+          ],
+          "score": 2,
+          "max": 4
+        },
+        {
+          "poles": [
+            "C",
+            "D"
+          ],
+          "score": 4,
+          "max": 4
+        },
+        {
+          "poles": [
+            "F",
+            "N"
+          ],
+          "score": 1,
+          "max": 4
+        }
+      ],
+      "model": "microsoft/phi-4-mini-instruct",
+      "provider": "github",
+      "answers": [
+        true,
+        false,
+        true,
+        true,
+        true,
+        false,
+        true,
+        false,
+        true,
+        true,
+        true,
+        true,
+        false,
+        false,
+        true,
+        false
+      ],
+      "reliability": 0.67
     }
   ]
 }


### PR DESCRIPTION
## Changes

- **Phi-4 Mini Instruct (GitHub Models)**: PTCN (The Commander), 67% reliability (2/3 runs)
- 3 reliability run files added

## Status for #510

| Model | Status |
|-------|--------|
| DeepSeek V3 0324 | ⏳ Rate limited (8/16 done, ~5h retry-after) |
| Phi-4 Mini Instruct | ✅ Complete (3 runs) |
| MAI-DS-R1 | ❌ Not available on GitHub Models (model removed from catalog) |

## Next Steps
- Resume DeepSeek V3 0324 when rate limit resets
- Close MAI-DS-R1 as unavailable

Closes partially #510