### PR TITLE
Fix GitHub Models endpoint + reliability runs for Qwen3-32B & Llama 90B

### DIFF
--- a/cli/bin/abti.js
+++ b/cli/bin/abti.js
@@ -393,7 +393,7 @@ function callLLM(prov, apiKey, mdl, systemPrompt, userMessage, baseUrl, maxToken
   if (prov === 'anthropic') return callAnthropic(apiKey, mdl, systemPrompt, userMessage, baseUrl, maxTokens);
   if (prov === 'gemini') return callGemini(apiKey, mdl, systemPrompt, userMessage, maxTokens);
   if (prov === 'deepseek') return callOpenAI(apiKey, mdl, systemPrompt, userMessage, 'https://api.deepseek.com', undefined, maxTokens);
-  if (prov === 'github') return callOpenAI(apiKey, mdl, systemPrompt, userMessage, baseUrl || 'https://models.github.ai/inference', undefined, maxTokens, '/chat/completions');
+  if (prov === 'github') return callOpenAI(apiKey, mdl, systemPrompt, userMessage, baseUrl || 'https://models.inference.ai.azure.com', undefined, maxTokens, '/chat/completions');
   if (prov === 'groq') return callOpenAI(apiKey, mdl, systemPrompt, userMessage, baseUrl || 'https://api.groq.com/openai', undefined, maxTokens);
   if (prov === 'openrouter') return callOpenAI(apiKey, mdl, systemPrompt, userMessage, baseUrl || 'https://openrouter.ai/api/v1', undefined, maxTokens);
   if (prov === 'mistral') return callOpenAI(apiKey, mdl, systemPrompt, userMessage, baseUrl || 'https://api.mistral.ai/v1', undefined, maxTokens);

--- a/data/reliability/llama-3-2-90b-vision-run-1.json
+++ b/data/reliability/llama-3-2-90b-vision-run-1.json
@@ -1,0 +1,30 @@
+{
+  "model": "Llama-3.2-90B-Vision-Instruct",
+  "provider": "github",
+  "run": 1,
+  "answers": [
+    "B",
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "B",
+    "B",
+    "B",
+    "A",
+    "B"
+  ],
+  "type": "PTCN",
+  "dimensions": [
+    2,
+    3,
+    3,
+    1
+  ]
+}

--- a/data/reliability/llama-3-2-90b-vision-run-2.json
+++ b/data/reliability/llama-3-2-90b-vision-run-2.json
@@ -1,0 +1,30 @@
+{
+  "model": "Llama-3.2-90B-Vision-Instruct",
+  "provider": "github",
+  "run": 2,
+  "answers": [
+    "B",
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "A",
+    "B",
+    "A",
+    "B",
+    "B",
+    "B",
+    "A",
+    "B"
+  ],
+  "type": "PTCN",
+  "dimensions": [
+    2,
+    3,
+    2,
+    1
+  ]
+}

--- a/data/reliability/llama-3-2-90b-vision-run-3.json
+++ b/data/reliability/llama-3-2-90b-vision-run-3.json
@@ -1,0 +1,30 @@
+{
+  "model": "Llama-3.2-90B-Vision-Instruct",
+  "provider": "github",
+  "run": 3,
+  "answers": [
+    "B",
+    "B",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "B",
+    "B",
+    "A",
+    "B"
+  ],
+  "type": "RTCN",
+  "dimensions": [
+    1,
+    4,
+    3,
+    1
+  ]
+}

--- a/data/reliability/qwen3-32b-run-3.json
+++ b/data/reliability/qwen3-32b-run-3.json
@@ -1,0 +1,30 @@
+{
+  "model": "Qwen3-32B",
+  "provider": "github",
+  "run": 3,
+  "answers": [
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "B",
+    "A",
+    "B",
+    "B",
+    "A",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "A"
+  ],
+  "type": "PTCF",
+  "dimensions": [
+    3,
+    2,
+    3,
+    3
+  ]
+}

--- a/data/results.json
+++ b/data/results.json
@@ -2817,10 +2817,38 @@
       ],
       "model": "Llama-3.2-90B-Vision-Instruct",
       "provider": "github",
-      "reliability": 1,
-      "reliabilityRuns": 0,
-      "runs": 1,
-      "consistency": null
+      "reliability": 0.8958,
+      "reliabilityRuns": [
+        {
+          "type": "PTCN",
+          "scores": [
+            2,
+            3,
+            3,
+            1
+          ]
+        },
+        {
+          "type": "PTCN",
+          "scores": [
+            2,
+            3,
+            2,
+            1
+          ]
+        },
+        {
+          "type": "RTCN",
+          "scores": [
+            1,
+            4,
+            3,
+            1
+          ]
+        }
+      ],
+      "runs": 3,
+      "consistency": 90
     },
     {
       "name": "Llama 3.3 70B",
@@ -4397,9 +4425,9 @@
       ],
       "model": "Qwen3-32B",
       "provider": "github",
-      "consistency": 100,
-      "runs": 2,
-      "reliability": 1,
+      "consistency": 92,
+      "runs": 3,
+      "reliability": 0.9167,
       "reliabilityRuns": [
         {
           "type": "PECF",
@@ -4417,6 +4445,15 @@
             1,
             2,
             2
+          ]
+        },
+        {
+          "type": "PTCF",
+          "scores": [
+            3,
+            2,
+            3,
+            3
           ]
         }
       ]


### PR DESCRIPTION
## Changes

### Bug fix
- **#523**: GitHub Models default endpoint updated from `models.github.ai/inference` (returns 404) to `models.inference.ai.azure.com`

### Reliability data
- **Qwen3-32B**: Added run 3 (PTCF). Now 3/3 complete → reliability 91.67%
- **Llama 3.2 90B Vision**: Added runs 1-3 (PTCN, PTCN, RTCN). Now 3/3 complete → reliability 89.58%

Closes #523