### PR TITLE
feat: version-aware discriminability analysis with cohort split

### DIFF
--- a/cli/bin/abti.js
+++ b/cli/bin/abti.js
@@ -1184,37 +1184,21 @@ async function runStats() {
         [DIM_NAMES[lang][d.dim][2]]: d.rightCount,
       })),
     };
-    // Add discriminability if local data exists
-    const reliabilityDirJson = require('path').join(__dirname, '..', '..', 'data', 'reliability');
-    if (fs.existsSync(reliabilityDirJson)) {
-      const relFilesJson = fs.readdirSync(reliabilityDirJson).filter(f => f.endsWith('.json'));
-      if (relFilesJson.length > 0) {
-        const aCountsJson = new Array(16).fill(0);
-        let totalRunsJson = 0;
-        for (const file of relFilesJson) {
-          try {
-            const rd = JSON.parse(fs.readFileSync(require('path').join(reliabilityDirJson, file), 'utf-8'));
-            if (!Array.isArray(rd.answers) || rd.answers.length !== 16) continue;
-            totalRunsJson++;
-            for (let i = 0; i < 16; i++) { if (rd.answers[i] === 'A') aCountsJson[i]++; }
-          } catch (_) {}
-        }
-        if (totalRunsJson > 0) {
-          output.discriminability = {
-            totalRuns: totalRunsJson,
-            threshold: 0.6,
-            questions: Array.from({ length: 16 }, (_, i) => {
-              const aPct = (aCountsJson[i] / totalRunsJson) * 100;
-              return {
-                question: i + 1,
-                aPercent: +aPct.toFixed(1),
-                bPercent: +(100 - aPct).toFixed(1),
-                discriminability: +(1 - Math.abs(aPct - 50) / 50).toFixed(3),
-              };
-            }),
-          };
-        }
-      }
+    // Add discriminability if generated data exists
+    const discFileJson = require('path').join(__dirname, '..', '..', 'data', 'discriminability.json');
+    if (fs.existsSync(discFileJson)) {
+      try {
+        const discJson = JSON.parse(fs.readFileSync(discFileJson, 'utf-8'));
+        const cohorts = discJson.cohorts || {};
+        const cohortKey = cohorts['v5-beta'] ? 'v5-beta' : 'all';
+        const cohort = cohorts[cohortKey] || { totalRuns: discJson.totalRuns, questions: discJson.questions };
+        output.discriminability = {
+          cohort: cohortKey,
+          totalRuns: cohort.totalRuns,
+          threshold: discJson.threshold || 0.6,
+          questions: cohort.questions,
+        };
+      } catch (_) {}
     }
     console.log(JSON.stringify(output, null, 2));
     return;
@@ -1260,33 +1244,32 @@ async function runStats() {
     console.log(`      ${dimNames[d.dim][2]} (${d.right}): ${c.yellow}${'█'.repeat(rightBar)}${c.reset} ${d.rightCount} (${rightPct}%)`);
   }
 
-  // Question Discriminability (from local reliability data)
-  const reliabilityDir = require('path').join(__dirname, '..', '..', 'data', 'reliability');
-  if (fs.existsSync(reliabilityDir)) {
-    const relFiles = fs.readdirSync(reliabilityDir).filter(f => f.endsWith('.json'));
-    if (relFiles.length > 0) {
-      const aCounts = new Array(16).fill(0);
-      let totalRuns = 0;
-      for (const file of relFiles) {
-        try {
-          const rd = JSON.parse(fs.readFileSync(require('path').join(reliabilityDir, file), 'utf-8'));
-          if (!Array.isArray(rd.answers) || rd.answers.length !== 16) continue;
-          totalRuns++;
-          for (let i = 0; i < 16; i++) { if (rd.answers[i] === 'A') aCounts[i]++; }
-        } catch (_) {}
-      }
-      if (totalRuns > 0) {
+  // Question Discriminability (from generated discriminability.json)
+  const discFile = require('path').join(__dirname, '..', '..', 'data', 'discriminability.json');
+  if (fs.existsSync(discFile)) {
+    try {
+      const discData = JSON.parse(fs.readFileSync(discFile, 'utf-8'));
+      const cohorts = discData.cohorts || {};
+      // Prefer v5-beta (current question set), fall back to all
+      const cohortKey = cohorts['v5-beta'] ? 'v5-beta' : 'all';
+      const cohort = cohorts[cohortKey] || { totalRuns: discData.totalRuns, questions: discData.questions };
+      const totalRuns = cohort.totalRuns;
+      if (totalRuns > 0 && cohort.questions) {
         const discDimNames = lang === 'zh'
           ? ['自主性', '精确度', '沟通风格', '适应性']
           : ['Autonomy', 'Precision', 'Transparency', 'Adaptability'];
         const discTitle = lang === 'zh' ? '题目区分度' : 'Question Discriminability';
-        const discThreshold = 0.6;
-        console.log(`\n  ${c.bold}${discTitle}:${c.reset}  (${totalRuns} ${lang === 'zh' ? '次测试' : 'runs'})\n`);
+        const discThreshold = discData.threshold || 0.6;
+        const cohortNote = cohortKey === 'v5-beta'
+          ? ` ${c.dim}(${cohortKey}, ${totalRuns} ${lang === 'zh' ? '次' : 'runs'})${c.reset}`
+          : ` ${c.dim}(${totalRuns} ${lang === 'zh' ? '次测试' : 'runs'})${c.reset}`;
+        console.log(`\n  ${c.bold}${discTitle}:${c.reset}${cohortNote}\n`);
         for (let d = 0; d < 4; d++) {
           console.log(`    ${discDimNames[d]}:`);
           for (let qi = d * 4; qi < d * 4 + 4; qi++) {
-            const aPct = (aCounts[qi] / totalRuns) * 100;
-            const disc = 1 - Math.abs(aPct - 50) / 50;
+            const q = cohort.questions[qi];
+            const aPct = q.aPercent;
+            const disc = q.discriminability;
             const discStr = disc.toFixed(3);
             const qLabel = `Q${qi + 1}`.padEnd(4);
             const barTotal = 20;
@@ -1294,11 +1277,11 @@ async function runStats() {
             const bBar = barTotal - aBar;
             const warnMark = disc < discThreshold ? ` ${c.yellow}⚠${c.reset}` : '';
             const discColor = disc >= discThreshold ? c.green : c.yellow;
-            console.log(`      ${qLabel} ${c.cyan}${'█'.repeat(aBar)}${c.reset}${c.dim}${'░'.repeat(bBar)}${c.reset} A:${aPct.toFixed(0).padStart(3)}% B:${(100 - aPct).toFixed(0).padStart(3)}%  ${discColor}${discStr}${c.reset}${warnMark}`);
+            console.log(`      ${qLabel} ${c.cyan}${'█'.repeat(aBar)}${c.reset}${c.dim}${'░'.repeat(bBar)}${c.reset} A:${aPct.toFixed(0).padStart(3)}% B:${q.bPercent.toFixed(0).padStart(3)}%  ${discColor}${discStr}${c.reset}${warnMark}`);
           }
         }
       }
-    }
+    } catch (_) {}
   }
 
   console.log();

--- a/data/discriminability.json
+++ b/data/discriminability.json
@@ -1,7 +1,7 @@
 {
-  "totalRuns": 192,
-  "generatedAt": "2026-06-24T10:39:47.659Z",
+  "generatedAt": "2026-06-24T12:55:50.956Z",
   "threshold": 0.6,
+  "totalRuns": 192,
   "questions": [
     {
       "question": 1,
@@ -301,5 +301,916 @@
       ],
       "averageDiscriminability": 0.617
     }
-  ]
+  ],
+  "cohorts": {
+    "all": {
+      "totalRuns": 192,
+      "questions": [
+        {
+          "question": 1,
+          "aCount": 92,
+          "bCount": 100,
+          "aPercent": 47.9,
+          "bPercent": 52.1,
+          "discriminability": 0.958
+        },
+        {
+          "question": 2,
+          "aCount": 110,
+          "bCount": 82,
+          "aPercent": 57.3,
+          "bPercent": 42.7,
+          "discriminability": 0.854
+        },
+        {
+          "question": 3,
+          "aCount": 74,
+          "bCount": 118,
+          "aPercent": 38.5,
+          "bPercent": 61.5,
+          "discriminability": 0.771
+        },
+        {
+          "question": 4,
+          "aCount": 142,
+          "bCount": 50,
+          "aPercent": 74,
+          "bPercent": 26,
+          "discriminability": 0.521
+        },
+        {
+          "question": 5,
+          "aCount": 128,
+          "bCount": 64,
+          "aPercent": 66.7,
+          "bPercent": 33.3,
+          "discriminability": 0.667
+        },
+        {
+          "question": 6,
+          "aCount": 72,
+          "bCount": 120,
+          "aPercent": 37.5,
+          "bPercent": 62.5,
+          "discriminability": 0.75
+        },
+        {
+          "question": 7,
+          "aCount": 124,
+          "bCount": 68,
+          "aPercent": 64.6,
+          "bPercent": 35.4,
+          "discriminability": 0.708
+        },
+        {
+          "question": 8,
+          "aCount": 53,
+          "bCount": 139,
+          "aPercent": 27.6,
+          "bPercent": 72.4,
+          "discriminability": 0.552
+        },
+        {
+          "question": 9,
+          "aCount": 110,
+          "bCount": 82,
+          "aPercent": 57.3,
+          "bPercent": 42.7,
+          "discriminability": 0.854
+        },
+        {
+          "question": 10,
+          "aCount": 124,
+          "bCount": 68,
+          "aPercent": 64.6,
+          "bPercent": 35.4,
+          "discriminability": 0.708
+        },
+        {
+          "question": 11,
+          "aCount": 146,
+          "bCount": 46,
+          "aPercent": 76,
+          "bPercent": 24,
+          "discriminability": 0.479
+        },
+        {
+          "question": 12,
+          "aCount": 154,
+          "bCount": 38,
+          "aPercent": 80.2,
+          "bPercent": 19.8,
+          "discriminability": 0.396
+        },
+        {
+          "question": 13,
+          "aCount": 72,
+          "bCount": 120,
+          "aPercent": 37.5,
+          "bPercent": 62.5,
+          "discriminability": 0.75
+        },
+        {
+          "question": 14,
+          "aCount": 83,
+          "bCount": 109,
+          "aPercent": 43.2,
+          "bPercent": 56.8,
+          "discriminability": 0.865
+        },
+        {
+          "question": 15,
+          "aCount": 164,
+          "bCount": 28,
+          "aPercent": 85.4,
+          "bPercent": 14.6,
+          "discriminability": 0.292
+        },
+        {
+          "question": 16,
+          "aCount": 54,
+          "bCount": 138,
+          "aPercent": 28.1,
+          "bPercent": 71.9,
+          "discriminability": 0.563
+        }
+      ],
+      "dimensions": [
+        {
+          "name": "Autonomy",
+          "poles": [
+            "P",
+            "R"
+          ],
+          "questions": [
+            {
+              "question": 1,
+              "aCount": 92,
+              "bCount": 100,
+              "aPercent": 47.9,
+              "bPercent": 52.1,
+              "discriminability": 0.958
+            },
+            {
+              "question": 2,
+              "aCount": 110,
+              "bCount": 82,
+              "aPercent": 57.3,
+              "bPercent": 42.7,
+              "discriminability": 0.854
+            },
+            {
+              "question": 3,
+              "aCount": 74,
+              "bCount": 118,
+              "aPercent": 38.5,
+              "bPercent": 61.5,
+              "discriminability": 0.771
+            },
+            {
+              "question": 4,
+              "aCount": 142,
+              "bCount": 50,
+              "aPercent": 74,
+              "bPercent": 26,
+              "discriminability": 0.521
+            }
+          ],
+          "averageDiscriminability": 0.776
+        },
+        {
+          "name": "Precision",
+          "poles": [
+            "T",
+            "E"
+          ],
+          "questions": [
+            {
+              "question": 5,
+              "aCount": 128,
+              "bCount": 64,
+              "aPercent": 66.7,
+              "bPercent": 33.3,
+              "discriminability": 0.667
+            },
+            {
+              "question": 6,
+              "aCount": 72,
+              "bCount": 120,
+              "aPercent": 37.5,
+              "bPercent": 62.5,
+              "discriminability": 0.75
+            },
+            {
+              "question": 7,
+              "aCount": 124,
+              "bCount": 68,
+              "aPercent": 64.6,
+              "bPercent": 35.4,
+              "discriminability": 0.708
+            },
+            {
+              "question": 8,
+              "aCount": 53,
+              "bCount": 139,
+              "aPercent": 27.6,
+              "bPercent": 72.4,
+              "discriminability": 0.552
+            }
+          ],
+          "averageDiscriminability": 0.669
+        },
+        {
+          "name": "Transparency",
+          "poles": [
+            "C",
+            "D"
+          ],
+          "questions": [
+            {
+              "question": 9,
+              "aCount": 110,
+              "bCount": 82,
+              "aPercent": 57.3,
+              "bPercent": 42.7,
+              "discriminability": 0.854
+            },
+            {
+              "question": 10,
+              "aCount": 124,
+              "bCount": 68,
+              "aPercent": 64.6,
+              "bPercent": 35.4,
+              "discriminability": 0.708
+            },
+            {
+              "question": 11,
+              "aCount": 146,
+              "bCount": 46,
+              "aPercent": 76,
+              "bPercent": 24,
+              "discriminability": 0.479
+            },
+            {
+              "question": 12,
+              "aCount": 154,
+              "bCount": 38,
+              "aPercent": 80.2,
+              "bPercent": 19.8,
+              "discriminability": 0.396
+            }
+          ],
+          "averageDiscriminability": 0.609
+        },
+        {
+          "name": "Adaptability",
+          "poles": [
+            "F",
+            "N"
+          ],
+          "questions": [
+            {
+              "question": 13,
+              "aCount": 72,
+              "bCount": 120,
+              "aPercent": 37.5,
+              "bPercent": 62.5,
+              "discriminability": 0.75
+            },
+            {
+              "question": 14,
+              "aCount": 83,
+              "bCount": 109,
+              "aPercent": 43.2,
+              "bPercent": 56.8,
+              "discriminability": 0.865
+            },
+            {
+              "question": 15,
+              "aCount": 164,
+              "bCount": 28,
+              "aPercent": 85.4,
+              "bPercent": 14.6,
+              "discriminability": 0.292
+            },
+            {
+              "question": 16,
+              "aCount": 54,
+              "bCount": 138,
+              "aPercent": 28.1,
+              "bPercent": 71.9,
+              "discriminability": 0.563
+            }
+          ],
+          "averageDiscriminability": 0.617
+        }
+      ]
+    },
+    "v4": {
+      "totalRuns": 157,
+      "questions": [
+        {
+          "question": 1,
+          "aCount": 79,
+          "bCount": 78,
+          "aPercent": 50.3,
+          "bPercent": 49.7,
+          "discriminability": 0.994
+        },
+        {
+          "question": 2,
+          "aCount": 86,
+          "bCount": 71,
+          "aPercent": 54.8,
+          "bPercent": 45.2,
+          "discriminability": 0.904
+        },
+        {
+          "question": 3,
+          "aCount": 72,
+          "bCount": 85,
+          "aPercent": 45.9,
+          "bPercent": 54.1,
+          "discriminability": 0.917
+        },
+        {
+          "question": 4,
+          "aCount": 114,
+          "bCount": 43,
+          "aPercent": 72.6,
+          "bPercent": 27.4,
+          "discriminability": 0.548
+        },
+        {
+          "question": 5,
+          "aCount": 103,
+          "bCount": 54,
+          "aPercent": 65.6,
+          "bPercent": 34.4,
+          "discriminability": 0.688
+        },
+        {
+          "question": 6,
+          "aCount": 51,
+          "bCount": 106,
+          "aPercent": 32.5,
+          "bPercent": 67.5,
+          "discriminability": 0.65
+        },
+        {
+          "question": 7,
+          "aCount": 98,
+          "bCount": 59,
+          "aPercent": 62.4,
+          "bPercent": 37.6,
+          "discriminability": 0.752
+        },
+        {
+          "question": 8,
+          "aCount": 44,
+          "bCount": 113,
+          "aPercent": 28,
+          "bPercent": 72,
+          "discriminability": 0.561
+        },
+        {
+          "question": 9,
+          "aCount": 91,
+          "bCount": 66,
+          "aPercent": 58,
+          "bPercent": 42,
+          "discriminability": 0.841
+        },
+        {
+          "question": 10,
+          "aCount": 100,
+          "bCount": 57,
+          "aPercent": 63.7,
+          "bPercent": 36.3,
+          "discriminability": 0.726
+        },
+        {
+          "question": 11,
+          "aCount": 114,
+          "bCount": 43,
+          "aPercent": 72.6,
+          "bPercent": 27.4,
+          "discriminability": 0.548
+        },
+        {
+          "question": 12,
+          "aCount": 124,
+          "bCount": 33,
+          "aPercent": 79,
+          "bPercent": 21,
+          "discriminability": 0.42
+        },
+        {
+          "question": 13,
+          "aCount": 61,
+          "bCount": 96,
+          "aPercent": 38.9,
+          "bPercent": 61.1,
+          "discriminability": 0.777
+        },
+        {
+          "question": 14,
+          "aCount": 67,
+          "bCount": 90,
+          "aPercent": 42.7,
+          "bPercent": 57.3,
+          "discriminability": 0.854
+        },
+        {
+          "question": 15,
+          "aCount": 135,
+          "bCount": 22,
+          "aPercent": 86,
+          "bPercent": 14,
+          "discriminability": 0.28
+        },
+        {
+          "question": 16,
+          "aCount": 44,
+          "bCount": 113,
+          "aPercent": 28,
+          "bPercent": 72,
+          "discriminability": 0.561
+        }
+      ],
+      "dimensions": [
+        {
+          "name": "Autonomy",
+          "poles": [
+            "P",
+            "R"
+          ],
+          "questions": [
+            {
+              "question": 1,
+              "aCount": 79,
+              "bCount": 78,
+              "aPercent": 50.3,
+              "bPercent": 49.7,
+              "discriminability": 0.994
+            },
+            {
+              "question": 2,
+              "aCount": 86,
+              "bCount": 71,
+              "aPercent": 54.8,
+              "bPercent": 45.2,
+              "discriminability": 0.904
+            },
+            {
+              "question": 3,
+              "aCount": 72,
+              "bCount": 85,
+              "aPercent": 45.9,
+              "bPercent": 54.1,
+              "discriminability": 0.917
+            },
+            {
+              "question": 4,
+              "aCount": 114,
+              "bCount": 43,
+              "aPercent": 72.6,
+              "bPercent": 27.4,
+              "discriminability": 0.548
+            }
+          ],
+          "averageDiscriminability": 0.841
+        },
+        {
+          "name": "Precision",
+          "poles": [
+            "T",
+            "E"
+          ],
+          "questions": [
+            {
+              "question": 5,
+              "aCount": 103,
+              "bCount": 54,
+              "aPercent": 65.6,
+              "bPercent": 34.4,
+              "discriminability": 0.688
+            },
+            {
+              "question": 6,
+              "aCount": 51,
+              "bCount": 106,
+              "aPercent": 32.5,
+              "bPercent": 67.5,
+              "discriminability": 0.65
+            },
+            {
+              "question": 7,
+              "aCount": 98,
+              "bCount": 59,
+              "aPercent": 62.4,
+              "bPercent": 37.6,
+              "discriminability": 0.752
+            },
+            {
+              "question": 8,
+              "aCount": 44,
+              "bCount": 113,
+              "aPercent": 28,
+              "bPercent": 72,
+              "discriminability": 0.561
+            }
+          ],
+          "averageDiscriminability": 0.663
+        },
+        {
+          "name": "Transparency",
+          "poles": [
+            "C",
+            "D"
+          ],
+          "questions": [
+            {
+              "question": 9,
+              "aCount": 91,
+              "bCount": 66,
+              "aPercent": 58,
+              "bPercent": 42,
+              "discriminability": 0.841
+            },
+            {
+              "question": 10,
+              "aCount": 100,
+              "bCount": 57,
+              "aPercent": 63.7,
+              "bPercent": 36.3,
+              "discriminability": 0.726
+            },
+            {
+              "question": 11,
+              "aCount": 114,
+              "bCount": 43,
+              "aPercent": 72.6,
+              "bPercent": 27.4,
+              "discriminability": 0.548
+            },
+            {
+              "question": 12,
+              "aCount": 124,
+              "bCount": 33,
+              "aPercent": 79,
+              "bPercent": 21,
+              "discriminability": 0.42
+            }
+          ],
+          "averageDiscriminability": 0.634
+        },
+        {
+          "name": "Adaptability",
+          "poles": [
+            "F",
+            "N"
+          ],
+          "questions": [
+            {
+              "question": 13,
+              "aCount": 61,
+              "bCount": 96,
+              "aPercent": 38.9,
+              "bPercent": 61.1,
+              "discriminability": 0.777
+            },
+            {
+              "question": 14,
+              "aCount": 67,
+              "bCount": 90,
+              "aPercent": 42.7,
+              "bPercent": 57.3,
+              "discriminability": 0.854
+            },
+            {
+              "question": 15,
+              "aCount": 135,
+              "bCount": 22,
+              "aPercent": 86,
+              "bPercent": 14,
+              "discriminability": 0.28
+            },
+            {
+              "question": 16,
+              "aCount": 44,
+              "bCount": 113,
+              "aPercent": 28,
+              "bPercent": 72,
+              "discriminability": 0.561
+            }
+          ],
+          "averageDiscriminability": 0.618
+        }
+      ]
+    },
+    "v5-beta": {
+      "totalRuns": 35,
+      "questions": [
+        {
+          "question": 1,
+          "aCount": 13,
+          "bCount": 22,
+          "aPercent": 37.1,
+          "bPercent": 62.9,
+          "discriminability": 0.743
+        },
+        {
+          "question": 2,
+          "aCount": 24,
+          "bCount": 11,
+          "aPercent": 68.6,
+          "bPercent": 31.4,
+          "discriminability": 0.629
+        },
+        {
+          "question": 3,
+          "aCount": 2,
+          "bCount": 33,
+          "aPercent": 5.7,
+          "bPercent": 94.3,
+          "discriminability": 0.114
+        },
+        {
+          "question": 4,
+          "aCount": 28,
+          "bCount": 7,
+          "aPercent": 80,
+          "bPercent": 20,
+          "discriminability": 0.4
+        },
+        {
+          "question": 5,
+          "aCount": 25,
+          "bCount": 10,
+          "aPercent": 71.4,
+          "bPercent": 28.6,
+          "discriminability": 0.571
+        },
+        {
+          "question": 6,
+          "aCount": 21,
+          "bCount": 14,
+          "aPercent": 60,
+          "bPercent": 40,
+          "discriminability": 0.8
+        },
+        {
+          "question": 7,
+          "aCount": 26,
+          "bCount": 9,
+          "aPercent": 74.3,
+          "bPercent": 25.7,
+          "discriminability": 0.514
+        },
+        {
+          "question": 8,
+          "aCount": 9,
+          "bCount": 26,
+          "aPercent": 25.7,
+          "bPercent": 74.3,
+          "discriminability": 0.514
+        },
+        {
+          "question": 9,
+          "aCount": 19,
+          "bCount": 16,
+          "aPercent": 54.3,
+          "bPercent": 45.7,
+          "discriminability": 0.914
+        },
+        {
+          "question": 10,
+          "aCount": 24,
+          "bCount": 11,
+          "aPercent": 68.6,
+          "bPercent": 31.4,
+          "discriminability": 0.629
+        },
+        {
+          "question": 11,
+          "aCount": 32,
+          "bCount": 3,
+          "aPercent": 91.4,
+          "bPercent": 8.6,
+          "discriminability": 0.171
+        },
+        {
+          "question": 12,
+          "aCount": 30,
+          "bCount": 5,
+          "aPercent": 85.7,
+          "bPercent": 14.3,
+          "discriminability": 0.286
+        },
+        {
+          "question": 13,
+          "aCount": 11,
+          "bCount": 24,
+          "aPercent": 31.4,
+          "bPercent": 68.6,
+          "discriminability": 0.629
+        },
+        {
+          "question": 14,
+          "aCount": 16,
+          "bCount": 19,
+          "aPercent": 45.7,
+          "bPercent": 54.3,
+          "discriminability": 0.914
+        },
+        {
+          "question": 15,
+          "aCount": 29,
+          "bCount": 6,
+          "aPercent": 82.9,
+          "bPercent": 17.1,
+          "discriminability": 0.343
+        },
+        {
+          "question": 16,
+          "aCount": 10,
+          "bCount": 25,
+          "aPercent": 28.6,
+          "bPercent": 71.4,
+          "discriminability": 0.571
+        }
+      ],
+      "dimensions": [
+        {
+          "name": "Autonomy",
+          "poles": [
+            "P",
+            "R"
+          ],
+          "questions": [
+            {
+              "question": 1,
+              "aCount": 13,
+              "bCount": 22,
+              "aPercent": 37.1,
+              "bPercent": 62.9,
+              "discriminability": 0.743
+            },
+            {
+              "question": 2,
+              "aCount": 24,
+              "bCount": 11,
+              "aPercent": 68.6,
+              "bPercent": 31.4,
+              "discriminability": 0.629
+            },
+            {
+              "question": 3,
+              "aCount": 2,
+              "bCount": 33,
+              "aPercent": 5.7,
+              "bPercent": 94.3,
+              "discriminability": 0.114
+            },
+            {
+              "question": 4,
+              "aCount": 28,
+              "bCount": 7,
+              "aPercent": 80,
+              "bPercent": 20,
+              "discriminability": 0.4
+            }
+          ],
+          "averageDiscriminability": 0.472
+        },
+        {
+          "name": "Precision",
+          "poles": [
+            "T",
+            "E"
+          ],
+          "questions": [
+            {
+              "question": 5,
+              "aCount": 25,
+              "bCount": 10,
+              "aPercent": 71.4,
+              "bPercent": 28.6,
+              "discriminability": 0.571
+            },
+            {
+              "question": 6,
+              "aCount": 21,
+              "bCount": 14,
+              "aPercent": 60,
+              "bPercent": 40,
+              "discriminability": 0.8
+            },
+            {
+              "question": 7,
+              "aCount": 26,
+              "bCount": 9,
+              "aPercent": 74.3,
+              "bPercent": 25.7,
+              "discriminability": 0.514
+            },
+            {
+              "question": 8,
+              "aCount": 9,
+              "bCount": 26,
+              "aPercent": 25.7,
+              "bPercent": 74.3,
+              "discriminability": 0.514
+            }
+          ],
+          "averageDiscriminability": 0.6
+        },
+        {
+          "name": "Transparency",
+          "poles": [
+            "C",
+            "D"
+          ],
+          "questions": [
+            {
+              "question": 9,
+              "aCount": 19,
+              "bCount": 16,
+              "aPercent": 54.3,
+              "bPercent": 45.7,
+              "discriminability": 0.914
+            },
+            {
+              "question": 10,
+              "aCount": 24,
+              "bCount": 11,
+              "aPercent": 68.6,
+              "bPercent": 31.4,
+              "discriminability": 0.629
+            },
+            {
+              "question": 11,
+              "aCount": 32,
+              "bCount": 3,
+              "aPercent": 91.4,
+              "bPercent": 8.6,
+              "discriminability": 0.171
+            },
+            {
+              "question": 12,
+              "aCount": 30,
+              "bCount": 5,
+              "aPercent": 85.7,
+              "bPercent": 14.3,
+              "discriminability": 0.286
+            }
+          ],
+          "averageDiscriminability": 0.5
+        },
+        {
+          "name": "Adaptability",
+          "poles": [
+            "F",
+            "N"
+          ],
+          "questions": [
+            {
+              "question": 13,
+              "aCount": 11,
+              "bCount": 24,
+              "aPercent": 31.4,
+              "bPercent": 68.6,
+              "discriminability": 0.629
+            },
+            {
+              "question": 14,
+              "aCount": 16,
+              "bCount": 19,
+              "aPercent": 45.7,
+              "bPercent": 54.3,
+              "discriminability": 0.914
+            },
+            {
+              "question": 15,
+              "aCount": 29,
+              "bCount": 6,
+              "aPercent": 82.9,
+              "bPercent": 17.1,
+              "discriminability": 0.343
+            },
+            {
+              "question": 16,
+              "aCount": 10,
+              "bCount": 25,
+              "aPercent": 28.6,
+              "bPercent": 71.4,
+              "discriminability": 0.571
+            }
+          ],
+          "averageDiscriminability": 0.614
+        }
+      ]
+    }
+  }
 }

--- a/scripts/generate-discriminability.js
+++ b/scripts/generate-discriminability.js
@@ -4,19 +4,22 @@
 /**
  * Generate per-question discriminability data from reliability test runs.
  *
- * Reads all data/reliability/*.json files, computes per-question A/B split
- * and discriminability score, then writes data/discriminability.json.
+ * Version-aware: splits runs into cohorts based on git commit date.
+ *   - Files committed before 2026-06-02T00:00:00+08:00 = 'v4'
+ *   - Files committed on/after that date = 'v5-beta'
  *
- * Discriminability formula: disc = 1 - |%A - 50| / 50
- *   0 = all answers same (no discrimination)
- *   1 = perfect 50/50 split (maximum discrimination)
+ * Output: data/discriminability.json with top-level questions/dimensions
+ * for backwards compat (= 'all' cohort) plus cohorts object.
  */
 
 const fs = require('fs');
 const path = require('path');
+const { execSync } = require('child_process');
 
 const RELIABILITY_DIR = path.join(__dirname, '..', 'data', 'reliability');
 const OUTPUT_FILE = path.join(__dirname, '..', 'data', 'discriminability.json');
+
+const V5_CUTOFF = new Date('2026-06-02T00:00:00+08:00').getTime();
 
 const DIMENSIONS = [
   { name: 'Autonomy', poles: ['P', 'R'], questions: [1, 2, 3, 4] },
@@ -25,41 +28,39 @@ const DIMENSIONS = [
   { name: 'Adaptability', poles: ['F', 'N'], questions: [13, 14, 15, 16] },
 ];
 
-function main() {
-  if (!fs.existsSync(RELIABILITY_DIR)) {
-    console.error('No reliability directory found at', RELIABILITY_DIR);
-    process.exit(1);
+function getFileCohort(filepath) {
+  try {
+    const output = execSync(
+      `git log --diff-filter=A --follow --format=%ai -- "${filepath}"`,
+      { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }
+    ).trim();
+    if (!output) return null;
+    // Take the last line (oldest = first commit that added the file)
+    const lines = output.split('\n');
+    const dateStr = lines[lines.length - 1].trim();
+    const ts = new Date(dateStr).getTime();
+    if (isNaN(ts)) return null;
+    return ts < V5_CUTOFF ? 'v4' : 'v5-beta';
+  } catch (e) {
+    return null;
   }
+}
 
-  const files = fs.readdirSync(RELIABILITY_DIR).filter(f => f.endsWith('.json'));
-  if (files.length === 0) {
-    console.error('No reliability files found');
-    process.exit(1);
-  }
-
-  // Count A answers per question
+function computeCohort(runs) {
+  if (runs.length === 0) return null;
   const aCounts = new Array(16).fill(0);
   let totalRuns = 0;
 
-  for (const file of files) {
-    try {
-      const data = JSON.parse(fs.readFileSync(path.join(RELIABILITY_DIR, file), 'utf-8'));
-      if (!Array.isArray(data.answers) || data.answers.length !== 16) continue;
-      totalRuns++;
-      for (let i = 0; i < 16; i++) {
-        if (data.answers[i] === 'A') aCounts[i]++;
-      }
-    } catch (e) {
-      console.warn(`  Skipping ${file}: ${e.message}`);
+  for (const data of runs) {
+    if (!Array.isArray(data.answers) || data.answers.length !== 16) continue;
+    totalRuns++;
+    for (let i = 0; i < 16; i++) {
+      if (data.answers[i] === 'A') aCounts[i]++;
     }
   }
 
-  if (totalRuns === 0) {
-    console.error('No valid reliability runs found');
-    process.exit(1);
-  }
+  if (totalRuns === 0) return null;
 
-  // Compute discriminability per question
   const questions = [];
   for (let i = 0; i < 16; i++) {
     const aPercent = (aCounts[i] / totalRuns) * 100;
@@ -75,7 +76,6 @@ function main() {
     });
   }
 
-  // Group by dimension
   const dimensions = DIMENSIONS.map(dim => {
     const dimQuestions = dim.questions.map(q => questions[q - 1]);
     const avgDisc = +(dimQuestions.reduce((s, q) => s + q.discriminability, 0) / dimQuestions.length).toFixed(3);
@@ -87,23 +87,92 @@ function main() {
     };
   });
 
+  return { totalRuns, questions, dimensions };
+}
+
+function main() {
+  if (!fs.existsSync(RELIABILITY_DIR)) {
+    console.error('No reliability directory found at', RELIABILITY_DIR);
+    process.exit(1);
+  }
+
+  const files = fs.readdirSync(RELIABILITY_DIR).filter(f => f.endsWith('.json'));
+  if (files.length === 0) {
+    console.error('No reliability files found');
+    process.exit(1);
+  }
+
+  // Determine cohorts via git
+  let gitAvailable = true;
+  const cohortMap = {}; // filename -> 'v4' | 'v5-beta' | null
+
+  for (const file of files) {
+    const filepath = path.join(RELIABILITY_DIR, file);
+    const cohort = getFileCohort(filepath);
+    if (cohort === null) gitAvailable = false;
+    cohortMap[file] = cohort;
+  }
+
+  // If any file failed git lookup, fall back to all-only
+  if (!gitAvailable) {
+    console.warn('  Git date lookup failed for some files; using "all" cohort only');
+  }
+
+  // Load all run data
+  const allRuns = [];
+  const v4Runs = [];
+  const v5Runs = [];
+
+  for (const file of files) {
+    let data;
+    try {
+      data = JSON.parse(fs.readFileSync(path.join(RELIABILITY_DIR, file), 'utf-8'));
+    } catch (e) {
+      console.warn(`  Skipping ${file}: ${e.message}`);
+      continue;
+    }
+    allRuns.push(data);
+    if (gitAvailable && cohortMap[file]) {
+      if (cohortMap[file] === 'v4') v4Runs.push(data);
+      else v5Runs.push(data);
+    }
+  }
+
+  const allCohort = computeCohort(allRuns);
+  if (!allCohort) {
+    console.error('No valid reliability runs found');
+    process.exit(1);
+  }
+
+  const cohorts = { all: allCohort };
+
+  if (gitAvailable) {
+    const v4Cohort = computeCohort(v4Runs);
+    const v5Cohort = computeCohort(v5Runs);
+    if (v4Cohort) cohorts.v4 = v4Cohort;
+    if (v5Cohort) cohorts['v5-beta'] = v5Cohort;
+  }
+
   const output = {
-    totalRuns,
     generatedAt: new Date().toISOString(),
     threshold: 0.6,
-    questions,
-    dimensions,
+    totalRuns: allCohort.totalRuns,
+    questions: allCohort.questions,
+    dimensions: allCohort.dimensions,
+    cohorts,
   };
 
   fs.writeFileSync(OUTPUT_FILE, JSON.stringify(output, null, 2) + '\n');
-  console.log(`Generated discriminability data from ${totalRuns} runs → ${OUTPUT_FILE}`);
+  console.log(`Generated discriminability data from ${allCohort.totalRuns} runs → ${OUTPUT_FILE}`);
 
-  // Summary
-  const belowThreshold = questions.filter(q => q.discriminability < 0.6);
-  if (belowThreshold.length > 0) {
-    console.log(`\n  ⚠ ${belowThreshold.length} question(s) below 0.6 threshold:`);
-    for (const q of belowThreshold) {
-      console.log(`    Q${q.question}: ${q.discriminability} (A:${q.aPercent}% B:${q.bPercent}%)`);
+  // Summary per cohort
+  for (const [name, cohort] of Object.entries(cohorts)) {
+    const belowThreshold = cohort.questions.filter(q => q.discriminability < 0.6);
+    console.log(`\n  [${name}] ${cohort.totalRuns} runs, ${belowThreshold.length} question(s) below 0.6 threshold`);
+    if (belowThreshold.length > 0) {
+      for (const q of belowThreshold) {
+        console.log(`    Q${q.question}: ${q.discriminability} (A:${q.aPercent}% B:${q.bPercent}%)`);
+      }
     }
   }
 }

--- a/stats.html
+++ b/stats.html
@@ -117,6 +117,12 @@ nav .lang-btn:hover { color: var(--accent); border-color: var(--accent); }
 
 /* Discriminability Section */
 .disc-section { margin-bottom: 2.5rem; }
+.disc-tabs { display: flex; gap: .4rem; margin-bottom: .75rem; }
+.disc-tab { background: var(--surface2); border: 1px solid var(--border); color: var(--text2); font-family: inherit; font-size: .72rem; font-weight: 600; padding: .35rem .75rem; border-radius: 6px; cursor: pointer; transition: all .2s; }
+.disc-tab.active { background: var(--accent); color: #fff; border-color: var(--accent); }
+.disc-tab:hover:not(.active) { border-color: var(--accent); color: var(--accent); }
+.disc-tab .badge { display: inline-block; background: #d97706; color: #fff; font-size: .6rem; font-weight: 700; padding: .1rem .35rem; border-radius: 99px; margin-left: .3rem; vertical-align: middle; }
+.disc-tab.active .badge { background: rgba(255,255,255,.85); color: var(--accent); }
 .disc-grid { display: flex; flex-direction: column; gap: .5rem; }
 .disc-dim-group { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); padding: 1rem 1.2rem; box-shadow: var(--shadow); }
 .disc-dim-title { font-size: .78rem; font-weight: 600; color: var(--text); margin-bottom: .6rem; letter-spacing: .03em; }
@@ -266,6 +272,9 @@ const i18n = {
     challengeDesc: 'These types have never been observed in the wild. Think your model has what it takes?',
     ctaText: 'Test Your Agent →',
     discTitle: 'QUESTION DISCRIMINABILITY',
+    discBased: 'Based on',
+    discRuns: 'runs',
+    discThreshold: 'Threshold',
     loading: 'Loading…',
     error: 'Failed to load stats.'
   },
@@ -285,6 +294,9 @@ const i18n = {
     challengeDesc: '这些类型从未在测试中出现过。你的模型能成为第一个吗？',
     ctaText: '测试你的智能体 →',
     discTitle: '题目区分度',
+    discBased: '数据来源',
+    discRuns: '次测试',
+    discThreshold: '阈值',
     loading: '加载中…',
     error: '加载失败。'
   }
@@ -425,34 +437,28 @@ function render() {
 
   // Question Discriminability
   if (discData && discData.questions) {
-    const discDimNames = lang === 'zh' ? ['自主性', '精确度', '沟通风格', '适应性'] : ['Autonomy', 'Precision', 'Transparency', 'Adaptability'];
-    const discTitle = lang === 'zh' ? '题目区分度' : 'QUESTION DISCRIMINABILITY';
     const threshold = discData.threshold || 0.6;
     html += '<div class="disc-section">';
-    html += '<div class="section-title">' + discTitle + '</div>';
-    html += '<div class="disc-grid">';
-    for (let d = 0; d < discData.dimensions.length; d++) {
-      const dim = discData.dimensions[d];
-      html += '<div class="disc-dim-group">';
-      html += '<div class="disc-dim-title">' + esc(discDimNames[d]) + ' <span class="disc-dim-avg">(avg ' + dim.averageDiscriminability.toFixed(2) + ')</span></div>';
-      html += '<div class="disc-questions">';
-      for (const q of dim.questions) {
-        const belowClass = q.discriminability < threshold ? ' below-threshold' : '';
-        const scoreClass = q.discriminability >= threshold ? 'good' : 'warn';
-        html += '<div class="disc-row' + belowClass + '">';
-        html += '<div class="disc-label">Q' + q.question + '</div>';
-        html += '<div class="disc-bar-wrap">';
-        html += '<div class="disc-bar-a" style="width:' + q.aPercent + '%"><span>' + q.aPercent + '%</span></div>';
-        html += '<div class="disc-bar-b"><span>' + q.bPercent + '%</span></div>';
-        html += '</div>';
-        html += '<div class="disc-score ' + scoreClass + '">' + q.discriminability.toFixed(2) + '</div>';
-        html += '</div>';
+    html += '<div class="section-title">' + t('discTitle') + '</div>';
+    // Cohort tabs
+    const cohorts = discData.cohorts || { all: { totalRuns: discData.totalRuns, questions: discData.questions, dimensions: discData.dimensions } };
+    const cohortKeys = Object.keys(cohorts);
+    if (cohortKeys.length > 1) {
+      html += '<div class="disc-tabs" id="discTabs">';
+      for (const key of cohortKeys) {
+        const cohort = cohorts[key];
+        const below = cohort.questions ? cohort.questions.filter(q => q.discriminability < threshold).length : 0;
+        const label = key === 'all' ? 'All' : key;
+        html += '<button class="disc-tab' + (key === 'all' ? ' active' : '') + '" data-cohort="' + key + '">' + esc(label);
+        if (below > 0) html += ' <span class="badge">' + below + '</span>';
+        html += '</button>';
       }
-      html += '</div></div>';
+      html += '</div>';
     }
+    html += '<div id="discContent"></div>';
     html += '</div>';
-    html += '<div class="disc-meta"><span>' + (lang === 'zh' ? '数据来源' : 'Based on') + ': ' + discData.totalRuns + (lang === 'zh' ? ' 次测试' : ' runs') + '</span><span>' + (lang === 'zh' ? '阈值' : 'Threshold') + ': ' + threshold + '</span></div>';
-    html += '</div>';
+    // Store cohort data for tab switching
+    html += '<script>window.__discCohorts=' + JSON.stringify(cohorts) + ';window.__discThreshold=' + threshold + ';</script>';
   }
 
   // Undiscovered Types Challenge
@@ -477,6 +483,21 @@ function render() {
   requestAnimationFrame(() => {
     document.querySelectorAll('.stat-number').forEach(el => el.classList.add('animate'));
   });
+
+  // Render discriminability cohort content + wire tabs
+  if (window.__discCohorts) {
+    renderDiscCohort('all');
+    const tabs = document.getElementById('discTabs');
+    if (tabs) {
+      tabs.addEventListener('click', function(e) {
+        const btn = e.target.closest('.disc-tab');
+        if (!btn) return;
+        tabs.querySelectorAll('.disc-tab').forEach(b => b.classList.remove('active'));
+        btn.classList.add('active');
+        renderDiscCohort(btn.dataset.cohort);
+      });
+    }
+  }
 }
 
 function statCard(value, label, detail) {
@@ -488,6 +509,38 @@ function statCard(value, label, detail) {
 }
 
 function esc(s) { const d = document.createElement('div'); d.textContent = s; return d.innerHTML; }
+
+function renderDiscCohort(cohortKey) {
+  const cohorts = window.__discCohorts;
+  const threshold = window.__discThreshold || 0.6;
+  const cohort = cohorts[cohortKey];
+  const container = document.getElementById('discContent');
+  if (!cohort || !container) return;
+  const discDimNames = lang === 'zh' ? ['自主性', '精确度', '沟通风格', '适应性'] : ['Autonomy', 'Precision', 'Transparency', 'Adaptability'];
+  let h = '<div class="disc-grid">';
+  for (let d = 0; d < cohort.dimensions.length; d++) {
+    const dim = cohort.dimensions[d];
+    h += '<div class="disc-dim-group">';
+    h += '<div class="disc-dim-title">' + esc(discDimNames[d]) + ' <span class="disc-dim-avg">(avg ' + dim.averageDiscriminability.toFixed(2) + ')</span></div>';
+    h += '<div class="disc-questions">';
+    for (const q of dim.questions) {
+      const belowClass = q.discriminability < threshold ? ' below-threshold' : '';
+      const scoreClass = q.discriminability >= threshold ? 'good' : 'warn';
+      h += '<div class="disc-row' + belowClass + '">';
+      h += '<div class="disc-label">Q' + q.question + '</div>';
+      h += '<div class="disc-bar-wrap">';
+      h += '<div class="disc-bar-a" style="width:' + q.aPercent + '%"><span>' + q.aPercent + '%</span></div>';
+      h += '<div class="disc-bar-b"><span>' + q.bPercent + '%</span></div>';
+      h += '</div>';
+      h += '<div class="disc-score ' + scoreClass + '">' + q.discriminability.toFixed(2) + '</div>';
+      h += '</div>';
+    }
+    h += '</div></div>';
+  }
+  h += '</div>';
+  h += '<div class="disc-meta"><span>' + t('discBased') + ': ' + cohort.totalRuns + ' ' + t('discRuns') + '</span><span>' + t('discThreshold') + ': ' + threshold + '</span></div>';
+  container.innerHTML = h;
+}
 
 init();
 </script>


### PR DESCRIPTION
## Summary

Enhances the discriminability analysis to split data by question version (v4 vs v5-beta), revealing that the v5-beta question redesign made discriminability worse, not better.

## Changes

- **`scripts/generate-discriminability.js`**: Uses git commit dates to classify each reliability file into v4 (pre June 2) or v5-beta (post June 2) cohort. Computes discriminability separately per cohort.
- **`data/discriminability.json`**: New `cohorts` section with per-cohort data. Top-level fields preserved for backwards compatibility.
- **`stats.html`**: Adds cohort tabs (All / v4 / v5-beta) to the discriminability section for visual comparison.
- **`cli/bin/abti.js`**: Shows v5-beta cohort by default in CLI stats (since that's the current question set).

## Key Findings

| Cohort | Runs | Questions below 0.6 |
|--------|------|---------------------|
| All | 192 | 6/16 |
| v4 | 157 | 6/16 |
| v5-beta | 35 | **9/16** |

The v5-beta redesign of Q11, Q12, Q15 (#493) either had no effect or made things worse:
- Q11: 0.548 (v4) → 0.171 (v5-beta) 📉
- Q12: 0.420 (v4) → 0.286 (v5-beta) 📉
- Q15: 0.280 (v4) → 0.343 (v5-beta) ≈ same

New problems in v5-beta: Q3 (0.114), Q5 (0.571), Q7 (0.514)

## Testing

- `node scripts/generate-discriminability.js` ✅ generates correct output
- `npm test` ✅ all 291 tests pass
- Graceful fallback when git unavailable

Closes #574