### PR TITLE
data: add DeepSeek V3 0324 reliability run-1

### DIFF
--- a/data/reliability/deepseek-v3-0324-run-1.json
+++ b/data/reliability/deepseek-v3-0324-run-1.json
@@ -1,0 +1,30 @@
+{
+  "model": "deepseek-v3-0324",
+  "provider": "github",
+  "run": 1,
+  "answers": [
+    "A",
+    "A",
+    "B",
+    "A",
+    "B",
+    "A",
+    "A",
+    "B",
+    "A",
+    "B",
+    "A",
+    "A",
+    "B",
+    "B",
+    "A",
+    "B"
+  ],
+  "type": "PTCN",
+  "dimensions": [
+    3,
+    2,
+    3,
+    1
+  ]
+}

--- a/data/results.json
+++ b/data/results.json
@@ -1049,10 +1049,20 @@
       "parseFailures": 0,
       "questionVersion": "5.0-beta",
       "confidence": 1,
-      "reliabilityRuns": 0,
+      "reliabilityRuns": [
+        {
+          "type": "PTCN",
+          "scores": [
+            3,
+            2,
+            3,
+            1
+          ]
+        }
+      ],
       "runs": 1,
-      "reliability": null,
-      "consistency": null
+      "reliability": 1,
+      "consistency": 100
     },
     {
       "name": "Dolphin Mistral 7B",


### PR DESCRIPTION
## Changes

Add first reliability run for DeepSeek V3 0324.

- **Main result**: PECF (scores 2/1/3/3)
- **Run-1 result**: PTCN (scores 3/2/3/1) — different type
- Converted from completed state file
- Synced results.json with new reliability data

Need 2 more reliability runs to complete assessment. The type difference (PECF vs PTCN) suggests low reliability for this model.

Refs: #516