### PR TITLE
test: isolate OG image generation to tmpDir via ABTI_OG_DIR env

### DIFF
--- a/api-server.js
+++ b/api-server.js
@@ -14,6 +14,7 @@ const mcpSessions = new Map();
 // Data persistence
 let DATA_DIR = process.env.ABTI_DATA_DIR || path.join(__dirname, 'data');
 let DATA_FILE = path.join(DATA_DIR, 'results.json');
+let OG_DIR = process.env.ABTI_OG_DIR || path.join(__dirname, 'og', 'agents');
 
 function loadData() {
   try {
@@ -32,6 +33,7 @@ function saveData(data) {
 function resetData() {
   DATA_DIR = process.env.ABTI_DATA_DIR || path.join(__dirname, 'data');
   DATA_FILE = path.join(DATA_DIR, 'results.json');
+  OG_DIR = process.env.ABTI_OG_DIR || path.join(__dirname, 'og', 'agents');
   agentData = loadData();
   startWatching();
 }
@@ -259,7 +261,7 @@ function registerAgent(entry) {
   if (entry.slug && entry.scores) {
     setImmediate(() => {
       try {
-        generateAgentOG(entry, path.join(__dirname, 'og', 'agents'));
+        generateAgentOG(entry, OG_DIR);
       } catch (e) {
         console.error(`OG generation failed for ${entry.slug}:`, e.message);
       }
@@ -467,7 +469,7 @@ const server = http.createServer((req, res) => {
           // Async OG image generation (non-blocking)
           setImmediate(() => {
             try {
-              generateAgentOG(entry, path.join(__dirname, 'og', 'agents'));
+              generateAgentOG(entry, OG_DIR);
             } catch (e) {
               console.error(`OG generation failed for ${entry.slug}:`, e.message);
             }

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -5,9 +5,11 @@ const os = require('node:os');
 const fs = require('node:fs');
 const path = require('node:path');
 
-// Set up isolated data dir BEFORE requiring the server
+// Set up isolated dirs BEFORE requiring the server
 const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'abti-test-'));
 process.env.ABTI_DATA_DIR = tmpDir;
+process.env.ABTI_OG_DIR = path.join(tmpDir, 'og');
+fs.mkdirSync(process.env.ABTI_OG_DIR, { recursive: true });
 
 const server = require('../api-server.js');
 const { rateLimitMap } = require('../api-server.js');
@@ -128,13 +130,16 @@ describe('POST /api/agent-test', () => {
     assert.ok(dimKeys.some(k => /自主/.test(k)));
   });
 
-  it('registers agent name', async () => {
+  it('writes generated agent OG images to the isolated test directory', async () => {
     const r = await req('/api/agent-test', { method: 'POST', body: { answers: allA, agentName: 'TestBot', agentUrl: 'https://example.com' } });
     assert.equal(r.status, 200);
     // verify via agents list
     const agents = await req('/api/agents');
     const j = agents.json();
     assert.ok(j.agents.some(a => a.name === 'TestBot'));
+
+    await new Promise(resolve => setImmediate(resolve));
+    assert.ok(fs.existsSync(path.join(process.env.ABTI_OG_DIR, 'testbot.png')));
   });
 
   it('stores model and provider when provided', async () => {


### PR DESCRIPTION
Fixes #539.

## Problem

`api-server.js` hardcoded `path.join(__dirname, 'og', 'agents')` for the OG image output dir at two call sites, ignoring the test isolation set up via `ABTI_DATA_DIR`. Every `npm test` run that POSTed a scored agent leaked a real PNG into the repo's `og/agents/` directory (`versionbot.png`, `noversionbot.png`, `slugprioritybot.png`, etc.).

## Fix

1. Add `ABTI_OG_DIR` env override in `api-server.js`, mirroring the existing `ABTI_DATA_DIR` pattern — including the equivalent reset inside `resetData()`.
2. `test/api.test.js` sets `process.env.ABTI_OG_DIR = path.join(tmpDir, 'og')` and `mkdirSync(... { recursive: true })` before requiring `api-server.js`.
3. Renamed/extended the existing `registers agent name` test into `writes generated agent OG images to the isolated test directory` with an `fs.existsSync` assertion against the tmp OG dir, so any future regression of this isolation breaks the test suite.

## Verification

- `npm test` — 275/275 pass.
- After test run: `git status og/agents/` clean — no untracked PNGs leaked.

## Out of scope

- Already-committed test PNGs (`dedupebot.png`, `consistbot.png`, `clihist*.png`) left alone — they predate this issue and removing them risks breaking integration test setup that may reference paths.