### PR TITLE
feat: add per-question discriminability analysis to stats page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ node_modules/
 data/*
 !data/results.json
 !data/reliability/
+!data/discriminability.json
 mcp/node_modules/
 data/reliability/.fuse_hidden*
 *-state.json

--- a/cli/bin/abti.js
+++ b/cli/bin/abti.js
@@ -1184,6 +1184,38 @@ async function runStats() {
         [DIM_NAMES[lang][d.dim][2]]: d.rightCount,
       })),
     };
+    // Add discriminability if local data exists
+    const reliabilityDirJson = require('path').join(__dirname, '..', '..', 'data', 'reliability');
+    if (fs.existsSync(reliabilityDirJson)) {
+      const relFilesJson = fs.readdirSync(reliabilityDirJson).filter(f => f.endsWith('.json'));
+      if (relFilesJson.length > 0) {
+        const aCountsJson = new Array(16).fill(0);
+        let totalRunsJson = 0;
+        for (const file of relFilesJson) {
+          try {
+            const rd = JSON.parse(fs.readFileSync(require('path').join(reliabilityDirJson, file), 'utf-8'));
+            if (!Array.isArray(rd.answers) || rd.answers.length !== 16) continue;
+            totalRunsJson++;
+            for (let i = 0; i < 16; i++) { if (rd.answers[i] === 'A') aCountsJson[i]++; }
+          } catch (_) {}
+        }
+        if (totalRunsJson > 0) {
+          output.discriminability = {
+            totalRuns: totalRunsJson,
+            threshold: 0.6,
+            questions: Array.from({ length: 16 }, (_, i) => {
+              const aPct = (aCountsJson[i] / totalRunsJson) * 100;
+              return {
+                question: i + 1,
+                aPercent: +aPct.toFixed(1),
+                bPercent: +(100 - aPct).toFixed(1),
+                discriminability: +(1 - Math.abs(aPct - 50) / 50).toFixed(3),
+              };
+            }),
+          };
+        }
+      }
+    }
     console.log(JSON.stringify(output, null, 2));
     return;
   }
@@ -1227,6 +1259,48 @@ async function runStats() {
     console.log(`      ${dimNames[d.dim][1]} (${d.left}): ${c.green}${'█'.repeat(leftBar)}${c.reset} ${d.leftCount} (${leftPct}%)`);
     console.log(`      ${dimNames[d.dim][2]} (${d.right}): ${c.yellow}${'█'.repeat(rightBar)}${c.reset} ${d.rightCount} (${rightPct}%)`);
   }
+
+  // Question Discriminability (from local reliability data)
+  const reliabilityDir = require('path').join(__dirname, '..', '..', 'data', 'reliability');
+  if (fs.existsSync(reliabilityDir)) {
+    const relFiles = fs.readdirSync(reliabilityDir).filter(f => f.endsWith('.json'));
+    if (relFiles.length > 0) {
+      const aCounts = new Array(16).fill(0);
+      let totalRuns = 0;
+      for (const file of relFiles) {
+        try {
+          const rd = JSON.parse(fs.readFileSync(require('path').join(reliabilityDir, file), 'utf-8'));
+          if (!Array.isArray(rd.answers) || rd.answers.length !== 16) continue;
+          totalRuns++;
+          for (let i = 0; i < 16; i++) { if (rd.answers[i] === 'A') aCounts[i]++; }
+        } catch (_) {}
+      }
+      if (totalRuns > 0) {
+        const discDimNames = lang === 'zh'
+          ? ['自主性', '精确度', '沟通风格', '适应性']
+          : ['Autonomy', 'Precision', 'Transparency', 'Adaptability'];
+        const discTitle = lang === 'zh' ? '题目区分度' : 'Question Discriminability';
+        const discThreshold = 0.6;
+        console.log(`\n  ${c.bold}${discTitle}:${c.reset}  (${totalRuns} ${lang === 'zh' ? '次测试' : 'runs'})\n`);
+        for (let d = 0; d < 4; d++) {
+          console.log(`    ${discDimNames[d]}:`);
+          for (let qi = d * 4; qi < d * 4 + 4; qi++) {
+            const aPct = (aCounts[qi] / totalRuns) * 100;
+            const disc = 1 - Math.abs(aPct - 50) / 50;
+            const discStr = disc.toFixed(3);
+            const qLabel = `Q${qi + 1}`.padEnd(4);
+            const barTotal = 20;
+            const aBar = Math.round((aPct / 100) * barTotal);
+            const bBar = barTotal - aBar;
+            const warnMark = disc < discThreshold ? ` ${c.yellow}⚠${c.reset}` : '';
+            const discColor = disc >= discThreshold ? c.green : c.yellow;
+            console.log(`      ${qLabel} ${c.cyan}${'█'.repeat(aBar)}${c.reset}${c.dim}${'░'.repeat(bBar)}${c.reset} A:${aPct.toFixed(0).padStart(3)}% B:${(100 - aPct).toFixed(0).padStart(3)}%  ${discColor}${discStr}${c.reset}${warnMark}`);
+          }
+        }
+      }
+    }
+  }
+
   console.log();
 }
 

--- a/data/discriminability.json
+++ b/data/discriminability.json
@@ -1,0 +1,305 @@
+{
+  "totalRuns": 192,
+  "generatedAt": "2026-06-24T10:39:47.659Z",
+  "threshold": 0.6,
+  "questions": [
+    {
+      "question": 1,
+      "aCount": 92,
+      "bCount": 100,
+      "aPercent": 47.9,
+      "bPercent": 52.1,
+      "discriminability": 0.958
+    },
+    {
+      "question": 2,
+      "aCount": 110,
+      "bCount": 82,
+      "aPercent": 57.3,
+      "bPercent": 42.7,
+      "discriminability": 0.854
+    },
+    {
+      "question": 3,
+      "aCount": 74,
+      "bCount": 118,
+      "aPercent": 38.5,
+      "bPercent": 61.5,
+      "discriminability": 0.771
+    },
+    {
+      "question": 4,
+      "aCount": 142,
+      "bCount": 50,
+      "aPercent": 74,
+      "bPercent": 26,
+      "discriminability": 0.521
+    },
+    {
+      "question": 5,
+      "aCount": 128,
+      "bCount": 64,
+      "aPercent": 66.7,
+      "bPercent": 33.3,
+      "discriminability": 0.667
+    },
+    {
+      "question": 6,
+      "aCount": 72,
+      "bCount": 120,
+      "aPercent": 37.5,
+      "bPercent": 62.5,
+      "discriminability": 0.75
+    },
+    {
+      "question": 7,
+      "aCount": 124,
+      "bCount": 68,
+      "aPercent": 64.6,
+      "bPercent": 35.4,
+      "discriminability": 0.708
+    },
+    {
+      "question": 8,
+      "aCount": 53,
+      "bCount": 139,
+      "aPercent": 27.6,
+      "bPercent": 72.4,
+      "discriminability": 0.552
+    },
+    {
+      "question": 9,
+      "aCount": 110,
+      "bCount": 82,
+      "aPercent": 57.3,
+      "bPercent": 42.7,
+      "discriminability": 0.854
+    },
+    {
+      "question": 10,
+      "aCount": 124,
+      "bCount": 68,
+      "aPercent": 64.6,
+      "bPercent": 35.4,
+      "discriminability": 0.708
+    },
+    {
+      "question": 11,
+      "aCount": 146,
+      "bCount": 46,
+      "aPercent": 76,
+      "bPercent": 24,
+      "discriminability": 0.479
+    },
+    {
+      "question": 12,
+      "aCount": 154,
+      "bCount": 38,
+      "aPercent": 80.2,
+      "bPercent": 19.8,
+      "discriminability": 0.396
+    },
+    {
+      "question": 13,
+      "aCount": 72,
+      "bCount": 120,
+      "aPercent": 37.5,
+      "bPercent": 62.5,
+      "discriminability": 0.75
+    },
+    {
+      "question": 14,
+      "aCount": 83,
+      "bCount": 109,
+      "aPercent": 43.2,
+      "bPercent": 56.8,
+      "discriminability": 0.865
+    },
+    {
+      "question": 15,
+      "aCount": 164,
+      "bCount": 28,
+      "aPercent": 85.4,
+      "bPercent": 14.6,
+      "discriminability": 0.292
+    },
+    {
+      "question": 16,
+      "aCount": 54,
+      "bCount": 138,
+      "aPercent": 28.1,
+      "bPercent": 71.9,
+      "discriminability": 0.563
+    }
+  ],
+  "dimensions": [
+    {
+      "name": "Autonomy",
+      "poles": [
+        "P",
+        "R"
+      ],
+      "questions": [
+        {
+          "question": 1,
+          "aCount": 92,
+          "bCount": 100,
+          "aPercent": 47.9,
+          "bPercent": 52.1,
+          "discriminability": 0.958
+        },
+        {
+          "question": 2,
+          "aCount": 110,
+          "bCount": 82,
+          "aPercent": 57.3,
+          "bPercent": 42.7,
+          "discriminability": 0.854
+        },
+        {
+          "question": 3,
+          "aCount": 74,
+          "bCount": 118,
+          "aPercent": 38.5,
+          "bPercent": 61.5,
+          "discriminability": 0.771
+        },
+        {
+          "question": 4,
+          "aCount": 142,
+          "bCount": 50,
+          "aPercent": 74,
+          "bPercent": 26,
+          "discriminability": 0.521
+        }
+      ],
+      "averageDiscriminability": 0.776
+    },
+    {
+      "name": "Precision",
+      "poles": [
+        "T",
+        "E"
+      ],
+      "questions": [
+        {
+          "question": 5,
+          "aCount": 128,
+          "bCount": 64,
+          "aPercent": 66.7,
+          "bPercent": 33.3,
+          "discriminability": 0.667
+        },
+        {
+          "question": 6,
+          "aCount": 72,
+          "bCount": 120,
+          "aPercent": 37.5,
+          "bPercent": 62.5,
+          "discriminability": 0.75
+        },
+        {
+          "question": 7,
+          "aCount": 124,
+          "bCount": 68,
+          "aPercent": 64.6,
+          "bPercent": 35.4,
+          "discriminability": 0.708
+        },
+        {
+          "question": 8,
+          "aCount": 53,
+          "bCount": 139,
+          "aPercent": 27.6,
+          "bPercent": 72.4,
+          "discriminability": 0.552
+        }
+      ],
+      "averageDiscriminability": 0.669
+    },
+    {
+      "name": "Transparency",
+      "poles": [
+        "C",
+        "D"
+      ],
+      "questions": [
+        {
+          "question": 9,
+          "aCount": 110,
+          "bCount": 82,
+          "aPercent": 57.3,
+          "bPercent": 42.7,
+          "discriminability": 0.854
+        },
+        {
+          "question": 10,
+          "aCount": 124,
+          "bCount": 68,
+          "aPercent": 64.6,
+          "bPercent": 35.4,
+          "discriminability": 0.708
+        },
+        {
+          "question": 11,
+          "aCount": 146,
+          "bCount": 46,
+          "aPercent": 76,
+          "bPercent": 24,
+          "discriminability": 0.479
+        },
+        {
+          "question": 12,
+          "aCount": 154,
+          "bCount": 38,
+          "aPercent": 80.2,
+          "bPercent": 19.8,
+          "discriminability": 0.396
+        }
+      ],
+      "averageDiscriminability": 0.609
+    },
+    {
+      "name": "Adaptability",
+      "poles": [
+        "F",
+        "N"
+      ],
+      "questions": [
+        {
+          "question": 13,
+          "aCount": 72,
+          "bCount": 120,
+          "aPercent": 37.5,
+          "bPercent": 62.5,
+          "discriminability": 0.75
+        },
+        {
+          "question": 14,
+          "aCount": 83,
+          "bCount": 109,
+          "aPercent": 43.2,
+          "bPercent": 56.8,
+          "discriminability": 0.865
+        },
+        {
+          "question": 15,
+          "aCount": 164,
+          "bCount": 28,
+          "aPercent": 85.4,
+          "bPercent": 14.6,
+          "discriminability": 0.292
+        },
+        {
+          "question": 16,
+          "aCount": 54,
+          "bCount": 138,
+          "aPercent": 28.1,
+          "bPercent": 71.9,
+          "discriminability": 0.563
+        }
+      ],
+      "averageDiscriminability": 0.617
+    }
+  ]
+}

--- a/scripts/generate-discriminability.js
+++ b/scripts/generate-discriminability.js
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * Generate per-question discriminability data from reliability test runs.
+ *
+ * Reads all data/reliability/*.json files, computes per-question A/B split
+ * and discriminability score, then writes data/discriminability.json.
+ *
+ * Discriminability formula: disc = 1 - |%A - 50| / 50
+ *   0 = all answers same (no discrimination)
+ *   1 = perfect 50/50 split (maximum discrimination)
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const RELIABILITY_DIR = path.join(__dirname, '..', 'data', 'reliability');
+const OUTPUT_FILE = path.join(__dirname, '..', 'data', 'discriminability.json');
+
+const DIMENSIONS = [
+  { name: 'Autonomy', poles: ['P', 'R'], questions: [1, 2, 3, 4] },
+  { name: 'Precision', poles: ['T', 'E'], questions: [5, 6, 7, 8] },
+  { name: 'Transparency', poles: ['C', 'D'], questions: [9, 10, 11, 12] },
+  { name: 'Adaptability', poles: ['F', 'N'], questions: [13, 14, 15, 16] },
+];
+
+function main() {
+  if (!fs.existsSync(RELIABILITY_DIR)) {
+    console.error('No reliability directory found at', RELIABILITY_DIR);
+    process.exit(1);
+  }
+
+  const files = fs.readdirSync(RELIABILITY_DIR).filter(f => f.endsWith('.json'));
+  if (files.length === 0) {
+    console.error('No reliability files found');
+    process.exit(1);
+  }
+
+  // Count A answers per question
+  const aCounts = new Array(16).fill(0);
+  let totalRuns = 0;
+
+  for (const file of files) {
+    try {
+      const data = JSON.parse(fs.readFileSync(path.join(RELIABILITY_DIR, file), 'utf-8'));
+      if (!Array.isArray(data.answers) || data.answers.length !== 16) continue;
+      totalRuns++;
+      for (let i = 0; i < 16; i++) {
+        if (data.answers[i] === 'A') aCounts[i]++;
+      }
+    } catch (e) {
+      console.warn(`  Skipping ${file}: ${e.message}`);
+    }
+  }
+
+  if (totalRuns === 0) {
+    console.error('No valid reliability runs found');
+    process.exit(1);
+  }
+
+  // Compute discriminability per question
+  const questions = [];
+  for (let i = 0; i < 16; i++) {
+    const aPercent = (aCounts[i] / totalRuns) * 100;
+    const bPercent = 100 - aPercent;
+    const disc = +(1 - Math.abs(aPercent - 50) / 50).toFixed(3);
+    questions.push({
+      question: i + 1,
+      aCount: aCounts[i],
+      bCount: totalRuns - aCounts[i],
+      aPercent: +aPercent.toFixed(1),
+      bPercent: +bPercent.toFixed(1),
+      discriminability: disc,
+    });
+  }
+
+  // Group by dimension
+  const dimensions = DIMENSIONS.map(dim => {
+    const dimQuestions = dim.questions.map(q => questions[q - 1]);
+    const avgDisc = +(dimQuestions.reduce((s, q) => s + q.discriminability, 0) / dimQuestions.length).toFixed(3);
+    return {
+      name: dim.name,
+      poles: dim.poles,
+      questions: dimQuestions,
+      averageDiscriminability: avgDisc,
+    };
+  });
+
+  const output = {
+    totalRuns,
+    generatedAt: new Date().toISOString(),
+    threshold: 0.6,
+    questions,
+    dimensions,
+  };
+
+  fs.writeFileSync(OUTPUT_FILE, JSON.stringify(output, null, 2) + '\n');
+  console.log(`Generated discriminability data from ${totalRuns} runs → ${OUTPUT_FILE}`);
+
+  // Summary
+  const belowThreshold = questions.filter(q => q.discriminability < 0.6);
+  if (belowThreshold.length > 0) {
+    console.log(`\n  ⚠ ${belowThreshold.length} question(s) below 0.6 threshold:`);
+    for (const q of belowThreshold) {
+      console.log(`    Q${q.question}: ${q.discriminability} (A:${q.aPercent}% B:${q.bPercent}%)`);
+    }
+  }
+}
+
+main();

--- a/stats.html
+++ b/stats.html
@@ -115,6 +115,26 @@ nav .lang-btn:hover { color: var(--accent); border-color: var(--accent); }
 .provider-bar span { font-size: .68rem; font-weight: 700; color: #fff; }
 .provider-count { width: 32px; font-size: .78rem; font-weight: 600; color: var(--text); text-align: left; }
 
+/* Discriminability Section */
+.disc-section { margin-bottom: 2.5rem; }
+.disc-grid { display: flex; flex-direction: column; gap: .5rem; }
+.disc-dim-group { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); padding: 1rem 1.2rem; box-shadow: var(--shadow); }
+.disc-dim-title { font-size: .78rem; font-weight: 600; color: var(--text); margin-bottom: .6rem; letter-spacing: .03em; }
+.disc-dim-avg { font-size: .68rem; color: var(--text2); margin-left: .5rem; font-weight: 400; }
+.disc-questions { display: flex; flex-direction: column; gap: .4rem; }
+.disc-row { display: flex; align-items: center; gap: .5rem; }
+.disc-label { width: 32px; font-size: .72rem; font-weight: 600; color: var(--text2); flex-shrink: 0; }
+.disc-bar-wrap { flex: 1; height: 20px; background: var(--surface2); border-radius: 5px; overflow: hidden; display: flex; }
+.disc-bar-a { height: 100%; background: var(--accent); display: flex; align-items: center; justify-content: center; min-width: 1px; transition: width .6s ease; }
+.disc-bar-b { height: 100%; background: var(--text3); opacity: .45; display: flex; align-items: center; justify-content: center; min-width: 1px; flex: 1; }
+.disc-bar-a span, .disc-bar-b span { font-size: .6rem; font-weight: 700; color: #fff; }
+.disc-score { width: 42px; font-size: .72rem; font-weight: 600; text-align: right; flex-shrink: 0; }
+.disc-score.good { color: var(--accent); }
+.disc-score.warn { color: #d97706; }
+.disc-row.below-threshold .disc-bar-a { background: #d97706; }
+.disc-row.below-threshold .disc-label { color: #d97706; }
+.disc-meta { display: flex; gap: 1rem; margin-top: .8rem; padding-top: .6rem; border-top: 1px solid var(--border); font-size: .72rem; color: var(--text2); }
+
 /* Undiscovered Challenge */
 .challenge-section { margin-bottom: 2.5rem; }
 .challenge-box { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); padding: 1.5rem; box-shadow: var(--shadow); text-align: center; }
@@ -245,6 +265,7 @@ const i18n = {
     challengeTitle: 'Undiscovered Types Challenge',
     challengeDesc: 'These types have never been observed in the wild. Think your model has what it takes?',
     ctaText: 'Test Your Agent →',
+    discTitle: 'QUESTION DISCRIMINABILITY',
     loading: 'Loading…',
     error: 'Failed to load stats.'
   },
@@ -263,6 +284,7 @@ const i18n = {
     challengeTitle: '未发现类型挑战',
     challengeDesc: '这些类型从未在测试中出现过。你的模型能成为第一个吗？',
     ctaText: '测试你的智能体 →',
+    discTitle: '题目区分度',
     loading: '加载中…',
     error: '加载失败。'
   }
@@ -270,6 +292,7 @@ const i18n = {
 
 let statsData = null;
 let agentsData = null;
+let discData = null;
 
 function t(key) { return (i18n[lang] || i18n.en)[key] || (i18n.en)[key]; }
 
@@ -289,6 +312,11 @@ async function init() {
     ]);
     statsData = await statsRes.json();
     agentsData = await agentsRes.json();
+    // Load discriminability data (optional, non-blocking)
+    try {
+      const discRes = await fetch('/data/discriminability.json');
+      if (discRes.ok) discData = await discRes.json();
+    } catch(_) {}
     render();
   } catch(e) {
     document.getElementById('content').innerHTML = '<div class="error">' + t('error') + '</div>';
@@ -394,6 +422,38 @@ function render() {
       + '</div>';
   }
   html += '</div></div>';
+
+  // Question Discriminability
+  if (discData && discData.questions) {
+    const discDimNames = lang === 'zh' ? ['自主性', '精确度', '沟通风格', '适应性'] : ['Autonomy', 'Precision', 'Transparency', 'Adaptability'];
+    const discTitle = lang === 'zh' ? '题目区分度' : 'QUESTION DISCRIMINABILITY';
+    const threshold = discData.threshold || 0.6;
+    html += '<div class="disc-section">';
+    html += '<div class="section-title">' + discTitle + '</div>';
+    html += '<div class="disc-grid">';
+    for (let d = 0; d < discData.dimensions.length; d++) {
+      const dim = discData.dimensions[d];
+      html += '<div class="disc-dim-group">';
+      html += '<div class="disc-dim-title">' + esc(discDimNames[d]) + ' <span class="disc-dim-avg">(avg ' + dim.averageDiscriminability.toFixed(2) + ')</span></div>';
+      html += '<div class="disc-questions">';
+      for (const q of dim.questions) {
+        const belowClass = q.discriminability < threshold ? ' below-threshold' : '';
+        const scoreClass = q.discriminability >= threshold ? 'good' : 'warn';
+        html += '<div class="disc-row' + belowClass + '">';
+        html += '<div class="disc-label">Q' + q.question + '</div>';
+        html += '<div class="disc-bar-wrap">';
+        html += '<div class="disc-bar-a" style="width:' + q.aPercent + '%"><span>' + q.aPercent + '%</span></div>';
+        html += '<div class="disc-bar-b"><span>' + q.bPercent + '%</span></div>';
+        html += '</div>';
+        html += '<div class="disc-score ' + scoreClass + '">' + q.discriminability.toFixed(2) + '</div>';
+        html += '</div>';
+      }
+      html += '</div></div>';
+    }
+    html += '</div>';
+    html += '<div class="disc-meta"><span>' + (lang === 'zh' ? '数据来源' : 'Based on') + ': ' + discData.totalRuns + (lang === 'zh' ? ' 次测试' : ' runs') + '</span><span>' + (lang === 'zh' ? '阈值' : 'Threshold') + ': ' + threshold + '</span></div>';
+    html += '</div>';
+  }
 
   // Undiscovered Types Challenge
   if (undiscoveredTypes.length > 0) {


### PR DESCRIPTION
## Summary

Add per-question discriminability analysis to both the stats page and CLI, showing how well each question differentiates models.

### Changes

- **`scripts/generate-discriminability.js`**: Reads reliability data (192 runs across 66 models), computes per-question A/B split and discriminability score (`disc = 1 - |%A - 50| / 50`)
- **`stats.html`**: New 'Question Discriminability' section with visual A%/B% bars grouped by dimension, highlighting questions below 0.6 threshold
- **`cli/bin/abti.js`**: `npx abti stats` now includes discriminability section when reliability data is present
- **`data/discriminability.json`**: Pre-generated data for the static site

### Current findings (192 runs)
- 6 questions below 0.6 threshold: Q4, Q8, Q11, Q12, Q15, Q16
- Best: Q1 (Autonomy) at 0.958 — near-perfect 48/52 split
- Worst: Q15 (Adaptability) at 0.292 — 85% pick A

This supports the v5-beta question redesign targeting Q11, Q12, Q15.

Closes #572