### PR TITLE
fix(ops): add git clean to deploy script to prevent untracked file conflicts

### DIFF
--- a/ops/abti-deploy.sh
+++ b/ops/abti-deploy.sh
@@ -19,6 +19,7 @@ BEFORE=$(git rev-parse HEAD)
 #   1. All test results are committed via PRs (the authoritative source)
 #   2. Runtime API submissions are ephemeral until merged upstream
 git checkout -- . 2>/dev/null || true
+git clean -fd 2>/dev/null || true
 
 git pull origin master --ff-only 2>/dev/null || exit 0
 


### PR DESCRIPTION
## Problem

The API server generates OG images at runtime (e.g. `og/agents/deepseek-v3-0324.png`). The deploy script only did `git checkout -- .` which resets tracked files but doesn't remove untracked ones. If an upstream commit adds a file that already exists locally as untracked, `git pull --ff-only` fails silently (`|| exit 0`), stalling deploys.

This caused a 2-day stall where the API was stuck at commit 4f33ccb while master advanced to d1d1cc6 (missing 4 new models from the API).

## Fix

Add `git clean -fd` after `git checkout -- .` to remove all untracked files/directories before pulling.

## Verification

Manually ran the fix on VM1 — API now serves all 66 agents correctly.