### PR TITLE
feat(action): add deepseek and cohere provider support

### DIFF
--- a/action/action.yml
+++ b/action/action.yml
@@ -10,7 +10,7 @@ inputs:
     description: 'Path to file containing the agent system prompt (e.g. AGENTS.md)'
     required: false
   provider:
-    description: 'LLM provider: openai, anthropic, or gemini'
+    description: 'LLM provider: openai|anthropic|gemini|deepseek|github|groq|openrouter|mistral|xai|cohere'
     required: true
   model:
     description: 'Model name (e.g. gpt-4o, claude-sonnet-4-20250514)'

--- a/action/index.js
+++ b/action/index.js
@@ -535,10 +535,10 @@ async function run() {
   }
 }
 
-// Allow testing when required as a module (INPUT_PROVIDER won't be set)
-if (!process.env.GITHUB_ACTIONS && !process.env.INPUT_PROVIDER) {
-  module.exports = { callLLM };
-} else {
+// Export for testing; run only when executed directly
+module.exports = { callLLM };
+
+if (require.main === module) {
   run().catch((error) => {
     setFailed(error.message);
   });

--- a/action/index.js
+++ b/action/index.js
@@ -256,7 +256,9 @@ function callLLM(provider, apiKey, model, systemPrompt, userMessage, baseUrl) {
   if (provider === 'openrouter') return callOpenAI(apiKey, model, systemPrompt, userMessage, baseUrl || 'https://openrouter.ai/api/v1');
   if (provider === 'mistral') return callOpenAI(apiKey, model, systemPrompt, userMessage, baseUrl || 'https://api.mistral.ai/v1');
   if (provider === 'xai') return callOpenAI(apiKey, model, systemPrompt, userMessage, baseUrl || 'https://api.x.ai/v1');
-  throw new Error(`Unknown provider: ${provider}. Must be "openai", "anthropic", "gemini", "github", "groq", "openrouter", "mistral", or "xai".`);
+  if (provider === 'deepseek') return callOpenAI(apiKey, model, systemPrompt, userMessage, baseUrl || 'https://api.deepseek.com');
+  if (provider === 'cohere') return callOpenAI(apiKey, model, systemPrompt, userMessage, baseUrl || 'https://api.cohere.com/compatibility');
+  throw new Error(`Unknown provider: ${provider}. Must be "openai", "anthropic", "gemini", "deepseek", "github", "groq", "openrouter", "mistral", "xai", or "cohere".`);
 }
 
 // ─── Answer parsing ──────────────────────────────────────────────────────────
@@ -533,6 +535,11 @@ async function run() {
   }
 }
 
-run().catch((error) => {
-  setFailed(error.message);
-});
+// Allow testing when required as a module (INPUT_PROVIDER won't be set)
+if (!process.env.GITHUB_ACTIONS && !process.env.INPUT_PROVIDER) {
+  module.exports = { callLLM };
+} else {
+  run().catch((error) => {
+    setFailed(error.message);
+  });
+}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "abti",
   "private": true,
   "scripts": {
-    "test": "node --test test/api.test.js test/mcp.test.js test/mcp-http.test.js test/compatibility.test.js test/cross-compatibility.test.js test/auto-reload.test.js test/parseAnswer.test.js test/provider.test.js test/resume.test.js test/list.test.js test/action-drift.test.js test/all-flag.test.js test/feed.test.js test/dynamic-models.test.js test/history.test.js test/shuffle.test.js test/compare.test.js test/info.test.js test/history-cli.test.js test/skip-existing.test.js test/validate-results.test.js test/proxy-sync.test.js",
+    "test": "node --test test/api.test.js test/mcp.test.js test/mcp-http.test.js test/compatibility.test.js test/cross-compatibility.test.js test/auto-reload.test.js test/parseAnswer.test.js test/provider.test.js test/resume.test.js test/list.test.js test/action-drift.test.js test/action-provider.test.js test/all-flag.test.js test/feed.test.js test/dynamic-models.test.js test/history.test.js test/shuffle.test.js test/compare.test.js test/info.test.js test/history-cli.test.js test/skip-existing.test.js test/validate-results.test.js test/proxy-sync.test.js",
     "generate-og": "node scripts/generate-og-images.js",
     "generate-sitemap": "node scripts/generate-sitemap.js",
     "generate-og-agents": "node scripts/generate-agent-og.js",

--- a/test/action-provider.test.js
+++ b/test/action-provider.test.js
@@ -1,0 +1,39 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const { callLLM } = require('../action/index.js');
+
+describe('action callLLM provider routing', () => {
+  it('should throw for unknown provider', () => {
+    assert.throws(
+      () => callLLM('unknown', 'key', 'model', 'sys', 'usr'),
+      /Unknown provider: unknown/
+    );
+  });
+
+  it('should route deepseek to callOpenAI (rejects with network error, not unknown provider)', async () => {
+    const promise = callLLM('deepseek', 'test-key', 'deepseek-chat', 'system', 'user');
+    await assert.rejects(promise, (err) => {
+      assert.ok(!err.message.includes('Unknown provider'), 'should not throw Unknown provider for deepseek');
+      return true;
+    });
+  });
+
+  it('should route cohere to callOpenAI (rejects with network error, not unknown provider)', async () => {
+    const promise = callLLM('cohere', 'test-key', 'command-a-08-2025', 'system', 'user');
+    await assert.rejects(promise, (err) => {
+      assert.ok(!err.message.includes('Unknown provider'), 'should not throw Unknown provider for cohere');
+      return true;
+    });
+  });
+
+  it('should include deepseek and cohere in error message for unknown providers', () => {
+    try {
+      callLLM('bad', 'key', 'model', 'sys', 'usr');
+      assert.fail('should have thrown');
+    } catch (e) {
+      assert.ok(e.message.includes('deepseek'), 'error message should list deepseek as valid provider');
+      assert.ok(e.message.includes('cohere'), 'error message should list cohere as valid provider');
+    }
+  });
+
+});


### PR DESCRIPTION
## Summary

Adds missing provider routing for **DeepSeek** and **Cohere** to the GitHub Action (`action/index.js`).

## Changes

- Add `deepseek` provider → routes to `https://api.deepseek.com` (OpenAI-compatible)
- Add `cohere` provider → routes to `https://api.cohere.com/compatibility` (OpenAI-compatible)
- Update `action.yml` description to list all 10 supported providers
- Export `callLLM` for testability when not running in GitHub Actions
- Add `test/action-provider.test.js` with 4 test cases

## Testing

All 286 tests pass (`npm test`).

Closes #547