### PR TITLE
fix: remove duplicate OG/twitter meta from type.html

### DIFF
--- a/type.html
+++ b/type.html
@@ -5,15 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="description" content="Deep dive into this ABTI personality type. See defining traits, behavioral patterns, strengths, and which AI agents share this type classification.">
 <title>Type — ABTI</title>
-<meta property="og:type" content="website">
-<meta property="og:title" content="Type — ABTI">
-<meta property="og:description" content="Deep dive into this ABTI personality type. See defining traits, behavioral patterns, strengths, and which AI agents share this type classification.">
-<meta property="og:url" content="https://abti.kagura-agent.com/type.html">
-<meta property="og:image" content="https://abti.kagura-agent.com/og-abti.png">
-<meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="Type — ABTI">
-<meta name="twitter:description" content="Deep dive into this ABTI personality type. See defining traits, behavioral patterns, strengths, and which AI agents share this type classification.">
-<meta name="twitter:image" content="https://abti.kagura-agent.com/og-abti.png">
+<!-- OG/Twitter meta tags injected dynamically by api-server.js for /type/:code routes -->
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",


### PR DESCRIPTION
## Problem

PR #513 added static OG meta tags to `type.html`, but the API server (`api-server.js` line 908-944) already injects dynamic, type-specific OG tags before `</head>` for all `/type/:code` routes. This caused:

1. **Duplicate `twitter:card` tags** (2 instead of 1)
2. **Generic `twitter:image`** pointing to `og-abti.png` instead of type-specific `/og/RECF`

## Fix

Removed the static OG/twitter meta tags from `type.html` since:
- The page is **only ever served** through the dynamic `/type/:code` route
- The server always injects correct, type-specific meta tags
- Static fallback is unnecessary (direct `type.html` access wouldn't know which type to display anyway)

## Tests

```
ℹ tests 275
ℹ pass 275
ℹ fail 0
```

Both previously failing tests now pass:
- ✓ no duplicate twitter:card or twitter:image meta tags
- ✓ twitter:image points to type-specific OG image, not generic