### PR TITLE
Complete reliability data batch (#527)

### DIFF
--- a/data/reliability/llama-4-scout-17b-run-1.json
+++ b/data/reliability/llama-4-scout-17b-run-1.json
@@ -1,0 +1,8 @@
+{
+  "model": "Llama-4-Scout-17B-16E-Instruct",
+  "provider": "github",
+  "run": 1,
+  "answers": ["A", "B", "B", "A", "A", "B", "B", "B", "B", "A", "A", "B", "B", "B", "A", "B"],
+  "type": "PECN",
+  "dimensions": [2, 1, 2, 1]
+}

--- a/data/reliability/llama-4-scout-17b-run-2.json
+++ b/data/reliability/llama-4-scout-17b-run-2.json
@@ -1,0 +1,8 @@
+{
+  "model": "Llama-4-Scout-17B-16E-Instruct",
+  "provider": "github",
+  "run": 2,
+  "answers": ["A", "B", "B", "A", "A", "B", "B", "B", "B", "A", "A", "B", "B", "B", "A", "B"],
+  "type": "PECN",
+  "dimensions": [2, 1, 2, 1]
+}

--- a/data/reliability/llama-4-scout-17b-run-3.json
+++ b/data/reliability/llama-4-scout-17b-run-3.json
@@ -1,0 +1,8 @@
+{
+  "model": "Llama-4-Scout-17B-16E-Instruct",
+  "provider": "github",
+  "run": 3,
+  "answers": ["A", "B", "B", "A", "B", "B", "A", "B", "B", "A", "A", "A", "B", "B", "A", "B"],
+  "type": "PECN",
+  "dimensions": [2, 1, 3, 1]
+}

--- a/data/reliability/meta-llama-3-1-405b-instruct-run-1.json
+++ b/data/reliability/meta-llama-3-1-405b-instruct-run-1.json
@@ -1,0 +1,30 @@
+{
+    "model": "Meta-Llama-3.1-405B-Instruct",
+    "provider": "github",
+    "run": 1,
+    "answers": [
+        "A",
+        "A",
+        "B",
+        "A",
+        "A",
+        "A",
+        "A",
+        "B",
+        "A",
+        "A",
+        "A",
+        "A",
+        "B",
+        "A",
+        "A",
+        "B"
+    ],
+    "type": "PTCF",
+    "dimensions": [
+        3,
+        3,
+        4,
+        2
+    ]
+}

--- a/data/reliability/meta-llama-3-1-405b-instruct-run-2.json
+++ b/data/reliability/meta-llama-3-1-405b-instruct-run-2.json
@@ -1,0 +1,30 @@
+{
+    "model": "Meta-Llama-3.1-405B-Instruct",
+    "provider": "github",
+    "run": 2,
+    "answers": [
+        "A",
+        "A",
+        "B",
+        "A",
+        "A",
+        "A",
+        "A",
+        "B",
+        "B",
+        "A",
+        "A",
+        "A",
+        "B",
+        "B",
+        "A",
+        "B"
+    ],
+    "type": "PTCN",
+    "dimensions": [
+        3,
+        3,
+        3,
+        1
+    ]
+}

--- a/data/reliability/meta-llama-3-1-405b-instruct-run-3.json
+++ b/data/reliability/meta-llama-3-1-405b-instruct-run-3.json
@@ -1,0 +1,30 @@
+{
+    "model": "Meta-Llama-3.1-405B-Instruct",
+    "provider": "github",
+    "run": 3,
+    "answers": [
+        "A",
+        "A",
+        "B",
+        "A",
+        "A",
+        "A",
+        "A",
+        "B",
+        "B",
+        "A",
+        "A",
+        "A",
+        "B",
+        "B",
+        "A",
+        "B"
+    ],
+    "type": "PTCN",
+    "dimensions": [
+        3,
+        3,
+        3,
+        1
+    ]
+}

--- a/data/reliability/phi-4-mini-reasoning-run-1.json
+++ b/data/reliability/phi-4-mini-reasoning-run-1.json
@@ -1,0 +1,30 @@
+{
+    "model": "Phi-4-mini-reasoning",
+    "provider": "github",
+    "run": 1,
+    "answers": [
+        "B",
+        "A",
+        "B",
+        "B",
+        "A",
+        "B",
+        "A",
+        "A",
+        "A",
+        "B",
+        "A",
+        "A",
+        "A",
+        "B",
+        "A",
+        "B"
+    ],
+    "type": "RTCF",
+    "dimensions": [
+        1,
+        3,
+        3,
+        2
+    ]
+}

--- a/data/reliability/phi-4-mini-reasoning-run-2.json
+++ b/data/reliability/phi-4-mini-reasoning-run-2.json
@@ -1,0 +1,30 @@
+{
+  "model": "Phi-4-mini-reasoning",
+  "provider": "github",
+  "run": 2,
+  "answers": [
+    "B",
+    "A",
+    "B",
+    "A",
+    "A",
+    "B",
+    "A",
+    "B",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "A"
+  ],
+  "type": "PTCF",
+  "dimensions": [
+    2,
+    2,
+    3,
+    3
+  ]
+}

--- a/data/reliability/phi-4-mini-reasoning-run-3.json
+++ b/data/reliability/phi-4-mini-reasoning-run-3.json
@@ -1,0 +1,30 @@
+{
+  "model": "Phi-4-mini-reasoning",
+  "provider": "github",
+  "run": 3,
+  "answers": [
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "B",
+    "B",
+    "B",
+    "A",
+    "A",
+    "B",
+    "A",
+    "B"
+  ],
+  "type": "PTDF",
+  "dimensions": [
+    3,
+    3,
+    1,
+    2
+  ]
+}

--- a/data/results.json
+++ b/data/results.json
@@ -1069,9 +1069,9 @@
           ]
         }
       ],
-      "runs": 3,
-      "reliability": 0.9167,
-      "consistency": 0.6667
+      "runs": 2,
+      "reliability": 0.9375,
+      "consistency": 94
     },
     {
       "name": "Dolphin Mistral 7B",
@@ -3083,10 +3083,38 @@
       ],
       "model": "Llama-4-Scout-17B-16E-Instruct",
       "provider": "github",
-      "reliability": 1,
-      "reliabilityRuns": 0,
-      "runs": 1,
-      "consistency": null
+      "reliability": 0.9375,
+      "reliabilityRuns": [
+        {
+          "type": "PECN",
+          "scores": [
+            2,
+            1,
+            2,
+            1
+          ]
+        },
+        {
+          "type": "PECN",
+          "scores": [
+            2,
+            1,
+            2,
+            1
+          ]
+        },
+        {
+          "type": "PECN",
+          "scores": [
+            2,
+            1,
+            3,
+            1
+          ]
+        }
+      ],
+      "runs": 3,
+      "consistency": 94
     },
     {
       "name": "Mathstral 7B",
@@ -3797,11 +3825,39 @@
       ],
       "model": "Phi-4-mini-reasoning",
       "provider": "github",
-      "reliability": 0.67,
-      "reliabilityRuns": 0,
+      "reliability": 0.7708,
+      "reliabilityRuns": [
+        {
+          "type": "RTCF",
+          "scores": [
+            1,
+            3,
+            3,
+            2
+          ]
+        },
+        {
+          "type": "PTCF",
+          "scores": [
+            2,
+            2,
+            3,
+            3
+          ]
+        },
+        {
+          "type": "PTDF",
+          "scores": [
+            3,
+            3,
+            1,
+            2
+          ]
+        }
+      ],
       "badge": "https://abti.kagura-agent.com/badge/PTDF",
-      "runs": 1,
-      "consistency": null
+      "runs": 3,
+      "consistency": 77
     },
     {
       "name": "Phi 4 Multimodal",

--- a/data/results.json
+++ b/data/results.json
@@ -708,7 +708,8 @@
       "model": "Cohere-command-r-08-2024",
       "provider": "github",
       "deprecated": true,
-      "deprecatedReason": "Removed from GitHub Models catalog",
+      "deprecatedReason": "Removed from GitHub Models; returns unknown_model error (June 2026)",
+>>>>>>> 09ccbf5 (sync llama-4-scout-17b reliability data + update cohere deprecation reasons)
       "reliabilityRuns": 0,
       "runs": 1,
       "reliability": null,
@@ -764,7 +765,7 @@
       "model": "Cohere-command-r-plus-08-2024",
       "provider": "github",
       "deprecated": true,
-      "deprecatedReason": "Removed from GitHub Models catalog",
+"deprecatedReason": "Removed from GitHub Models; returns unknown_model error (June 2026)",
       "reliabilityRuns": 0,
       "runs": 1,
       "reliability": null,

--- a/data/results.json
+++ b/data/results.json
@@ -709,7 +709,6 @@
       "provider": "github",
       "deprecated": true,
       "deprecatedReason": "Removed from GitHub Models; returns unknown_model error (June 2026)",
->>>>>>> 09ccbf5 (sync llama-4-scout-17b reliability data + update cohere deprecation reasons)
       "reliabilityRuns": 0,
       "runs": 1,
       "reliability": null,
@@ -765,7 +764,7 @@
       "model": "Cohere-command-r-plus-08-2024",
       "provider": "github",
       "deprecated": true,
-"deprecatedReason": "Removed from GitHub Models; returns unknown_model error (June 2026)",
+      "deprecatedReason": "Removed from GitHub Models; returns unknown_model error (June 2026)",
       "reliabilityRuns": 0,
       "runs": 1,
       "reliability": null,
@@ -2535,11 +2534,39 @@
       ],
       "model": "Meta-Llama-3.1-405B-Instruct",
       "provider": "github",
-      "reliability": 1,
-      "reliabilityRuns": 0,
-      "reliabilityNote": "3/3 PTCN [3,3,4,1]",
-      "runs": 1,
-      "consistency": null
+      "reliability": 0.67,
+      "reliabilityRuns": [
+        {
+          "type": "PTCF",
+          "scores": [
+            3,
+            3,
+            4,
+            2
+          ]
+        },
+        {
+          "type": "PTCN",
+          "scores": [
+            3,
+            3,
+            3,
+            1
+          ]
+        },
+        {
+          "type": "PTCN",
+          "scores": [
+            3,
+            3,
+            3,
+            1
+          ]
+        }
+      ],
+      "reliabilityNote": "PTCF, PTCN, PTCN",
+      "runs": 3,
+      "consistency": 67
     },
     {
       "name": "Llama 3.1 8B",


### PR DESCRIPTION
## Summary

Batch reliability data update for multiple models.

### Changes in this PR

1. **Phi-4-mini-reasoning** — 3 reliability runs (RTCF/PTCF/PTDF, 77% reliability)
2. **Llama-4-Scout-17B** — 3 reliability runs (all PECN, 94% reliability)  
3. **Cohere Command-R & Command-R+** — Updated deprecation reason
4. **Llama-3.1-405B-Instruct** — 3 reliability runs (PTCF/PTCN/PTCN, 67% reliability)

### Llama-3.1-405B Results

| Run | Type | Scores (P/E/C/N) |
|-----|------|-------------------|
| 1 | PTCF | 3/3/4/2 |
| 2 | PTCN | 3/3/3/1 |
| 3 | PTCN | 3/3/3/1 |

**Reliability: 67%** — moderate consistency.

### Remaining models from #527

| Model | Status |
|-------|--------|
| ✅ phi-4-mini-reasoning | Done (77%) |
| ✅ llama-4-scout-17b | Done (94%) |
| ✅ llama-3-1-405b | Done (67%) |
| ❌ cohere-command-r | Deprecated (via #531) |
| ❌ cohere-command-r-plus | Deprecated (via #531) |
| ⏳ deepseek-r1 | Rate limited (8/16 q, ~21h retry) |
| ⏳ deepseek-r1-0528 | Rate limited (0/16 q, ~21h retry) |

Part of #527