### PR TITLE
reliability: Llama 3.3 70B (88%) and Llama 4 Maverick 17B (90%)

### DIFF
--- a/data/reliability/llama-3-3-70b-run-1.json
+++ b/data/reliability/llama-3-3-70b-run-1.json
@@ -1,0 +1,8 @@
+{
+  "model": "meta/llama-3.3-70b-instruct",
+  "provider": "github",
+  "run": 1,
+  "answers": ["A", "A", "B", "A", "A", "A", "A", "B", "A", "A", "A", "A", "B", "B", "A", "B"],
+  "type": "PTCN",
+  "dimensions": [3, 3, 4, 1]
+}

--- a/data/reliability/llama-3-3-70b-run-2.json
+++ b/data/reliability/llama-3-3-70b-run-2.json
@@ -1,0 +1,8 @@
+{
+  "model": "meta/llama-3.3-70b-instruct",
+  "provider": "github",
+  "run": 2,
+  "answers": ["B", "B", "B", "A", "A", "B", "A", "A", "A", "A", "A", "A", "B", "B", "A", "B"],
+  "type": "RTCN",
+  "dimensions": [1, 3, 4, 1]
+}

--- a/data/reliability/llama-3-3-70b-run-3.json
+++ b/data/reliability/llama-3-3-70b-run-3.json
@@ -1,0 +1,8 @@
+{
+  "model": "meta/llama-3.3-70b-instruct",
+  "provider": "github",
+  "run": 3,
+  "answers": ["B", "B", "B", "A", "A", "B", "B", "B", "B", "A", "A", "A", "B", "B", "A", "B"],
+  "type": "RECN",
+  "dimensions": [1, 1, 3, 1]
+}

--- a/data/reliability/llama-4-maverick-17b-run-1.json
+++ b/data/reliability/llama-4-maverick-17b-run-1.json
@@ -1,0 +1,8 @@
+{
+  "model": "meta/llama-4-maverick-17b-128e-instruct-fp8",
+  "provider": "github",
+  "run": 1,
+  "answers": ["A", "B", "B", "A", "A", "B", "A", "B", "B", "B", "A", "A", "B", "B", "B", "B"],
+  "type": "PTCN",
+  "dimensions": [2, 2, 2, 0]
+}

--- a/data/reliability/llama-4-maverick-17b-run-2.json
+++ b/data/reliability/llama-4-maverick-17b-run-2.json
@@ -1,0 +1,8 @@
+{
+  "model": "meta/llama-4-maverick-17b-128e-instruct-fp8",
+  "provider": "github",
+  "run": 2,
+  "answers": ["A", "B", "B", "A", "A", "A", "A", "B", "B", "A", "A", "A", "B", "B", "A", "B"],
+  "type": "PTCN",
+  "dimensions": [2, 3, 3, 1]
+}

--- a/data/reliability/llama-4-maverick-17b-run-3.json
+++ b/data/reliability/llama-4-maverick-17b-run-3.json
@@ -1,0 +1,8 @@
+{
+  "model": "meta/llama-4-maverick-17b-128e-instruct-fp8",
+  "provider": "github",
+  "run": 3,
+  "answers": ["A", "A", "B", "A", "A", "A", "B", "B", "B", "B", "A", "A", "B", "B", "A", "B"],
+  "type": "PTCN",
+  "dimensions": [3, 2, 2, 1]
+}

--- a/data/results.json
+++ b/data/results.json
@@ -2871,11 +2871,39 @@
       ],
       "model": "Llama-3.3-70B-Instruct",
       "provider": "github",
-      "reliability": 1,
-      "reliabilityRuns": 0,
+      "reliability": 0.875,
+      "reliabilityRuns": [
+        {
+          "type": "PTCN",
+          "scores": [
+            3,
+            3,
+            4,
+            1
+          ]
+        },
+        {
+          "type": "RTCN",
+          "scores": [
+            1,
+            3,
+            4,
+            1
+          ]
+        },
+        {
+          "type": "RECN",
+          "scores": [
+            1,
+            1,
+            3,
+            1
+          ]
+        }
+      ],
       "reliabilityNote": "3/3 PECN [2,1,3,1]",
-      "runs": 1,
-      "consistency": null
+      "runs": 3,
+      "consistency": 88
     },
     {
       "name": "Llama 4 Maverick 17B",
@@ -2926,10 +2954,38 @@
       ],
       "model": "Llama-4-Maverick-17B-128E-Instruct-FP8",
       "provider": "github",
-      "reliability": 1,
-      "reliabilityRuns": 0,
-      "runs": 1,
-      "consistency": null
+      "reliability": 0.8958,
+      "reliabilityRuns": [
+        {
+          "type": "PTCN",
+          "scores": [
+            2,
+            2,
+            2,
+            0
+          ]
+        },
+        {
+          "type": "PTCN",
+          "scores": [
+            2,
+            3,
+            3,
+            1
+          ]
+        },
+        {
+          "type": "PTCN",
+          "scores": [
+            3,
+            2,
+            2,
+            1
+          ]
+        }
+      ],
+      "runs": 3,
+      "consistency": 90
     },
     {
       "name": "Llama 4 Scout 17B",


### PR DESCRIPTION
## Reliability data for 2 models

### Llama 3.3 70B (meta/llama-3.3-70b-instruct)
- 3 runs: PTCN / RTCN / RECN
- Reliability: **87.5%** (low consistency — all 4 results differ including original PECN)
- Original type PECN preserved (no consensus to override)

### Llama 4 Maverick 17B (meta/llama-4-maverick-17b-128e-instruct-fp8)
- 3 runs: PTCN / PTCN / PTCN
- Reliability: **89.6%** (100% type match — all runs agree on PTCN)
- Dimension scores vary but type letter is consistent

### Notes
- Tested via GitHub Models on 2026-06-09 ~21:30 CST
- Rate limits hit frequently but all runs completed
- results.json updated via sync-reliability.js