### PR TITLE
reliability: DeepSeek V3 0324 run-2 (PTCN, 92% reliability)

### DIFF
--- a/data/reliability/deepseek-v3-0324-run-2.json
+++ b/data/reliability/deepseek-v3-0324-run-2.json
@@ -1,0 +1,30 @@
+{
+  "model": "deepseek-v3-0324",
+  "provider": "github",
+  "run": 2,
+  "answers": [
+    "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "B",
+    "A",
+    "B",
+    "A",
+    "A",
+    "B",
+    "B",
+    "B",
+    "B"
+  ],
+  "type": "PTCN",
+  "dimensions": [
+    4,
+    2,
+    3,
+    0
+  ]
+}

--- a/data/results.json
+++ b/data/results.json
@@ -983,14 +983,14 @@
       "name": "DeepSeek V3 0324",
       "slug": "deepseek-v3-0324",
       "url": "",
-      "type": "PECF",
-      "nick": "The Spark",
+      "type": "PTCN",
+      "nick": "The Commander",
       "testedAt": "2026-06-07T06:44:43.937Z",
       "scores": [
         4,
-        1,
+        2,
         3,
-        2
+        1
       ],
       "dimensions": [
         {
@@ -1006,7 +1006,7 @@
             "T",
             "E"
           ],
-          "score": 1,
+          "score": 2,
           "max": 4
         },
         {
@@ -1022,7 +1022,7 @@
             "F",
             "N"
           ],
-          "score": 2,
+          "score": 1,
           "max": 4
         }
       ],
@@ -1034,15 +1034,15 @@
         true,
         true,
         false,
-        false,
-        true,
-        false,
-        true,
-        false,
         true,
         true,
         false,
         true,
+        false,
+        true,
+        true,
+        false,
+        false,
         true,
         false
       ],
@@ -1058,11 +1058,20 @@
             3,
             1
           ]
+        },
+        {
+          "type": "PTCN",
+          "scores": [
+            4,
+            2,
+            3,
+            0
+          ]
         }
       ],
-      "runs": 1,
-      "reliability": 1,
-      "consistency": 100
+      "runs": 3,
+      "reliability": 0.9167,
+      "consistency": 0.6667
     },
     {
       "name": "Dolphin Mistral 7B",


### PR DESCRIPTION
## Changes

- Added reliability run 2 for DeepSeek V3 0324: **PTCN** (scores 4/2/3/0)
- Updated consensus type: PECF → **PTCN** (2/3 runs agree)
- Reliability: **91.67%** (3 runs total)
- Consistency: 66.67%

### Run details
| Run | Type | Autonomy | Precision | Transparency | Adaptability |
|-----|------|----------|-----------|--------------|-------------|
| Main | PECF | 4 | 1 | 3 | 2 |
| Run 1 | PTCN | 3 | 2 | 3 | 1 |
| Run 2 | PTCN | 4 | 2 | 3 | 0 |

All tests pass (275/275).