### PR TITLE
test: DeepSeek V3 0324 & Phi-4 Mini Instruct test results

### DIFF
--- a/data/results.json
+++ b/data/results.json
@@ -944,6 +944,76 @@
       ]
     },
     {
+      "name": "DeepSeek V3 0324",
+      "slug": "deepseek-v3-0324",
+      "url": "",
+      "type": "PECF",
+      "nick": "The Spark",
+      "testedAt": "2026-06-07T06:44:43.937Z",
+      "scores": [
+        4,
+        1,
+        3,
+        2
+      ],
+      "dimensions": [
+        {
+          "poles": [
+            "P",
+            "R"
+          ],
+          "score": 4,
+          "max": 4
+        },
+        {
+          "poles": [
+            "T",
+            "E"
+          ],
+          "score": 1,
+          "max": 4
+        },
+        {
+          "poles": [
+            "C",
+            "D"
+          ],
+          "score": 3,
+          "max": 4
+        },
+        {
+          "poles": [
+            "F",
+            "N"
+          ],
+          "score": 2,
+          "max": 4
+        }
+      ],
+      "model": "deepseek/DeepSeek-V3-0324",
+      "provider": "github",
+      "rawAnswers": [
+        true,
+        true,
+        true,
+        true,
+        false,
+        false,
+        true,
+        false,
+        true,
+        false,
+        true,
+        true,
+        false,
+        true,
+        true,
+        false
+      ],
+      "parseFailures": 0,
+      "questionVersion": "5.0-beta"
+    },
+    {
       "name": "Dolphin Mistral 7B",
       "slug": "dolphin-mistral-7b",
       "url": "",
@@ -4394,7 +4464,21 @@
         true,
         false
       ],
-      "reliability": 0.67
+      "reliability": 0.67,
+      "reliabilityRuns": [
+        {
+          "type": "PTCN",
+          "scores": null
+        },
+        {
+          "type": "PECF",
+          "scores": null
+        },
+        {
+          "type": "PTCN",
+          "scores": null
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary
Closes #510 (partially — MAI-DS-R1 removed from GitHub Models catalog)

### Results
- **DeepSeek V3 0324**: PECF (The Spark) — submitted to registry, reliability runs pending (daily rate limit)
- **Phi-4 Mini Instruct (GitHub)**: PTCN (The Commander) — 3 reliability runs (67% consistency: PTCN/PECF/PTCN)
- **MAI-DS-R1**: ❌ Removed from GitHub Models catalog, cannot test

### Changes
- Added DeepSeek V3 0324 entry to `data/results.json`
- Updated Phi-4 Mini Instruct (GitHub) with reliability run data

### Notes
- MAI-DS-R1 is no longer available in the GitHub Models catalog
- DeepSeek V3 0324 reliability runs blocked by GitHub Models daily per-model rate limit (retry in ~2h)
- Both models tested via GitHub Models provider with `--submit` to the ABTI registry API