### PR TITLE
feat(data): add reliability runs for 6 models (GPT-5.4, Gemini 3.x, MiniMax)

### DIFF
--- a/data/reliability/gemini-3-1-pro-preview-run-1.json
+++ b/data/reliability/gemini-3-1-pro-preview-run-1.json
@@ -1,0 +1,30 @@
+{
+    "model": "gemini-3.1-pro-preview",
+    "provider": "floway",
+    "run": 1,
+    "answers": [
+        "B",
+        "A",
+        "B",
+        "A",
+        "B",
+        "A",
+        "B",
+        "B",
+        "A",
+        "A",
+        "A",
+        "A",
+        "A",
+        "A",
+        "A",
+        "A"
+    ],
+    "type": "PECF",
+    "dimensions": [
+        2,
+        1,
+        4,
+        4
+    ]
+}

--- a/data/reliability/gemini-3-1-pro-preview-run-2.json
+++ b/data/reliability/gemini-3-1-pro-preview-run-2.json
@@ -1,0 +1,30 @@
+{
+    "model": "gemini-3.1-pro-preview",
+    "provider": "floway",
+    "run": 2,
+    "answers": [
+        "B",
+        "A",
+        "B",
+        "B",
+        "B",
+        "A",
+        "A",
+        "B",
+        "A",
+        "A",
+        "A",
+        "A",
+        "B",
+        "A",
+        "A",
+        "A"
+    ],
+    "type": "RTCF",
+    "dimensions": [
+        1,
+        2,
+        4,
+        3
+    ]
+}

--- a/data/reliability/gemini-3-1-pro-preview-run-3.json
+++ b/data/reliability/gemini-3-1-pro-preview-run-3.json
@@ -1,0 +1,30 @@
+{
+    "model": "gemini-3.1-pro-preview",
+    "provider": "floway",
+    "run": 3,
+    "answers": [
+        "B",
+        "A",
+        "B",
+        "B",
+        "A",
+        "A",
+        "A",
+        "B",
+        "A",
+        "A",
+        "A",
+        "A",
+        "A",
+        "A",
+        "A",
+        "A"
+    ],
+    "type": "RTCF",
+    "dimensions": [
+        1,
+        3,
+        4,
+        4
+    ]
+}

--- a/data/reliability/gemini-3-5-flash-run-1.json
+++ b/data/reliability/gemini-3-5-flash-run-1.json
@@ -1,0 +1,30 @@
+{
+    "model": "gemini-3.5-flash",
+    "provider": "floway",
+    "run": 1,
+    "answers": [
+        "B",
+        "A",
+        "A",
+        "A",
+        "A",
+        "A",
+        "A",
+        "A",
+        "A",
+        "A",
+        "A",
+        "A",
+        "B",
+        "A",
+        "A",
+        "A"
+    ],
+    "type": "PTCF",
+    "dimensions": [
+        3,
+        4,
+        4,
+        3
+    ]
+}

--- a/data/reliability/gemini-3-5-flash-run-2.json
+++ b/data/reliability/gemini-3-5-flash-run-2.json
@@ -1,0 +1,30 @@
+{
+    "model": "gemini-3.5-flash",
+    "provider": "floway",
+    "run": 2,
+    "answers": [
+        "B",
+        "A",
+        "B",
+        "A",
+        "A",
+        "A",
+        "A",
+        "B",
+        "A",
+        "A",
+        "A",
+        "A",
+        "A",
+        "A",
+        "A",
+        "A"
+    ],
+    "type": "PTCF",
+    "dimensions": [
+        2,
+        3,
+        4,
+        4
+    ]
+}

--- a/data/reliability/gemini-3-5-flash-run-3.json
+++ b/data/reliability/gemini-3-5-flash-run-3.json
@@ -1,0 +1,30 @@
+{
+    "model": "gemini-3.5-flash",
+    "provider": "floway",
+    "run": 3,
+    "answers": [
+        "B",
+        "A",
+        "B",
+        "A",
+        "A",
+        "A",
+        "A",
+        "B",
+        "A",
+        "A",
+        "A",
+        "A",
+        "A",
+        "A",
+        "A",
+        "A"
+    ],
+    "type": "PTCF",
+    "dimensions": [
+        2,
+        3,
+        4,
+        4
+    ]
+}

--- a/data/reliability/gemini-3-flash-preview-run-1.json
+++ b/data/reliability/gemini-3-flash-preview-run-1.json
@@ -1,0 +1,30 @@
+{
+    "model": "gemini-3-flash-preview",
+    "provider": "floway",
+    "run": 1,
+    "answers": [
+        "B",
+        "A",
+        "B",
+        "A",
+        "A",
+        "A",
+        "A",
+        "A",
+        "A",
+        "A",
+        "A",
+        "A",
+        "A",
+        "A",
+        "B",
+        "B"
+    ],
+    "type": "PTCF",
+    "dimensions": [
+        2,
+        4,
+        4,
+        2
+    ]
+}

--- a/data/reliability/gemini-3-flash-preview-run-2.json
+++ b/data/reliability/gemini-3-flash-preview-run-2.json
@@ -1,0 +1,30 @@
+{
+    "model": "gemini-3-flash-preview",
+    "provider": "floway",
+    "run": 2,
+    "answers": [
+        "B",
+        "A",
+        "B",
+        "A",
+        "A",
+        "A",
+        "A",
+        "A",
+        "A",
+        "A",
+        "A",
+        "A",
+        "B",
+        "A",
+        "A",
+        "B"
+    ],
+    "type": "PTCF",
+    "dimensions": [
+        2,
+        4,
+        4,
+        2
+    ]
+}

--- a/data/reliability/gemini-3-flash-preview-run-3.json
+++ b/data/reliability/gemini-3-flash-preview-run-3.json
@@ -1,0 +1,30 @@
+{
+    "model": "gemini-3-flash-preview",
+    "provider": "floway",
+    "run": 3,
+    "answers": [
+        "B",
+        "A",
+        "B",
+        "A",
+        "B",
+        "A",
+        "A",
+        "A",
+        "A",
+        "A",
+        "A",
+        "A",
+        "A",
+        "A",
+        "A",
+        "B"
+    ],
+    "type": "PTCF",
+    "dimensions": [
+        2,
+        3,
+        4,
+        3
+    ]
+}

--- a/data/reliability/gpt-5-4-mini-run-1.json
+++ b/data/reliability/gpt-5-4-mini-run-1.json
@@ -1,0 +1,30 @@
+{
+    "model": "gpt-5.4-mini",
+    "provider": "floway",
+    "run": 1,
+    "answers": [
+        "B",
+        "A",
+        "A",
+        "A",
+        "B",
+        "B",
+        "A",
+        "B",
+        "A",
+        "A",
+        "A",
+        "A",
+        "A",
+        "B",
+        "A",
+        "B"
+    ],
+    "type": "PECF",
+    "dimensions": [
+        3,
+        1,
+        4,
+        2
+    ]
+}

--- a/data/reliability/gpt-5-4-mini-run-2.json
+++ b/data/reliability/gpt-5-4-mini-run-2.json
@@ -1,0 +1,30 @@
+{
+    "model": "gpt-5.4-mini",
+    "provider": "floway",
+    "run": 2,
+    "answers": [
+        "B",
+        "A",
+        "B",
+        "A",
+        "B",
+        "B",
+        "A",
+        "B",
+        "A",
+        "A",
+        "A",
+        "A",
+        "B",
+        "B",
+        "A",
+        "B"
+    ],
+    "type": "PECN",
+    "dimensions": [
+        2,
+        1,
+        4,
+        1
+    ]
+}

--- a/data/reliability/gpt-5-4-mini-run-3.json
+++ b/data/reliability/gpt-5-4-mini-run-3.json
@@ -1,0 +1,30 @@
+{
+    "model": "gpt-5.4-mini",
+    "provider": "floway",
+    "run": 3,
+    "answers": [
+        "B",
+        "A",
+        "B",
+        "A",
+        "B",
+        "B",
+        "A",
+        "B",
+        "A",
+        "A",
+        "A",
+        "A",
+        "A",
+        "A",
+        "A",
+        "B"
+    ],
+    "type": "PECF",
+    "dimensions": [
+        2,
+        1,
+        4,
+        3
+    ]
+}

--- a/data/reliability/gpt-5-4-run-1.json
+++ b/data/reliability/gpt-5-4-run-1.json
@@ -1,0 +1,30 @@
+{
+    "model": "gpt-5.4",
+    "provider": "floway",
+    "run": 1,
+    "answers": [
+        "B",
+        "B",
+        "B",
+        "B",
+        "A",
+        "A",
+        "A",
+        "B",
+        "B",
+        "A",
+        "A",
+        "A",
+        "B",
+        "A",
+        "A",
+        "B"
+    ],
+    "type": "RTCF",
+    "dimensions": [
+        0,
+        3,
+        3,
+        2
+    ]
+}

--- a/data/reliability/gpt-5-4-run-2.json
+++ b/data/reliability/gpt-5-4-run-2.json
@@ -1,0 +1,30 @@
+{
+    "model": "gpt-5.4",
+    "provider": "floway",
+    "run": 2,
+    "answers": [
+        "B",
+        "B",
+        "B",
+        "B",
+        "A",
+        "A",
+        "A",
+        "A",
+        "A",
+        "A",
+        "A",
+        "A",
+        "B",
+        "B",
+        "A",
+        "A"
+    ],
+    "type": "RTCF",
+    "dimensions": [
+        0,
+        4,
+        4,
+        2
+    ]
+}

--- a/data/reliability/gpt-5-4-run-3.json
+++ b/data/reliability/gpt-5-4-run-3.json
@@ -1,0 +1,30 @@
+{
+    "model": "gpt-5.4",
+    "provider": "floway",
+    "run": 3,
+    "answers": [
+        "B",
+        "B",
+        "B",
+        "B",
+        "A",
+        "A",
+        "B",
+        "A",
+        "A",
+        "B",
+        "A",
+        "A",
+        "B",
+        "A",
+        "A",
+        "B"
+    ],
+    "type": "RTCF",
+    "dimensions": [
+        0,
+        3,
+        3,
+        2
+    ]
+}

--- a/data/reliability/minimax-m2-7-run-1.json
+++ b/data/reliability/minimax-m2-7-run-1.json
@@ -1,0 +1,30 @@
+{
+    "model": "MiniMax-M2.7",
+    "provider": "floway",
+    "run": 1,
+    "answers": [
+        "A",
+        "B",
+        "B",
+        "A",
+        "B",
+        "A",
+        "B",
+        "A",
+        "B",
+        "B",
+        "B",
+        "B",
+        "B",
+        "A",
+        "B",
+        "A"
+    ],
+    "type": "PTDF",
+    "dimensions": [
+        2,
+        2,
+        0,
+        2
+    ]
+}

--- a/data/reliability/minimax-m2-7-run-2.json
+++ b/data/reliability/minimax-m2-7-run-2.json
@@ -1,0 +1,30 @@
+{
+    "model": "MiniMax-M2.7",
+    "provider": "floway",
+    "run": 2,
+    "answers": [
+        "A",
+        "A",
+        "B",
+        "B",
+        "B",
+        "A",
+        "A",
+        "B",
+        "B",
+        "B",
+        "A",
+        "B",
+        "B",
+        "B",
+        "B",
+        "B"
+    ],
+    "type": "PTDN",
+    "dimensions": [
+        2,
+        2,
+        1,
+        0
+    ]
+}

--- a/data/reliability/minimax-m2-7-run-3.json
+++ b/data/reliability/minimax-m2-7-run-3.json
@@ -1,0 +1,30 @@
+{
+    "model": "MiniMax-M2.7",
+    "provider": "floway",
+    "run": 3,
+    "answers": [
+        "B",
+        "A",
+        "B",
+        "A",
+        "A",
+        "B",
+        "B",
+        "B",
+        "A",
+        "B",
+        "B",
+        "B",
+        "A",
+        "A",
+        "B",
+        "B"
+    ],
+    "type": "PEDF",
+    "dimensions": [
+        2,
+        1,
+        1,
+        2
+    ]
+}

--- a/data/results.json
+++ b/data/results.json
@@ -5760,10 +5760,38 @@
       ],
       "model": "gemini-3.1-pro-preview",
       "provider": "openai",
-      "runs": 1,
-      "reliabilityRuns": 0,
-      "reliability": null,
-      "consistency": null
+      "runs": 3,
+      "reliabilityRuns": [
+        {
+          "type": "PECF",
+          "scores": [
+            2,
+            1,
+            4,
+            4
+          ]
+        },
+        {
+          "type": "RTCF",
+          "scores": [
+            1,
+            2,
+            4,
+            3
+          ]
+        },
+        {
+          "type": "RTCF",
+          "scores": [
+            1,
+            3,
+            4,
+            4
+          ]
+        }
+      ],
+      "reliability": 0.9167,
+      "consistency": 92
     },
     {
       "name": "MiniMax M2.7",
@@ -5814,10 +5842,38 @@
       ],
       "model": "MiniMax-M2.7",
       "provider": "openai",
-      "runs": 1,
-      "reliabilityRuns": 0,
-      "reliability": null,
-      "consistency": null
+      "runs": 3,
+      "reliabilityRuns": [
+        {
+          "type": "PTDF",
+          "scores": [
+            2,
+            2,
+            0,
+            2
+          ]
+        },
+        {
+          "type": "PTDN",
+          "scores": [
+            2,
+            2,
+            1,
+            0
+          ]
+        },
+        {
+          "type": "PEDF",
+          "scores": [
+            2,
+            1,
+            1,
+            2
+          ]
+        }
+      ],
+      "reliability": 0.75,
+      "consistency": 75
     },
     {
       "name": "GPT-5.4",
@@ -6032,10 +6088,38 @@
       ],
       "model": "gemini-3-flash-preview",
       "provider": "openai",
-      "runs": 1,
-      "reliabilityRuns": 0,
-      "reliability": null,
-      "consistency": null
+      "runs": 3,
+      "reliabilityRuns": [
+        {
+          "type": "PTCF",
+          "scores": [
+            2,
+            4,
+            4,
+            2
+          ]
+        },
+        {
+          "type": "PTCF",
+          "scores": [
+            2,
+            4,
+            4,
+            2
+          ]
+        },
+        {
+          "type": "PTCF",
+          "scores": [
+            2,
+            3,
+            4,
+            3
+          ]
+        }
+      ],
+      "reliability": 0.9375,
+      "consistency": 94
     }
   ]
 }

--- a/data/results.json
+++ b/data/results.json
@@ -5678,7 +5678,38 @@
       ],
       "model": "gemini-3.5-flash",
       "provider": "openai",
-      "runs": 1
+      "runs": 3,
+      "reliabilityRuns": [
+        {
+          "type": "PTCF",
+          "scores": [
+            3,
+            4,
+            4,
+            3
+          ]
+        },
+        {
+          "type": "PTCF",
+          "scores": [
+            2,
+            3,
+            4,
+            4
+          ]
+        },
+        {
+          "type": "PTCF",
+          "scores": [
+            2,
+            3,
+            4,
+            4
+          ]
+        }
+      ],
+      "reliability": 0.9375,
+      "consistency": 94
     },
     {
       "name": "Gemini 3.1 Pro Preview",
@@ -5729,7 +5760,10 @@
       ],
       "model": "gemini-3.1-pro-preview",
       "provider": "openai",
-      "runs": 1
+      "runs": 1,
+      "reliabilityRuns": 0,
+      "reliability": null,
+      "consistency": null
     },
     {
       "name": "MiniMax M2.7",
@@ -5780,7 +5814,10 @@
       ],
       "model": "MiniMax-M2.7",
       "provider": "openai",
-      "runs": 1
+      "runs": 1,
+      "reliabilityRuns": 0,
+      "reliability": null,
+      "consistency": null
     },
     {
       "name": "GPT-5.4",
@@ -5831,7 +5868,38 @@
       ],
       "model": "gpt-5.4",
       "provider": "openai",
-      "runs": 1
+      "runs": 3,
+      "reliabilityRuns": [
+        {
+          "type": "RTCF",
+          "scores": [
+            0,
+            3,
+            3,
+            2
+          ]
+        },
+        {
+          "type": "RTCF",
+          "scores": [
+            0,
+            4,
+            4,
+            2
+          ]
+        },
+        {
+          "type": "RTCF",
+          "scores": [
+            0,
+            3,
+            3,
+            2
+          ]
+        }
+      ],
+      "reliability": 0.875,
+      "consistency": 88
     },
     {
       "name": "GPT-5.4 Mini",
@@ -5882,7 +5950,38 @@
       ],
       "model": "gpt-5.4-mini",
       "provider": "openai",
-      "runs": 1
+      "runs": 3,
+      "reliabilityRuns": [
+        {
+          "type": "PECF",
+          "scores": [
+            3,
+            1,
+            4,
+            2
+          ]
+        },
+        {
+          "type": "PECN",
+          "scores": [
+            2,
+            1,
+            4,
+            1
+          ]
+        },
+        {
+          "type": "PECF",
+          "scores": [
+            2,
+            1,
+            4,
+            3
+          ]
+        }
+      ],
+      "reliability": 0.9375,
+      "consistency": 94
     },
     {
       "name": "Gemini 3 Flash Preview",
@@ -5933,7 +6032,10 @@
       ],
       "model": "gemini-3-flash-preview",
       "provider": "openai",
-      "runs": 1
+      "runs": 1,
+      "reliabilityRuns": 0,
+      "reliability": null,
+      "consistency": null
     }
   ]
 }


### PR DESCRIPTION
## Changes

Complete 3-run reliability data for **6 models** that previously had only initial test results (no reliability scoring):

### GPT-5.4
- **Type**: RTCF (The Advisor) — consistent across all 3 runs
- **Reliability**: 87.5%
- Responsive, thorough, candid, flexible

### GPT-5.4-mini
- **Type**: PECF (The Spark) / PECN (The Drill Sergeant)
- **Reliability**: 93.75%
- Proactive, efficient, candid — principled/flexible varies

### Gemini 3.5 Flash
- **Type**: PTCF (The Architect) — consistent across all 3 runs
- **Reliability**: 93.75%
- Proactive, thorough, candid, flexible

### Gemini 3.1 Pro Preview
- **Type**: PECF/RTCF — fluctuates on autonomy and precision
- **Reliability**: 91.67%
- Always candid and flexible; varies on proactive/responsive and thorough/efficient

### Gemini 3 Flash Preview
- **Type**: PTCF (The Architect) — consistent across all 3 runs
- **Reliability**: 93.75%
- Proactive, thorough, candid, flexible

### MiniMax M2.7
- **Type**: PTDF/PTDN/PEDF — inconsistent across dimensions
- **Reliability**: 75%
- Lowest reliability in this batch; fluctuates on precision, transparency, and adaptability

### Testing Method
- Tested via floway proxy (OpenAI-compatible `/v1/chat/completions` endpoint)
- Position bias mitigation (random A/B swap) via CLI's built-in shuffle
- All runs validated via `sync-reliability.js` and `validate-results.js`
- Full test suite passes (291/291)

### Summary
| Model | Type | Reliability |
|-------|------|------------|
| GPT-5.4 | RTCF | 87.5% |
| GPT-5.4-mini | PECF/PECN | 93.75% |
| Gemini 3.5 Flash | PTCF | 93.75% |
| Gemini 3.1 Pro Preview | PECF/RTCF | 91.67% |
| Gemini 3 Flash Preview | PTCF | 93.75% |
| MiniMax M2.7 | varied | 75% |