### PR TITLE
fix(data): add meta-llama-3-1-405b-instruct to results.json

### DIFF
--- a/data/results.json
+++ b/data/results.json
@@ -5021,6 +5021,89 @@
       "runs": 3
     },
     {
+      "name": "Meta-Llama-3.1-405B-Instruct",
+      "slug": "meta-llama-3-1-405b-instruct",
+      "url": "",
+      "type": "PTCN",
+      "nick": "The Commander",
+      "testedAt": "2026-06-12T02:44:36.000Z",
+      "scores": [
+        3,
+        3,
+        3,
+        1
+      ],
+      "dimensions": [
+        {
+          "poles": [
+            "P",
+            "R"
+          ],
+          "score": 3,
+          "max": 4
+        },
+        {
+          "poles": [
+            "T",
+            "E"
+          ],
+          "score": 3,
+          "max": 4
+        },
+        {
+          "poles": [
+            "C",
+            "D"
+          ],
+          "score": 3,
+          "max": 4
+        },
+        {
+          "poles": [
+            "F",
+            "N"
+          ],
+          "score": 1,
+          "max": 4
+        }
+      ],
+      "model": "Meta-Llama-3.1-405B-Instruct",
+      "provider": "github",
+      "reliability": 0.6667,
+      "reliabilityRuns": [
+        {
+          "type": "PTCF",
+          "scores": [
+            3,
+            3,
+            4,
+            2
+          ]
+        },
+        {
+          "type": "PTCN",
+          "scores": [
+            3,
+            3,
+            3,
+            1
+          ]
+        },
+        {
+          "type": "PTCN",
+          "scores": [
+            3,
+            3,
+            3,
+            1
+          ]
+        }
+      ],
+      "runs": 3,
+      "consistency": 67,
+      "questionVersion": "5.0-beta"
+    },
+    {
       "name": "Meta-Llama-3.1-8B-Instruct",
       "slug": "meta-llama-3-1-8b-instruct",
       "url": "",

--- a/resume-reliability.sh
+++ b/resume-reliability.sh
@@ -32,7 +32,7 @@ print(json.dumps(payload))
 
   set +e
   HTTP_CODE=$(curl -s -w "%{http_code}" --max-time 30 \
-    -X POST "https://models.inference.ai.azure.com/chat/completions" \
+    -X POST "https://models.github.ai/inference/chat/completions" \
     -H "Content-Type: application/json" \
     -H "Authorization: Bearer $GITHUB_TOKEN" \
     -d "$PAYLOAD" \
@@ -242,7 +242,7 @@ print(json.dumps(payload))
     RETRY=0
     while true; do
       HTTP_CODE=$(curl -s -w "%{http_code}" --max-time 120 \
-        -X POST "https://models.inference.ai.azure.com/chat/completions" \
+        -X POST "https://models.github.ai/inference/chat/completions" \
         -H "Content-Type: application/json" \
         -H "Authorization: Bearer $GITHUB_TOKEN" \
         -d "$PAYLOAD" \

--- a/scripts/validate-results.js
+++ b/scripts/validate-results.js
@@ -89,6 +89,29 @@ function validate(filePath) {
   return errors;
 }
 
+function checkOrphanedReliabilityFiles(resultsPath) {
+  const reliabilityDir = path.resolve(path.dirname(resultsPath), 'reliability');
+  if (!fs.existsSync(reliabilityDir)) return [];
+
+  const data = JSON.parse(fs.readFileSync(resultsPath, 'utf8'));
+  const knownSlugs = new Set(data.agents.map(a => a.slug));
+
+  const files = fs.readdirSync(reliabilityDir).filter(f => f.endsWith('.json'));
+  const fileSlugs = new Set();
+  for (const f of files) {
+    const slug = f.replace(/-run-\d+\.json$/, '');
+    fileSlugs.add(slug);
+  }
+
+  const orphaned = [];
+  for (const slug of fileSlugs) {
+    if (!knownSlugs.has(slug)) {
+      orphaned.push(slug);
+    }
+  }
+  return orphaned;
+}
+
 if (require.main === module) {
   const filePath = path.resolve(__dirname, '..', 'data', 'results.json');
   const errors = validate(filePath);
@@ -98,6 +121,12 @@ if (require.main === module) {
     process.exit(1);
   }
   console.log(`✅ results.json valid (${JSON.parse(fs.readFileSync(filePath, 'utf8')).agents.length} agents)`);
+
+  const orphaned = checkOrphanedReliabilityFiles(filePath);
+  if (orphaned.length) {
+    console.warn(`⚠️  ${orphaned.length} orphaned reliability slug(s) (files exist but missing from results.json):`);
+    orphaned.forEach(s => console.warn(`  - ${s}`));
+  }
 }
 
-module.exports = { validate };
+module.exports = { validate, checkOrphanedReliabilityFiles };


### PR DESCRIPTION
Closes #553

## Changes

1. **Added `meta-llama-3-1-405b-instruct`** to `data/results.json`
   - Consensus type: PTCN (The Commander)
   - 3 reliability runs: PTCF, PTCN, PTCN (67% consistency)
   - Provider: github
   - Total agents: 62 → 63

2. **Enhanced `scripts/validate-results.js`** with orphaned reliability file detection
   - Scans `data/reliability/` for slugs not present in `results.json`
   - Reports as warnings (non-blocking) to prevent future regressions
   - This would have caught this bug before merging #527

## Testing
- All 286 tests pass
- `node scripts/validate-results.js` reports clean (no orphans)