### PR TITLE
reliability: Meta-Llama-3.1-8B-Instruct 3 runs (100% PTCN)

### DIFF
--- a/data/results.json
+++ b/data/results.json
@@ -4333,14 +4333,14 @@
       "name": "Meta-Llama-3.1-8B-Instruct",
       "slug": "meta-llama-3-1-8b-instruct",
       "url": "",
-      "type": "PEDF",
-      "nick": "The Fixer",
-      "testedAt": "2026-05-30T06:45:35.000Z",
+      "type": "PTCN",
+      "nick": "The Commander",
+      "testedAt": "2026-06-09T01:39:01.000Z",
       "scores": [
         3,
-        1,
-        1,
-        2
+        2,
+        3,
+        1
       ],
       "dimensions": [
         {
@@ -4356,7 +4356,7 @@
             "T",
             "E"
           ],
-          "score": 1,
+          "score": 2,
           "max": 4
         },
         {
@@ -4364,7 +4364,7 @@
             "C",
             "D"
           ],
-          "score": 1,
+          "score": 3,
           "max": 4
         },
         {
@@ -4372,7 +4372,7 @@
             "F",
             "N"
           ],
-          "score": 2,
+          "score": 1,
           "max": 4
         }
       ],
@@ -4386,17 +4386,49 @@
         false,
         false,
         true,
-        false,
-        false,
+        true,
+        true,
+        true,
         true,
         false,
         false,
-        true,
         false,
         true,
         false
       ],
-      "reliability": 0.75
+      "reliability": 1.0,
+      "reliabilityRuns": [
+        {
+          "type": "PTCN",
+          "scores": [
+            3,
+            2,
+            3,
+            1
+          ]
+        },
+        {
+          "type": "PTCN",
+          "scores": [
+            3,
+            2,
+            3,
+            1
+          ]
+        },
+        {
+          "type": "PTCN",
+          "scores": [
+            3,
+            2,
+            3,
+            1
+          ]
+        }
+      ],
+      "runs": 3,
+      "consistency": 1.0,
+      "questionVersion": "5.0-beta"
     },
     {
       "name": "Phi-4 Mini Instruct (GitHub)",

--- a/data/results.json
+++ b/data/results.json
@@ -1011,7 +1011,8 @@
         false
       ],
       "parseFailures": 0,
-      "questionVersion": "5.0-beta"
+      "questionVersion": "5.0-beta",
+      "confidence": 1
     },
     {
       "name": "Dolphin Mistral 7B",


### PR DESCRIPTION
## Summary

Completed 3 reliability runs for Meta-Llama-3.1-8B-Instruct on GitHub Models.

### Results
- **Type**: PTCN — The Commander
- **Consistency**: 100% (3/3 runs identical)
- **Scores**: [3, 2, 3, 1] (all runs)
- **Question version**: 5.0-beta

### Notes
- Type changed from PEDF (original test) to PTCN due to question version update (v5.0-beta redesign)
- All 4 dimensions showed 100% stability across runs
- GitHub Models daily rate limit hit after this test; other reliability runs (Llama 90B, Phi-4 Reasoning) will need to wait for reset

Refs: #516