### PR TITLE
fix(cli): omit temperature for reasoning models + add 6 new model results

### DIFF
--- a/cli/bin/abti.js
+++ b/cli/bin/abti.js
@@ -367,7 +367,7 @@ function callOpenAI(apiKey, mdl, systemPrompt, userMessage, baseUrl, options, ma
   const suffix = chatPath || '/v1/chat/completions';
   const parsed = baseUrl ? new URL(baseUrl.replace(/\/+$/, '') + suffix) : new URL('https://api.openai.com/v1/chat/completions');
   const maxTok = maxTokens || (isReasoningModel(mdl) ? 2048 : 16);
-  const payload = JSON.stringify({ model: mdl, messages: [{ role: 'system', content: systemPrompt }, { role: 'user', content: userMessage }], max_tokens: maxTok, temperature: 0, ...options });
+  const payload = JSON.stringify({ model: mdl, messages: [{ role: 'system', content: systemPrompt }, { role: 'user', content: userMessage }], max_tokens: maxTok, ...(!isReasoningModel(mdl) && { temperature: 0 }), ...options });
   return llmRequest({ hostname: parsed.hostname, port: parsed.port, path: parsed.pathname + parsed.search, method: 'POST', protocol: parsed.protocol, headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${apiKey}`, 'Content-Length': Buffer.byteLength(payload) } }, payload)
     .then(json => {
       const msg = json.choices[0].message;

--- a/data/results.json
+++ b/data/results.json
@@ -5628,6 +5628,312 @@
       ],
       "consistency": 100,
       "runs": 3
+    },
+    {
+      "name": "Gemini 3.5 Flash",
+      "slug": "gemini-3-5-flash",
+      "url": "",
+      "type": "PTCF",
+      "nick": "The Architect",
+      "testedAt": "2026-06-24T08:31:00.000Z",
+      "scores": [
+        2,
+        4,
+        4,
+        2
+      ],
+      "dimensions": [
+        {
+          "poles": [
+            "P",
+            "R"
+          ],
+          "score": 2,
+          "max": 4
+        },
+        {
+          "poles": [
+            "T",
+            "E"
+          ],
+          "score": 4,
+          "max": 4
+        },
+        {
+          "poles": [
+            "C",
+            "D"
+          ],
+          "score": 4,
+          "max": 4
+        },
+        {
+          "poles": [
+            "F",
+            "N"
+          ],
+          "score": 2,
+          "max": 4
+        }
+      ],
+      "model": "gemini-3.5-flash",
+      "provider": "openai",
+      "runs": 1
+    },
+    {
+      "name": "Gemini 3.1 Pro Preview",
+      "slug": "gemini-3-1-pro-preview",
+      "url": "",
+      "type": "RTCF",
+      "nick": "The Advisor",
+      "testedAt": "2026-06-24T08:32:00.000Z",
+      "scores": [
+        1,
+        2,
+        4,
+        4
+      ],
+      "dimensions": [
+        {
+          "poles": [
+            "P",
+            "R"
+          ],
+          "score": 1,
+          "max": 4
+        },
+        {
+          "poles": [
+            "T",
+            "E"
+          ],
+          "score": 2,
+          "max": 4
+        },
+        {
+          "poles": [
+            "C",
+            "D"
+          ],
+          "score": 4,
+          "max": 4
+        },
+        {
+          "poles": [
+            "F",
+            "N"
+          ],
+          "score": 4,
+          "max": 4
+        }
+      ],
+      "model": "gemini-3.1-pro-preview",
+      "provider": "openai",
+      "runs": 1
+    },
+    {
+      "name": "MiniMax M2.7",
+      "slug": "minimax-m2-7",
+      "url": "",
+      "type": "PECF",
+      "nick": "The Spark",
+      "testedAt": "2026-06-24T08:32:30.000Z",
+      "scores": [
+        4,
+        0,
+        4,
+        2
+      ],
+      "dimensions": [
+        {
+          "poles": [
+            "P",
+            "R"
+          ],
+          "score": 4,
+          "max": 4
+        },
+        {
+          "poles": [
+            "T",
+            "E"
+          ],
+          "score": 0,
+          "max": 4
+        },
+        {
+          "poles": [
+            "C",
+            "D"
+          ],
+          "score": 4,
+          "max": 4
+        },
+        {
+          "poles": [
+            "F",
+            "N"
+          ],
+          "score": 2,
+          "max": 4
+        }
+      ],
+      "model": "MiniMax-M2.7",
+      "provider": "openai",
+      "runs": 1
+    },
+    {
+      "name": "GPT-5.4",
+      "slug": "gpt-5-4",
+      "url": "",
+      "type": "RTCF",
+      "nick": "The Advisor",
+      "testedAt": "2026-06-24T08:35:00.000Z",
+      "scores": [
+        1,
+        2,
+        4,
+        3
+      ],
+      "dimensions": [
+        {
+          "poles": [
+            "P",
+            "R"
+          ],
+          "score": 1,
+          "max": 4
+        },
+        {
+          "poles": [
+            "T",
+            "E"
+          ],
+          "score": 2,
+          "max": 4
+        },
+        {
+          "poles": [
+            "C",
+            "D"
+          ],
+          "score": 4,
+          "max": 4
+        },
+        {
+          "poles": [
+            "F",
+            "N"
+          ],
+          "score": 3,
+          "max": 4
+        }
+      ],
+      "model": "gpt-5.4",
+      "provider": "openai",
+      "runs": 1
+    },
+    {
+      "name": "GPT-5.4 Mini",
+      "slug": "gpt-5-4-mini",
+      "url": "",
+      "type": "PTCF",
+      "nick": "The Architect",
+      "testedAt": "2026-06-24T08:36:00.000Z",
+      "scores": [
+        3,
+        3,
+        4,
+        2
+      ],
+      "dimensions": [
+        {
+          "poles": [
+            "P",
+            "R"
+          ],
+          "score": 3,
+          "max": 4
+        },
+        {
+          "poles": [
+            "T",
+            "E"
+          ],
+          "score": 3,
+          "max": 4
+        },
+        {
+          "poles": [
+            "C",
+            "D"
+          ],
+          "score": 4,
+          "max": 4
+        },
+        {
+          "poles": [
+            "F",
+            "N"
+          ],
+          "score": 2,
+          "max": 4
+        }
+      ],
+      "model": "gpt-5.4-mini",
+      "provider": "openai",
+      "runs": 1
+    },
+    {
+      "name": "Gemini 3 Flash Preview",
+      "slug": "gemini-3-flash-preview",
+      "url": "",
+      "type": "PTCF",
+      "nick": "The Architect",
+      "testedAt": "2026-06-24T08:37:00.000Z",
+      "scores": [
+        2,
+        4,
+        4,
+        2
+      ],
+      "dimensions": [
+        {
+          "poles": [
+            "P",
+            "R"
+          ],
+          "score": 2,
+          "max": 4
+        },
+        {
+          "poles": [
+            "T",
+            "E"
+          ],
+          "score": 4,
+          "max": 4
+        },
+        {
+          "poles": [
+            "C",
+            "D"
+          ],
+          "score": 4,
+          "max": 4
+        },
+        {
+          "poles": [
+            "F",
+            "N"
+          ],
+          "score": 2,
+          "max": 4
+        }
+      ],
+      "model": "gemini-3-flash-preview",
+      "provider": "openai",
+      "runs": 1
     }
   ]
 }


### PR DESCRIPTION
## Changes

### Bug Fix (#569)
`callOpenAI()` was unconditionally sending `temperature: 0` in the payload, which reasoning models (gpt-5.x, o1, o3, o4, gemini-3.x) reject with a 400 error.

**Fix:** Conditionally spread `{ temperature: 0 }` only for non-reasoning models (detected by existing `isReasoningModel()`).

### New Test Results (6 models)

| Model | Type | Nickname |
|-------|------|----------|
| gemini-3.5-flash | PTCF | The Architect |
| gemini-3.1-pro-preview | RTCF | The Advisor |
| gemini-3-flash-preview | PTCF | The Architect |
| MiniMax-M2.7 | PECF | The Spark |
| gpt-5.4 | RTCF | The Advisor |
| gpt-5.4-mini | PTCF | The Architect |

Total tested models: 65 → 71

### Testing
- Verified gpt-5.4 and gpt-5.4-mini now test successfully (previously failed with 400)
- All 6 new models tested and results submitted

Closes #569