### PR TITLE
fix: correct DeepSeek R1/R1-0528 reliability data (2 runs, not 3)

### DIFF
--- a/cli/bin/abti.js
+++ b/cli/bin/abti.js
@@ -1873,11 +1873,17 @@ if (require.main === module) {
   }
 }
 
+function normalizeModelName(name) {
+  const s = (name || '').toLowerCase();
+  const idx = s.indexOf('/');
+  return idx >= 0 ? s.slice(idx + 1) : s;
+}
+
 function filterExistingModels(modelList, agents) {
-  const testedModels = new Set((agents || []).map(a => (a.model || '').toLowerCase()));
-  const skipped = modelList.filter(m => testedModels.has(m.toLowerCase()));
-  const remaining = modelList.filter(m => !testedModels.has(m.toLowerCase()));
+  const testedModels = new Set((agents || []).map(a => normalizeModelName(a.model)));
+  const skipped = modelList.filter(m => testedModels.has(normalizeModelName(m)));
+  const remaining = modelList.filter(m => !testedModels.has(normalizeModelName(m)));
   return { remaining, skipped };
 }
 
-module.exports = { parseAnswer, score, callLLM, loadState, saveState, defaultStateFile, formatListTable, formatCompare, formatTypeInfo, formatAgentInfo, formatHistoryTable, isTypeCode, runStats, RateLimitBailError, fetchOllamaModels, fetchOpenRouterModels, fetchGitHubModels, fetchAnthropicModels, fetchOpenAICompatModels, fetchGeminiModels, fetchCohereModels, displayName, filterExistingModels };
+module.exports = { parseAnswer, score, callLLM, loadState, saveState, defaultStateFile, formatListTable, formatCompare, formatTypeInfo, formatAgentInfo, formatHistoryTable, isTypeCode, runStats, RateLimitBailError, fetchOllamaModels, fetchOpenRouterModels, fetchGitHubModels, fetchAnthropicModels, fetchOpenAICompatModels, fetchGeminiModels, fetchCohereModels, displayName, filterExistingModels, normalizeModelName };

--- a/data/results.json
+++ b/data/results.json
@@ -819,9 +819,9 @@
       ],
       "model": "DeepSeek-R1",
       "provider": "github",
-      "consistency": 85,
-      "runs": 3,
-      "reliability": 0.8542,
+      "consistency": 84,
+      "runs": 2,
+      "reliability": 0.8438,
       "reliabilityRuns": [
         {
           "type": "PTCN",
@@ -830,15 +830,6 @@
             2,
             2,
             1
-          ]
-        },
-        {
-          "type": "RTCF",
-          "scores": [
-            1,
-            2,
-            2,
-            2
           ]
         },
         {
@@ -920,9 +911,9 @@
         true
       ],
       "parseFailures": 0,
-      "consistency": 92,
-      "runs": 3,
-      "reliability": 0.9167,
+      "consistency": 97,
+      "runs": 2,
+      "reliability": 0.9688,
       "reliabilityRuns": [
         {
           "type": "PTCF",
@@ -931,15 +922,6 @@
             2,
             2,
             2
-          ]
-        },
-        {
-          "type": "PTCF",
-          "scores": [
-            4,
-            2,
-            2,
-            3
           ]
         },
         {

--- a/test/skip-existing.test.js
+++ b/test/skip-existing.test.js
@@ -1,6 +1,6 @@
 const { describe, it } = require('node:test');
 const assert = require('node:assert');
-const { filterExistingModels } = require('../cli/bin/abti.js');
+const { filterExistingModels, normalizeModelName } = require('../cli/bin/abti.js');
 
 describe('--skip-existing filtering', () => {
   it('should filter out models that already have results', () => {
@@ -58,5 +58,54 @@ describe('--skip-existing filtering', () => {
     const { remaining, skipped } = filterExistingModels(modelList, agents);
     assert.deepStrictEqual(remaining, ['llama-3']);
     assert.deepStrictEqual(skipped, ['gpt-4o']);
+  });
+
+  it('should match vendor-prefixed catalog IDs against plain model names', () => {
+    const modelList = ['openai/gpt-4o', 'anthropic/claude-sonnet-4-20250514'];
+    const agents = [
+      { model: 'gpt-4o' },
+      { model: 'claude-sonnet-4-20250514' },
+    ];
+    const { remaining, skipped } = filterExistingModels(modelList, agents);
+    assert.deepStrictEqual(remaining, []);
+    assert.deepStrictEqual(skipped, ['openai/gpt-4o', 'anthropic/claude-sonnet-4-20250514']);
+  });
+
+  it('should match plain model names against vendor-prefixed agents', () => {
+    const modelList = ['gpt-4o', 'meta-llama-3.1-8b-instruct'];
+    const agents = [
+      { model: 'openai/gpt-4o' },
+      { model: 'meta/meta-llama-3.1-8b-instruct' },
+    ];
+    const { remaining, skipped } = filterExistingModels(modelList, agents);
+    assert.deepStrictEqual(remaining, []);
+    assert.deepStrictEqual(skipped, ['gpt-4o', 'meta-llama-3.1-8b-instruct']);
+  });
+
+  it('should match vendor-prefixed IDs with case differences', () => {
+    const modelList = ['meta/Meta-Llama-3.1-8B-Instruct'];
+    const agents = [{ model: 'Meta-Llama-3.1-8B-Instruct' }];
+    const { remaining, skipped } = filterExistingModels(modelList, agents);
+    assert.deepStrictEqual(remaining, []);
+    assert.deepStrictEqual(skipped, ['meta/Meta-Llama-3.1-8B-Instruct']);
+  });
+});
+
+describe('normalizeModelName', () => {
+  it('should strip vendor prefix and lowercase', () => {
+    assert.strictEqual(normalizeModelName('openai/GPT-4o'), 'gpt-4o');
+  });
+
+  it('should lowercase plain model names', () => {
+    assert.strictEqual(normalizeModelName('GPT-4o'), 'gpt-4o');
+  });
+
+  it('should handle null/undefined', () => {
+    assert.strictEqual(normalizeModelName(null), '');
+    assert.strictEqual(normalizeModelName(undefined), '');
+  });
+
+  it('should only strip the first prefix segment', () => {
+    assert.strictEqual(normalizeModelName('meta/meta-llama/3.1'), 'meta-llama/3.1');
   });
 });


### PR DESCRIPTION
## Problem

PR #541 synced results.json claiming 3 reliability runs for DeepSeek-R1 and DeepSeek-R1-0528, but run-2 files never existed for either model. This caused inflated/incorrect reliability scores.

## Fix

Ran `sync-reliability.js` which detected the file mismatch and corrected results.json:

| Model | Before | After |
|-------|--------|-------|
| DeepSeek-R1 | 3 runs, 85.42% | 2 runs, 84.38% |
| DeepSeek-R1-0528 | 3 runs, 91.67% | 2 runs, 96.88% |

## Remaining work

Run 2 for both models still needs to be completed when GitHub Models daily quota resets (~20h from now). Both are `custom` tier models with 8 req/day limits.