### PR TITLE
feat: complete reliability data for DeepSeek-R1 (85.4%) and R1-0528 (91.7%)

### DIFF
--- a/data/reliability/deepseek-r1-0528-run-3.json
+++ b/data/reliability/deepseek-r1-0528-run-3.json
@@ -1,0 +1,30 @@
+{
+    "model": "DeepSeek-R1-0528",
+    "provider": "github",
+    "run": 3,
+    "answers": [
+        "B",
+        "A",
+        "B",
+        "A",
+        "A",
+        "B",
+        "A",
+        "B",
+        "B",
+        "B",
+        "A",
+        "A",
+        "A",
+        "B",
+        "A",
+        "A"
+    ],
+    "type": "PTCF",
+    "dimensions": [
+        2,
+        2,
+        2,
+        3
+    ]
+}

--- a/data/reliability/deepseek-r1-run-3.json
+++ b/data/reliability/deepseek-r1-run-3.json
@@ -1,0 +1,34 @@
+{
+    "model": "DeepSeek-R1",
+    "provider": "github",
+    "run": 3,
+    "answers": [
+        "B",
+        "A",
+        "B",
+        "A",
+        "B",
+        "A",
+        "A",
+        "B",
+        "B",
+        "B",
+        "A",
+        "A",
+        "B",
+        "B",
+        "A",
+        "A",
+        "A",
+        "B",
+        "B",
+        "B"
+    ],
+    "type": "PTCF",
+    "dimensions": [
+        2,
+        2,
+        2,
+        2
+    ]
+}

--- a/data/results.json
+++ b/data/results.json
@@ -819,10 +819,38 @@
       ],
       "model": "DeepSeek-R1",
       "provider": "github",
-      "consistency": 100,
-      "runs": 1,
-      "reliability": 1,
-      "reliabilityRuns": 0
+      "consistency": 85,
+      "runs": 3,
+      "reliability": 0.8542,
+      "reliabilityRuns": [
+        {
+          "type": "PTCN",
+          "scores": [
+            2,
+            2,
+            2,
+            1
+          ]
+        },
+        {
+          "type": "RTCF",
+          "scores": [
+            1,
+            2,
+            2,
+            2
+          ]
+        },
+        {
+          "type": "PTCF",
+          "scores": [
+            2,
+            2,
+            2,
+            2
+          ]
+        }
+      ]
     },
     {
       "name": "DeepSeek R1 0528",
@@ -892,10 +920,38 @@
         true
       ],
       "parseFailures": 0,
-      "consistency": 100,
-      "runs": 1,
-      "reliability": 1,
-      "reliabilityRuns": 0
+      "consistency": 92,
+      "runs": 3,
+      "reliability": 0.9167,
+      "reliabilityRuns": [
+        {
+          "type": "PTCF",
+          "scores": [
+            2,
+            2,
+            2,
+            2
+          ]
+        },
+        {
+          "type": "PTCF",
+          "scores": [
+            4,
+            2,
+            2,
+            3
+          ]
+        },
+        {
+          "type": "PTCF",
+          "scores": [
+            2,
+            2,
+            2,
+            3
+          ]
+        }
+      ]
     },
     {
       "name": "DeepSeek R1 7B",


### PR DESCRIPTION
## Summary

Final reliability data for the last 2 models in #527.

### Results
| Model | Run 1 | Run 2 | Run 3 | Reliability |
|-------|-------|-------|-------|-------------|
| DeepSeek-R1 | PTCN [2,2,2,1] | RTCF [1,2,2,2] | PTCF [2,2,2,2] | **85.42%** |
| DeepSeek-R1-0528 | PTCF [2,2,2,2] | PTCF [4,2,2,3] | PTCF [2,2,2,3] | **91.67%** |

### Notes
- DeepSeek-R1-0528 shows high consistency: PTCF across all 3 runs
- DeepSeek-R1 shows more variation: PTCN → RTCF → PTCF (P/R boundary is thin)
- Completed via drip-testing over 12 days (GitHub Models 8 req/day rate limit)

### Testing
- 275/275 tests pass
- results.json validated by sync-reliability.js

Closes #527