### PR TITLE
fix(cli): filter custom-tier models from GitHub --all enumeration

### DIFF
--- a/cli/bin/abti.js
+++ b/cli/bin/abti.js
@@ -141,6 +141,7 @@ const resumeFile = opt('--resume') || null;
 const saveStateFlag = flag('--save-state') || !!resumeFile;
 const interQuestionDelay = parseInt(opt('--delay') || '0', 10);
 const skipExisting = flag('--skip-existing');
+const includeCustomFlag = flag('--include-custom');
 
 // Keep backward compat: --model and --provider used for submit metadata too
 const model = autoModel;
@@ -716,6 +717,7 @@ function fetchGitHubModels(apiKey) {
           const json = JSON.parse(data);
           const models = (Array.isArray(json) ? json : json.data || json.models || [])
             .filter(m => m.supported_output_modalities && m.supported_output_modalities.includes('text'))
+            .filter(m => includeCustomFlag || m.rate_limit_tier !== 'custom')
             .map(m => m.id)
             .sort((a, b) => a.localeCompare(b));
           resolve(models);


### PR DESCRIPTION
## Problem

When running `abti test --provider github --all`, the CLI includes models with `rate_limit_tier: "custom"` (GPT-5 family, o-series reasoning models) that are listed in the catalog but consistently return `400 unavailable_model`. This wastes time on guaranteed failures.

## Fix

- Filter out `custom` tier models by default in `fetchGitHubModels()`
- Add `--include-custom` flag for users with elevated access who want to include them

## Verified behavior

**Without --include-custom (default):**
```
Discovering Github models...
  Skipping 23 already-tested model(s)...
  No models found.  # All accessible models already tested ✓
```

**With --include-custom:**
```
Found 9 model(s): openai/gpt-5, openai/gpt-5-chat, openai/gpt-5-nano, openai/o1, ...
[1/9] openai/gpt-5 → FAILED: unavailable_model
...  # All custom-tier models correctly inaccessible
```

Closes #551