### PR TITLE
data: v5.0 reliability results for all target models

### DIFF
--- a/data/reliability/claude-haiku-4-5-v5-run-1.json
+++ b/data/reliability/claude-haiku-4-5-v5-run-1.json
@@ -1,0 +1,25 @@
+{
+  "model": "claude-haiku-4-5",
+  "provider": "anthropic",
+  "run": 1,
+  "answers": [
+    "B",
+    "A",
+    "A",
+    "B",
+    "B",
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "B",
+    "A",
+    "A"
+  ],
+  "type": "PTCF",
+  "questionVersion": "5.0"
+}

--- a/data/reliability/claude-haiku-4-5-v5-run-2.json
+++ b/data/reliability/claude-haiku-4-5-v5-run-2.json
@@ -1,0 +1,25 @@
+{
+  "model": "claude-haiku-4-5",
+  "provider": "anthropic",
+  "run": 2,
+  "answers": [
+    "B",
+    "A",
+    "A",
+    "B",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "B"
+  ],
+  "type": "PTCF",
+  "questionVersion": "5.0"
+}

--- a/data/reliability/claude-haiku-4-5-v5-run-3.json
+++ b/data/reliability/claude-haiku-4-5-v5-run-3.json
@@ -1,0 +1,25 @@
+{
+  "model": "claude-haiku-4-5",
+  "provider": "anthropic",
+  "run": 3,
+  "answers": [
+    "B",
+    "B",
+    "A",
+    "B",
+    "B",
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "B",
+    "A",
+    "B"
+  ],
+  "type": "RTCN",
+  "questionVersion": "5.0"
+}

--- a/data/reliability/claude-opus-4-8-v5-run-1.json
+++ b/data/reliability/claude-opus-4-8-v5-run-1.json
@@ -1,0 +1,25 @@
+{
+  "model": "claude-opus-4-8",
+  "provider": "anthropic",
+  "run": 1,
+  "answers": [
+    "B",
+    "A",
+    "B",
+    "B",
+    "A",
+    "B",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "B",
+    "B",
+    "A",
+    "A"
+  ],
+  "type": "RTCF",
+  "questionVersion": "5.0"
+}

--- a/data/reliability/claude-opus-4-8-v5-run-2.json
+++ b/data/reliability/claude-opus-4-8-v5-run-2.json
@@ -1,0 +1,25 @@
+{
+  "model": "claude-opus-4-8",
+  "provider": "anthropic",
+  "run": 2,
+  "answers": [
+    "B",
+    "A",
+    "A",
+    "B",
+    "B",
+    "A",
+    "B",
+    "B",
+    "A",
+    "A",
+    "A",
+    "B",
+    "B",
+    "B",
+    "A",
+    "B"
+  ],
+  "type": "PECN",
+  "questionVersion": "5.0"
+}

--- a/data/reliability/claude-opus-4-8-v5-run-3.json
+++ b/data/reliability/claude-opus-4-8-v5-run-3.json
@@ -1,0 +1,25 @@
+{
+  "model": "claude-opus-4-8",
+  "provider": "anthropic",
+  "run": 3,
+  "answers": [
+    "B",
+    "B",
+    "A",
+    "B",
+    "B",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "B",
+    "A",
+    "A",
+    "B"
+  ],
+  "type": "RTCF",
+  "questionVersion": "5.0"
+}

--- a/data/reliability/claude-sonnet-4-5-v5-run-1.json
+++ b/data/reliability/claude-sonnet-4-5-v5-run-1.json
@@ -1,0 +1,25 @@
+{
+  "model": "claude-sonnet-4-5",
+  "provider": "anthropic",
+  "run": 1,
+  "answers": [
+    "A",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "A",
+    "B",
+    "A",
+    "A",
+    "B",
+    "B",
+    "B",
+    "A",
+    "B"
+  ],
+  "type": "RECN",
+  "questionVersion": "5.0"
+}

--- a/data/reliability/claude-sonnet-4-5-v5-run-2.json
+++ b/data/reliability/claude-sonnet-4-5-v5-run-2.json
@@ -1,0 +1,25 @@
+{
+  "model": "claude-sonnet-4-5",
+  "provider": "anthropic",
+  "run": 2,
+  "answers": [
+    "A",
+    "B",
+    "A",
+    "B",
+    "B",
+    "A",
+    "B",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "B"
+  ],
+  "type": "PECF",
+  "questionVersion": "5.0"
+}

--- a/data/reliability/claude-sonnet-4-5-v5-run-3.json
+++ b/data/reliability/claude-sonnet-4-5-v5-run-3.json
@@ -1,0 +1,25 @@
+{
+  "model": "claude-sonnet-4-5",
+  "provider": "anthropic",
+  "run": 3,
+  "answers": [
+    "B",
+    "A",
+    "A",
+    "B",
+    "B",
+    "A",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "A",
+    "B"
+  ],
+  "type": "PEDN",
+  "questionVersion": "5.0"
+}

--- a/data/reliability/claude-sonnet-4-6-v5-run-1.json
+++ b/data/reliability/claude-sonnet-4-6-v5-run-1.json
@@ -1,0 +1,25 @@
+{
+  "model": "claude-sonnet-4-6",
+  "provider": "anthropic",
+  "run": 1,
+  "answers": [
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "A",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "B"
+  ],
+  "type": "RECF",
+  "questionVersion": "5.0"
+}

--- a/data/reliability/claude-sonnet-4-6-v5-run-2.json
+++ b/data/reliability/claude-sonnet-4-6-v5-run-2.json
@@ -1,0 +1,25 @@
+{
+  "model": "claude-sonnet-4-6",
+  "provider": "anthropic",
+  "run": 2,
+  "answers": [
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "A",
+    "A",
+    "B",
+    "B",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "A"
+  ],
+  "type": "RTCF",
+  "questionVersion": "5.0"
+}

--- a/data/reliability/claude-sonnet-4-6-v5-run-3.json
+++ b/data/reliability/claude-sonnet-4-6-v5-run-3.json
@@ -1,0 +1,25 @@
+{
+  "model": "claude-sonnet-4-6",
+  "provider": "anthropic",
+  "run": 3,
+  "answers": [
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "A",
+    "B",
+    "B",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "A"
+  ],
+  "type": "RECF",
+  "questionVersion": "5.0"
+}

--- a/data/reliability/gemini-2-5-pro-v5-run-1.json
+++ b/data/reliability/gemini-2-5-pro-v5-run-1.json
@@ -1,0 +1,25 @@
+{
+  "model": "gemini-2.5-pro",
+  "provider": "anthropic",
+  "run": 1,
+  "answers": [
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "B",
+    "B",
+    "A",
+    "B"
+  ],
+  "type": "PTCN",
+  "questionVersion": "5.0"
+}

--- a/data/reliability/gemini-2-5-pro-v5-run-2.json
+++ b/data/reliability/gemini-2-5-pro-v5-run-2.json
@@ -1,0 +1,25 @@
+{
+  "model": "gemini-2.5-pro",
+  "provider": "anthropic",
+  "run": 2,
+  "answers": [
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "B",
+    "A",
+    "A",
+    "B",
+    "B",
+    "A",
+    "B"
+  ],
+  "type": "PTCN",
+  "questionVersion": "5.0"
+}

--- a/data/reliability/gemini-2-5-pro-v5-run-3.json
+++ b/data/reliability/gemini-2-5-pro-v5-run-3.json
@@ -1,0 +1,25 @@
+{
+  "model": "gemini-2.5-pro",
+  "provider": "anthropic",
+  "run": 3,
+  "answers": [
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "B",
+    "B",
+    "A",
+    "B"
+  ],
+  "type": "PTCN",
+  "questionVersion": "5.0"
+}

--- a/data/reliability/gpt-4-1-v5-run-1.json
+++ b/data/reliability/gpt-4-1-v5-run-1.json
@@ -1,0 +1,25 @@
+{
+  "model": "gpt-4.1",
+  "provider": "anthropic",
+  "run": 1,
+  "answers": [
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "B",
+    "B",
+    "A",
+    "A",
+    "B",
+    "B",
+    "A",
+    "B"
+  ],
+  "type": "PTCN",
+  "questionVersion": "5.0"
+}

--- a/data/reliability/gpt-4-1-v5-run-2.json
+++ b/data/reliability/gpt-4-1-v5-run-2.json
@@ -1,0 +1,25 @@
+{
+  "model": "gpt-4.1",
+  "provider": "anthropic",
+  "run": 2,
+  "answers": [
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "B",
+    "A",
+    "B",
+    "B",
+    "A",
+    "A",
+    "B",
+    "B",
+    "A",
+    "B"
+  ],
+  "type": "PTCN",
+  "questionVersion": "5.0"
+}

--- a/data/reliability/gpt-4-1-v5-run-3.json
+++ b/data/reliability/gpt-4-1-v5-run-3.json
@@ -1,0 +1,25 @@
+{
+  "model": "gpt-4.1",
+  "provider": "anthropic",
+  "run": 3,
+  "answers": [
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "B",
+    "A",
+    "B",
+    "B",
+    "A",
+    "A",
+    "B",
+    "B",
+    "A",
+    "B"
+  ],
+  "type": "PTCN",
+  "questionVersion": "5.0"
+}

--- a/data/reliability/gpt-5-4-v5-run-1.json
+++ b/data/reliability/gpt-5-4-v5-run-1.json
@@ -1,0 +1,25 @@
+{
+  "model": "gpt-5.4",
+  "provider": "anthropic",
+  "run": 1,
+  "answers": [
+    "B",
+    "A",
+    "A",
+    "B",
+    "B",
+    "B",
+    "A",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "B"
+  ],
+  "type": "PTCF",
+  "questionVersion": "5.0"
+}

--- a/data/reliability/gpt-5-4-v5-run-2.json
+++ b/data/reliability/gpt-5-4-v5-run-2.json
@@ -1,0 +1,25 @@
+{
+  "model": "gpt-5.4",
+  "provider": "anthropic",
+  "run": 2,
+  "answers": [
+    "B",
+    "A",
+    "A",
+    "B",
+    "B",
+    "B",
+    "A",
+    "A",
+    "B",
+    "B",
+    "A",
+    "A",
+    "B",
+    "B",
+    "A",
+    "B"
+  ],
+  "type": "PTCN",
+  "questionVersion": "5.0"
+}

--- a/data/reliability/gpt-5-4-v5-run-3.json
+++ b/data/reliability/gpt-5-4-v5-run-3.json
@@ -1,0 +1,25 @@
+{
+  "model": "gpt-5.4",
+  "provider": "anthropic",
+  "run": 3,
+  "answers": [
+    "B",
+    "A",
+    "A",
+    "B",
+    "A",
+    "B",
+    "A",
+    "A",
+    "B",
+    "B",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "B"
+  ],
+  "type": "PTCF",
+  "questionVersion": "5.0"
+}

--- a/data/reliability/gpt-5-5-v5-run-1.json
+++ b/data/reliability/gpt-5-5-v5-run-1.json
@@ -1,0 +1,25 @@
+{
+  "model": "gpt-5.5",
+  "provider": "anthropic",
+  "run": 1,
+  "answers": [
+    "B",
+    "A",
+    "A",
+    "B",
+    "B",
+    "B",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "B"
+  ],
+  "type": "PTCF",
+  "questionVersion": "5.0"
+}

--- a/data/reliability/gpt-5-5-v5-run-2.json
+++ b/data/reliability/gpt-5-5-v5-run-2.json
@@ -1,0 +1,25 @@
+{
+  "model": "gpt-5.5",
+  "provider": "anthropic",
+  "run": 2,
+  "answers": [
+    "B",
+    "A",
+    "A",
+    "B",
+    "B",
+    "B",
+    "B",
+    "A",
+    "B",
+    "B",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "B"
+  ],
+  "type": "PECF",
+  "questionVersion": "5.0"
+}

--- a/data/reliability/gpt-5-5-v5-run-3.json
+++ b/data/reliability/gpt-5-5-v5-run-3.json
@@ -1,0 +1,25 @@
+{
+  "model": "gpt-5.5",
+  "provider": "anthropic",
+  "run": 3,
+  "answers": [
+    "B",
+    "A",
+    "A",
+    "B",
+    "B",
+    "B",
+    "B",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "B"
+  ],
+  "type": "PECF",
+  "questionVersion": "5.0"
+}

--- a/data/reliability/v4/claude-haiku-4-5-run-1.json
+++ b/data/reliability/v4/claude-haiku-4-5-run-1.json
@@ -1,0 +1,30 @@
+{
+  "model": "claude-haiku-4.5",
+  "provider": "anthropic",
+  "run": 1,
+  "answers": [
+    "B",
+    "B",
+    "B",
+    "B",
+    "A",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "B"
+  ],
+  "type": "RTCF",
+  "dimensions": [
+    0,
+    3,
+    4,
+    2
+  ]
+}

--- a/data/reliability/v4/claude-haiku-4-5-run-2.json
+++ b/data/reliability/v4/claude-haiku-4-5-run-2.json
@@ -1,0 +1,30 @@
+{
+  "model": "claude-haiku-4.5",
+  "provider": "anthropic",
+  "run": 2,
+  "answers": [
+    "B",
+    "B",
+    "B",
+    "B",
+    "A",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "B",
+    "A",
+    "B"
+  ],
+  "type": "RTCN",
+  "dimensions": [
+    0,
+    3,
+    4,
+    1
+  ]
+}

--- a/data/reliability/v4/claude-haiku-4-5-run-3.json
+++ b/data/reliability/v4/claude-haiku-4-5-run-3.json
@@ -1,0 +1,30 @@
+{
+  "model": "claude-haiku-4.5",
+  "provider": "anthropic",
+  "run": 3,
+  "answers": [
+    "B",
+    "B",
+    "B",
+    "B",
+    "A",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "B"
+  ],
+  "type": "RTCF",
+  "dimensions": [
+    0,
+    3,
+    4,
+    2
+  ]
+}

--- a/data/reliability/v4/claude-opus-4-6-run-1.json
+++ b/data/reliability/v4/claude-opus-4-6-run-1.json
@@ -1,0 +1,8 @@
+{
+  "model": "claude-opus-4.6",
+  "provider": "anthropic",
+  "run": 1,
+  "answers": ["B","B","B","A","B","B","B","B","A","A","A","A","B","A","A","B"],
+  "type": "RECF",
+  "dimensions": [1, 0, 4, 2]
+}

--- a/data/reliability/v4/claude-opus-4-6-run-2.json
+++ b/data/reliability/v4/claude-opus-4-6-run-2.json
@@ -1,0 +1,8 @@
+{
+  "model": "claude-opus-4.6",
+  "provider": "anthropic",
+  "run": 2,
+  "answers": ["B","B","B","A","B","B","B","B","A","A","A","A","B","A","A","B"],
+  "type": "RECF",
+  "dimensions": [1, 0, 4, 2]
+}

--- a/data/reliability/v4/claude-opus-4-6-run-3.json
+++ b/data/reliability/v4/claude-opus-4-6-run-3.json
@@ -1,0 +1,8 @@
+{
+  "model": "claude-opus-4.6",
+  "provider": "anthropic",
+  "run": 3,
+  "answers": ["B","B","B","A","B","B","B","B","A","A","A","A","B","A","A","B"],
+  "type": "RECF",
+  "dimensions": [1, 0, 4, 2]
+}

--- a/data/reliability/v4/claude-opus-4-7-run-1.json
+++ b/data/reliability/v4/claude-opus-4-7-run-1.json
@@ -1,0 +1,30 @@
+{
+  "model": "claude-opus-4.7",
+  "provider": "anthropic",
+  "run": 1,
+  "answers": [
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "B"
+  ],
+  "type": "RECF",
+  "dimensions": [
+    0,
+    0,
+    4,
+    2
+  ]
+}

--- a/data/reliability/v4/claude-opus-4-7-run-2.json
+++ b/data/reliability/v4/claude-opus-4-7-run-2.json
@@ -1,0 +1,30 @@
+{
+  "model": "claude-opus-4.7",
+  "provider": "anthropic",
+  "run": 2,
+  "answers": [
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "B"
+  ],
+  "type": "RECF",
+  "dimensions": [
+    0,
+    0,
+    4,
+    2
+  ]
+}

--- a/data/reliability/v4/claude-opus-4-7-run-3.json
+++ b/data/reliability/v4/claude-opus-4-7-run-3.json
@@ -1,0 +1,30 @@
+{
+  "model": "claude-opus-4.7",
+  "provider": "anthropic",
+  "run": 3,
+  "answers": [
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "A",
+    "B",
+    "B"
+  ],
+  "type": "RECN",
+  "dimensions": [
+    0,
+    0,
+    4,
+    1
+  ]
+}

--- a/data/reliability/v4/claude-opus-4-8-run-1.json
+++ b/data/reliability/v4/claude-opus-4-8-run-1.json
@@ -1,0 +1,30 @@
+{
+  "model": "claude-opus-4-8",
+  "provider": "anthropic",
+  "run": 1,
+  "answers": [
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "A",
+    "B",
+    "B",
+    "A",
+    "B",
+    "B",
+    "A",
+    "B"
+  ],
+  "type": "RECN",
+  "dimensions": [
+    0,
+    0,
+    2,
+    1
+  ]
+}

--- a/data/reliability/v4/claude-opus-4-8-run-2.json
+++ b/data/reliability/v4/claude-opus-4-8-run-2.json
@@ -1,0 +1,30 @@
+{
+  "model": "claude-opus-4-8",
+  "provider": "anthropic",
+  "run": 2,
+  "answers": [
+    "B",
+    "A",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "A",
+    "A",
+    "B",
+    "A",
+    "B",
+    "B",
+    "A",
+    "B"
+  ],
+  "type": "RECN",
+  "dimensions": [
+    1,
+    0,
+    3,
+    1
+  ]
+}

--- a/data/reliability/v4/claude-opus-4-8-run-3.json
+++ b/data/reliability/v4/claude-opus-4-8-run-3.json
@@ -1,0 +1,30 @@
+{
+  "model": "claude-opus-4-8",
+  "provider": "anthropic",
+  "run": 3,
+  "answers": [
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "A",
+    "A",
+    "A",
+    "B",
+    "B",
+    "A",
+    "B"
+  ],
+  "type": "RECN",
+  "dimensions": [
+    0,
+    0,
+    3,
+    1
+  ]
+}

--- a/data/reliability/v4/claude-sonnet-4-5-run-1.json
+++ b/data/reliability/v4/claude-sonnet-4-5-run-1.json
@@ -1,0 +1,30 @@
+{
+  "model": "claude-sonnet-4.5",
+  "provider": "anthropic",
+  "run": 1,
+  "answers": [
+    "A",
+    "A",
+    "B",
+    "B",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "B",
+    "A",
+    "B",
+    "B"
+  ],
+  "type": "PTCN",
+  "dimensions": [
+    2,
+    3,
+    3,
+    1
+  ]
+}

--- a/data/reliability/v4/claude-sonnet-4-5-run-2.json
+++ b/data/reliability/v4/claude-sonnet-4-5-run-2.json
@@ -1,0 +1,30 @@
+{
+  "model": "claude-sonnet-4.5",
+  "provider": "anthropic",
+  "run": 2,
+  "answers": [
+    "B",
+    "B",
+    "A",
+    "B",
+    "B",
+    "A",
+    "B",
+    "B",
+    "A",
+    "B",
+    "B",
+    "A",
+    "B",
+    "B",
+    "A",
+    "B"
+  ],
+  "type": "RECN",
+  "dimensions": [
+    1,
+    1,
+    2,
+    1
+  ]
+}

--- a/data/reliability/v4/claude-sonnet-4-5-run-3.json
+++ b/data/reliability/v4/claude-sonnet-4-5-run-3.json
@@ -1,0 +1,30 @@
+{
+  "model": "claude-sonnet-4.5",
+  "provider": "anthropic",
+  "run": 3,
+  "answers": [
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "B",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "A",
+    "B",
+    "A"
+  ],
+  "type": "PTCF",
+  "dimensions": [
+    3,
+    2,
+    4,
+    2
+  ]
+}

--- a/data/reliability/v4/claude-sonnet-4-6-run-1.json
+++ b/data/reliability/v4/claude-sonnet-4-6-run-1.json
@@ -1,0 +1,30 @@
+{
+  "model": "claude-sonnet-4.6",
+  "provider": "anthropic",
+  "run": 1,
+  "answers": [
+    "B",
+    "B",
+    "B",
+    "B",
+    "A",
+    "B",
+    "B",
+    "B",
+    "A",
+    "B",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "B"
+  ],
+  "type": "RECF",
+  "dimensions": [
+    0,
+    1,
+    3,
+    2
+  ]
+}

--- a/data/reliability/v4/claude-sonnet-4-6-run-2.json
+++ b/data/reliability/v4/claude-sonnet-4-6-run-2.json
@@ -1,0 +1,30 @@
+{
+  "model": "claude-sonnet-4.6",
+  "provider": "anthropic",
+  "run": 2,
+  "answers": [
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "A",
+    "B",
+    "A",
+    "A",
+    "B",
+    "A",
+    "B",
+    "A",
+    "A",
+    "B"
+  ],
+  "type": "RECF",
+  "dimensions": [
+    0,
+    1,
+    3,
+    2
+  ]
+}

--- a/data/reliability/v4/claude-sonnet-4-6-run-3.json
+++ b/data/reliability/v4/claude-sonnet-4-6-run-3.json
@@ -1,0 +1,30 @@
+{
+  "model": "claude-sonnet-4.6",
+  "provider": "anthropic",
+  "run": 3,
+  "answers": [
+    "B",
+    "B",
+    "B",
+    "B",
+    "A",
+    "B",
+    "A",
+    "B",
+    "A",
+    "A",
+    "B",
+    "A",
+    "B",
+    "A",
+    "A",
+    "B"
+  ],
+  "type": "RTCF",
+  "dimensions": [
+    0,
+    2,
+    3,
+    2
+  ]
+}

--- a/data/reliability/v4/gemini-2-5-pro-run-1.json
+++ b/data/reliability/v4/gemini-2-5-pro-run-1.json
@@ -1,0 +1,30 @@
+{
+  "model": "gemini-2.5-pro",
+  "provider": "anthropic",
+  "run": 1,
+  "answers": [
+    "B",
+    "A",
+    "B",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "B",
+    "B",
+    "B",
+    "B"
+  ],
+  "type": "PTCN",
+  "dimensions": [
+    2,
+    3,
+    3,
+    0
+  ]
+}

--- a/data/reliability/v4/gemini-2-5-pro-run-2.json
+++ b/data/reliability/v4/gemini-2-5-pro-run-2.json
@@ -1,0 +1,30 @@
+{
+  "model": "gemini-2.5-pro",
+  "provider": "anthropic",
+  "run": 2,
+  "answers": [
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B"
+  ],
+  "type": "PTCN",
+  "dimensions": [
+    3,
+    3,
+    2,
+    0
+  ]
+}

--- a/data/reliability/v4/gemini-2-5-pro-run-3.json
+++ b/data/reliability/v4/gemini-2-5-pro-run-3.json
@@ -1,0 +1,30 @@
+{
+  "model": "gemini-2.5-pro",
+  "provider": "anthropic",
+  "run": 3,
+  "answers": [
+    "B",
+    "A",
+    "B",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B"
+  ],
+  "type": "PTCN",
+  "dimensions": [
+    2,
+    3,
+    2,
+    0
+  ]
+}

--- a/data/reliability/v4/gpt-4-1-run-1.json
+++ b/data/reliability/v4/gpt-4-1-run-1.json
@@ -1,0 +1,30 @@
+{
+  "model": "gpt-4.1",
+  "provider": "github",
+  "run": 1,
+  "answers": [
+    "B",
+    "A",
+    "B",
+    "A",
+    "A",
+    "B",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "B"
+  ],
+  "type": "PTCF",
+  "dimensions": [
+    2,
+    2,
+    4,
+    2
+  ]
+}

--- a/data/reliability/v4/gpt-4-1-run-2.json
+++ b/data/reliability/v4/gpt-4-1-run-2.json
@@ -1,0 +1,30 @@
+{
+  "model": "gpt-4.1",
+  "provider": "github",
+  "run": 2,
+  "answers": [
+    "B",
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "B"
+  ],
+  "type": "PTCF",
+  "dimensions": [
+    2,
+    3,
+    4,
+    2
+  ]
+}

--- a/data/reliability/v4/gpt-4-1-run-3.json
+++ b/data/reliability/v4/gpt-4-1-run-3.json
@@ -1,0 +1,30 @@
+{
+  "model": "gpt-4.1",
+  "provider": "github",
+  "run": 3,
+  "answers": [
+    "B",
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "B"
+  ],
+  "type": "PTCF",
+  "dimensions": [
+    2,
+    3,
+    4,
+    2
+  ]
+}

--- a/data/reliability/v4/gpt-5-4-run-1.json
+++ b/data/reliability/v4/gpt-5-4-run-1.json
@@ -1,0 +1,30 @@
+{
+    "model": "gpt-5.4",
+    "provider": "floway",
+    "run": 1,
+    "answers": [
+        "B",
+        "B",
+        "B",
+        "B",
+        "A",
+        "A",
+        "A",
+        "B",
+        "B",
+        "A",
+        "A",
+        "A",
+        "B",
+        "A",
+        "A",
+        "B"
+    ],
+    "type": "RTCF",
+    "dimensions": [
+        0,
+        3,
+        3,
+        2
+    ]
+}

--- a/data/reliability/v4/gpt-5-4-run-2.json
+++ b/data/reliability/v4/gpt-5-4-run-2.json
@@ -1,0 +1,30 @@
+{
+    "model": "gpt-5.4",
+    "provider": "floway",
+    "run": 2,
+    "answers": [
+        "B",
+        "B",
+        "B",
+        "B",
+        "A",
+        "A",
+        "A",
+        "A",
+        "A",
+        "A",
+        "A",
+        "A",
+        "B",
+        "B",
+        "A",
+        "A"
+    ],
+    "type": "RTCF",
+    "dimensions": [
+        0,
+        4,
+        4,
+        2
+    ]
+}

--- a/data/reliability/v4/gpt-5-4-run-3.json
+++ b/data/reliability/v4/gpt-5-4-run-3.json
@@ -1,0 +1,30 @@
+{
+    "model": "gpt-5.4",
+    "provider": "floway",
+    "run": 3,
+    "answers": [
+        "B",
+        "B",
+        "B",
+        "B",
+        "A",
+        "A",
+        "B",
+        "A",
+        "A",
+        "B",
+        "A",
+        "A",
+        "B",
+        "A",
+        "A",
+        "B"
+    ],
+    "type": "RTCF",
+    "dimensions": [
+        0,
+        3,
+        3,
+        2
+    ]
+}

--- a/data/reliability/v4/gpt-5-5-run-1.json
+++ b/data/reliability/v4/gpt-5-5-run-1.json
@@ -1,0 +1,30 @@
+{
+  "model": "gpt-5.5",
+  "provider": "anthropic",
+  "run": 1,
+  "answers": [
+    "B",
+    "A",
+    "B",
+    "A",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "A"
+  ],
+  "type": "PECF",
+  "dimensions": [
+    2,
+    0,
+    2,
+    3
+  ]
+}

--- a/data/reliability/v4/gpt-5-5-run-2.json
+++ b/data/reliability/v4/gpt-5-5-run-2.json
@@ -1,0 +1,30 @@
+{
+  "model": "gpt-5.5",
+  "provider": "anthropic",
+  "run": 2,
+  "answers": [
+    "B",
+    "B",
+    "B",
+    "A",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "B"
+  ],
+  "type": "RECF",
+  "dimensions": [
+    1,
+    0,
+    2,
+    2
+  ]
+}

--- a/data/reliability/v4/gpt-5-5-run-3.json
+++ b/data/reliability/v4/gpt-5-5-run-3.json
@@ -1,0 +1,30 @@
+{
+  "model": "gpt-5.5",
+  "provider": "anthropic",
+  "run": 3,
+  "answers": [
+    "B",
+    "A",
+    "B",
+    "A",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "B"
+  ],
+  "type": "PECF",
+  "dimensions": [
+    2,
+    0,
+    2,
+    2
+  ]
+}


### PR DESCRIPTION
## Summary

Re-run reliability tests using redesigned v5.0 questions (#577, #579, #580, #582) for all models listed in #583.

## Results — Claude models (via floway)

| Model | Run 1 | Run 2 | Run 3 |
|-------|-------|-------|-------|
| Opus 4.8 | RTCF | PECN | RTCF |
| Sonnet 4.6 | RECF | RTCF | RECF |
| Sonnet 4.5 | RECN | PECF | PEDN |
| Haiku 4.5 | PTCF | PTCF | RTCN |

## Results — GPT & Gemini (via floway)

| Model | Run 1 | Run 2 | Run 3 |
|-------|-------|-------|-------|
| GPT-5.5 | PTCF | PECF | PECF |
| GPT-5.4 | PTCF | PTCN | PTCF |
| GPT-4.1 | PTCN | PTCN | PTCN |
| Gemini 2.5 Pro | PTCN | PTCN | PTCN |

## Already on master (from earlier PRs)

| Model | Run 1 | Run 2 | Run 3 |
|-------|-------|-------|-------|
| Opus 4.6 | PEDF | PECF | PEDF |
| Opus 4.7 | RTCF | RECF | RTCF |

All data tagged with `questionVersion: '5.0'`.

## Observations
- **GPT-4.1 and Gemini 2.5 Pro** show perfect consistency across 3 runs (PTCN)
- **Claude models** show more variation — Opus 4.8 oscillates between RTCF/PECN, Sonnet 4.5 between RECN/PECF/PEDN
- The v5.0 questions appear to produce more differentiated results across model families

## Remaining for #583
- [ ] Archive old v4 data to `data/reliability/v4/`

Closes #583