### PR TITLE
fix: update GitHub provider to use models.github.ai/inference endpoint

### DIFF
--- a/action/index.js
+++ b/action/index.js
@@ -251,7 +251,7 @@ function callLLM(provider, apiKey, model, systemPrompt, userMessage, baseUrl) {
   if (provider === 'openai') return callOpenAI(apiKey, model, systemPrompt, userMessage, baseUrl);
   if (provider === 'anthropic') return callAnthropic(apiKey, model, systemPrompt, userMessage, baseUrl);
   if (provider === 'gemini') return callGemini(apiKey, model, systemPrompt, userMessage);
-  if (provider === 'github') return callOpenAI(apiKey, model, systemPrompt, userMessage, baseUrl || 'https://models.inference.ai.azure.com', '/chat/completions');
+  if (provider === 'github') return callOpenAI(apiKey, model, systemPrompt, userMessage, baseUrl || 'https://models.github.ai/inference', '/chat/completions');
   if (provider === 'groq') return callOpenAI(apiKey, model, systemPrompt, userMessage, baseUrl || 'https://api.groq.com/openai');
   if (provider === 'openrouter') return callOpenAI(apiKey, model, systemPrompt, userMessage, baseUrl || 'https://openrouter.ai/api/v1');
   if (provider === 'mistral') return callOpenAI(apiKey, model, systemPrompt, userMessage, baseUrl || 'https://api.mistral.ai/v1');

--- a/cli/bin/abti.js
+++ b/cli/bin/abti.js
@@ -393,7 +393,7 @@ function callLLM(prov, apiKey, mdl, systemPrompt, userMessage, baseUrl, maxToken
   if (prov === 'anthropic') return callAnthropic(apiKey, mdl, systemPrompt, userMessage, baseUrl, maxTokens);
   if (prov === 'gemini') return callGemini(apiKey, mdl, systemPrompt, userMessage, maxTokens);
   if (prov === 'deepseek') return callOpenAI(apiKey, mdl, systemPrompt, userMessage, 'https://api.deepseek.com', undefined, maxTokens);
-  if (prov === 'github') return callOpenAI(apiKey, mdl, systemPrompt, userMessage, baseUrl || 'https://models.inference.ai.azure.com', undefined, maxTokens, '/chat/completions');
+  if (prov === 'github') return callOpenAI(apiKey, mdl, systemPrompt, userMessage, baseUrl || 'https://models.github.ai/inference', undefined, maxTokens, '/chat/completions');
   if (prov === 'groq') return callOpenAI(apiKey, mdl, systemPrompt, userMessage, baseUrl || 'https://api.groq.com/openai', undefined, maxTokens);
   if (prov === 'openrouter') return callOpenAI(apiKey, mdl, systemPrompt, userMessage, baseUrl || 'https://openrouter.ai/api/v1', undefined, maxTokens);
   if (prov === 'mistral') return callOpenAI(apiKey, mdl, systemPrompt, userMessage, baseUrl || 'https://api.mistral.ai/v1', undefined, maxTokens);

--- a/scripts/seed-registry.js
+++ b/scripts/seed-registry.js
@@ -27,7 +27,7 @@ function parseArgs() {
   // Auto-set defaults for known providers
   if (opts.provider === 'ollama' && !opts.baseUrl) opts.baseUrl = 'http://localhost:11434';
   if (opts.provider === 'ollama' && !opts.apiKey) opts.apiKey = 'ollama';
-  if (opts.provider === 'github' && !opts.baseUrl) opts.baseUrl = 'https://models.inference.ai.azure.com';
+  if (opts.provider === 'github' && !opts.baseUrl) opts.baseUrl = 'https://models.github.ai/inference';
   if (opts.provider === 'github' && !opts.apiKey) opts.apiKey = process.env.GITHUB_TOKEN || '';
   if (opts.provider === 'deepseek' && !opts.baseUrl) opts.baseUrl = 'https://api.deepseek.com';
   if (!opts.apiKey && !['ollama'].includes(opts.provider)) { console.error('Error: --api-key is required'); process.exit(1); }


### PR DESCRIPTION
## Summary

Fixes #542 — `--provider github --all` was broken because the catalog API returns model IDs in `vendor/name` format (e.g., `meta/meta-llama-3.1-8b-instruct`) which the old inference endpoint (`models.inference.ai.azure.com`) rejected as "unknown model".

## Changes

Updated the default base URL for the GitHub provider from `https://models.inference.ai.azure.com` to `https://models.github.ai/inference` in 3 files:
- `cli/bin/abti.js`
- `action/index.js`
- `scripts/seed-registry.js`

## Why this is safe

The new endpoint accepts **both** formats:
- Catalog IDs: `meta/meta-llama-3.1-8b-instruct` ✅
- Azure names: `Meta-Llama-3.1-8B-Instruct` ✅

So existing manual tests with Azure-format model names continue to work.

## Verification

- All 275 tests pass
- Integration tested: `npx abti test --provider github --model "meta/meta-llama-3.1-8b-instruct"` → returns PECN type (previously would fail with "unknown model")