### PR TITLE
data: refresh Claude reliability data after Q15 redesign

### DIFF
--- a/data/discriminability.json
+++ b/data/discriminability.json
@@ -1,15 +1,15 @@
 {
-  "generatedAt": "2026-06-26T08:50:28.599Z",
+  "generatedAt": "2026-06-26T12:10:29.923Z",
   "threshold": 0.6,
   "totalRuns": 192,
   "questions": [
     {
       "question": 1,
-      "aCount": 112,
-      "bCount": 80,
-      "aPercent": 58.3,
-      "bPercent": 41.7,
-      "discriminability": 0.833
+      "aCount": 114,
+      "bCount": 78,
+      "aPercent": 59.4,
+      "bPercent": 40.6,
+      "discriminability": 0.813
     },
     {
       "question": 2,
@@ -21,43 +21,43 @@
     },
     {
       "question": 3,
-      "aCount": 99,
-      "bCount": 93,
-      "aPercent": 51.6,
-      "bPercent": 48.4,
-      "discriminability": 0.969
+      "aCount": 100,
+      "bCount": 92,
+      "aPercent": 52.1,
+      "bPercent": 47.9,
+      "discriminability": 0.958
     },
     {
       "question": 4,
-      "aCount": 141,
-      "bCount": 51,
-      "aPercent": 73.4,
-      "bPercent": 26.6,
-      "discriminability": 0.531
+      "aCount": 140,
+      "bCount": 52,
+      "aPercent": 72.9,
+      "bPercent": 27.1,
+      "discriminability": 0.542
     },
     {
       "question": 5,
-      "aCount": 127,
-      "bCount": 65,
-      "aPercent": 66.1,
-      "bPercent": 33.9,
-      "discriminability": 0.677
+      "aCount": 126,
+      "bCount": 66,
+      "aPercent": 65.6,
+      "bPercent": 34.4,
+      "discriminability": 0.688
     },
     {
       "question": 6,
-      "aCount": 67,
-      "bCount": 125,
-      "aPercent": 34.9,
-      "bPercent": 65.1,
-      "discriminability": 0.698
+      "aCount": 71,
+      "bCount": 121,
+      "aPercent": 37,
+      "bPercent": 63,
+      "discriminability": 0.74
     },
     {
       "question": 7,
-      "aCount": 131,
-      "bCount": 61,
-      "aPercent": 68.2,
-      "bPercent": 31.8,
-      "discriminability": 0.635
+      "aCount": 128,
+      "bCount": 64,
+      "aPercent": 66.7,
+      "bPercent": 33.3,
+      "discriminability": 0.667
     },
     {
       "question": 8,
@@ -69,67 +69,67 @@
     },
     {
       "question": 9,
-      "aCount": 98,
-      "bCount": 94,
-      "aPercent": 51,
-      "bPercent": 49,
-      "discriminability": 0.979
+      "aCount": 95,
+      "bCount": 97,
+      "aPercent": 49.5,
+      "bPercent": 50.5,
+      "discriminability": 0.99
     },
     {
       "question": 10,
-      "aCount": 116,
-      "bCount": 76,
-      "aPercent": 60.4,
-      "bPercent": 39.6,
-      "discriminability": 0.792
+      "aCount": 117,
+      "bCount": 75,
+      "aPercent": 60.9,
+      "bPercent": 39.1,
+      "discriminability": 0.781
     },
     {
       "question": 11,
-      "aCount": 129,
-      "bCount": 63,
-      "aPercent": 67.2,
-      "bPercent": 32.8,
-      "discriminability": 0.656
+      "aCount": 130,
+      "bCount": 62,
+      "aPercent": 67.7,
+      "bPercent": 32.3,
+      "discriminability": 0.646
     },
     {
       "question": 12,
-      "aCount": 151,
-      "bCount": 41,
-      "aPercent": 78.6,
-      "bPercent": 21.4,
-      "discriminability": 0.427
+      "aCount": 150,
+      "bCount": 42,
+      "aPercent": 78.1,
+      "bPercent": 21.9,
+      "discriminability": 0.438
     },
     {
       "question": 13,
-      "aCount": 96,
-      "bCount": 96,
-      "aPercent": 50,
-      "bPercent": 50,
-      "discriminability": 1
+      "aCount": 93,
+      "bCount": 99,
+      "aPercent": 48.4,
+      "bPercent": 51.6,
+      "discriminability": 0.969
     },
     {
       "question": 14,
+      "aCount": 78,
+      "bCount": 114,
+      "aPercent": 40.6,
+      "bPercent": 59.4,
+      "discriminability": 0.813
+    },
+    {
+      "question": 15,
+      "aCount": 161,
+      "bCount": 31,
+      "aPercent": 83.9,
+      "bPercent": 16.1,
+      "discriminability": 0.323
+    },
+    {
+      "question": 16,
       "aCount": 76,
       "bCount": 116,
       "aPercent": 39.6,
       "bPercent": 60.4,
       "discriminability": 0.792
-    },
-    {
-      "question": 15,
-      "aCount": 167,
-      "bCount": 25,
-      "aPercent": 87,
-      "bPercent": 13,
-      "discriminability": 0.26
-    },
-    {
-      "question": 16,
-      "aCount": 74,
-      "bCount": 118,
-      "aPercent": 38.5,
-      "bPercent": 61.5,
-      "discriminability": 0.771
     }
   ],
   "dimensions": [
@@ -142,11 +142,11 @@
       "questions": [
         {
           "question": 1,
-          "aCount": 112,
-          "bCount": 80,
-          "aPercent": 58.3,
-          "bPercent": 41.7,
-          "discriminability": 0.833
+          "aCount": 114,
+          "bCount": 78,
+          "aPercent": 59.4,
+          "bPercent": 40.6,
+          "discriminability": 0.813
         },
         {
           "question": 2,
@@ -158,22 +158,22 @@
         },
         {
           "question": 3,
-          "aCount": 99,
-          "bCount": 93,
-          "aPercent": 51.6,
-          "bPercent": 48.4,
-          "discriminability": 0.969
+          "aCount": 100,
+          "bCount": 92,
+          "aPercent": 52.1,
+          "bPercent": 47.9,
+          "discriminability": 0.958
         },
         {
           "question": 4,
-          "aCount": 141,
-          "bCount": 51,
-          "aPercent": 73.4,
-          "bPercent": 26.6,
-          "discriminability": 0.531
+          "aCount": 140,
+          "bCount": 52,
+          "aPercent": 72.9,
+          "bPercent": 27.1,
+          "discriminability": 0.542
         }
       ],
-      "averageDiscriminability": 0.784
+      "averageDiscriminability": 0.779
     },
     {
       "name": "Precision",
@@ -184,27 +184,27 @@
       "questions": [
         {
           "question": 5,
-          "aCount": 127,
-          "bCount": 65,
-          "aPercent": 66.1,
-          "bPercent": 33.9,
-          "discriminability": 0.677
+          "aCount": 126,
+          "bCount": 66,
+          "aPercent": 65.6,
+          "bPercent": 34.4,
+          "discriminability": 0.688
         },
         {
           "question": 6,
-          "aCount": 67,
-          "bCount": 125,
-          "aPercent": 34.9,
-          "bPercent": 65.1,
-          "discriminability": 0.698
+          "aCount": 71,
+          "bCount": 121,
+          "aPercent": 37,
+          "bPercent": 63,
+          "discriminability": 0.74
         },
         {
           "question": 7,
-          "aCount": 131,
-          "bCount": 61,
-          "aPercent": 68.2,
-          "bPercent": 31.8,
-          "discriminability": 0.635
+          "aCount": 128,
+          "bCount": 64,
+          "aPercent": 66.7,
+          "bPercent": 33.3,
+          "discriminability": 0.667
         },
         {
           "question": 8,
@@ -215,7 +215,7 @@
           "discriminability": 0.615
         }
       ],
-      "averageDiscriminability": 0.656
+      "averageDiscriminability": 0.677
     },
     {
       "name": "Transparency",
@@ -226,35 +226,35 @@
       "questions": [
         {
           "question": 9,
-          "aCount": 98,
-          "bCount": 94,
-          "aPercent": 51,
-          "bPercent": 49,
-          "discriminability": 0.979
+          "aCount": 95,
+          "bCount": 97,
+          "aPercent": 49.5,
+          "bPercent": 50.5,
+          "discriminability": 0.99
         },
         {
           "question": 10,
-          "aCount": 116,
-          "bCount": 76,
-          "aPercent": 60.4,
-          "bPercent": 39.6,
-          "discriminability": 0.792
+          "aCount": 117,
+          "bCount": 75,
+          "aPercent": 60.9,
+          "bPercent": 39.1,
+          "discriminability": 0.781
         },
         {
           "question": 11,
-          "aCount": 129,
-          "bCount": 63,
-          "aPercent": 67.2,
-          "bPercent": 32.8,
-          "discriminability": 0.656
+          "aCount": 130,
+          "bCount": 62,
+          "aPercent": 67.7,
+          "bPercent": 32.3,
+          "discriminability": 0.646
         },
         {
           "question": 12,
-          "aCount": 151,
-          "bCount": 41,
-          "aPercent": 78.6,
-          "bPercent": 21.4,
-          "discriminability": 0.427
+          "aCount": 150,
+          "bCount": 42,
+          "aPercent": 78.1,
+          "bPercent": 21.9,
+          "discriminability": 0.438
         }
       ],
       "averageDiscriminability": 0.714
@@ -268,38 +268,38 @@
       "questions": [
         {
           "question": 13,
-          "aCount": 96,
-          "bCount": 96,
-          "aPercent": 50,
-          "bPercent": 50,
-          "discriminability": 1
+          "aCount": 93,
+          "bCount": 99,
+          "aPercent": 48.4,
+          "bPercent": 51.6,
+          "discriminability": 0.969
         },
         {
           "question": 14,
+          "aCount": 78,
+          "bCount": 114,
+          "aPercent": 40.6,
+          "bPercent": 59.4,
+          "discriminability": 0.813
+        },
+        {
+          "question": 15,
+          "aCount": 161,
+          "bCount": 31,
+          "aPercent": 83.9,
+          "bPercent": 16.1,
+          "discriminability": 0.323
+        },
+        {
+          "question": 16,
           "aCount": 76,
           "bCount": 116,
           "aPercent": 39.6,
           "bPercent": 60.4,
           "discriminability": 0.792
-        },
-        {
-          "question": 15,
-          "aCount": 167,
-          "bCount": 25,
-          "aPercent": 87,
-          "bPercent": 13,
-          "discriminability": 0.26
-        },
-        {
-          "question": 16,
-          "aCount": 74,
-          "bCount": 118,
-          "aPercent": 38.5,
-          "bPercent": 61.5,
-          "discriminability": 0.771
         }
       ],
-      "averageDiscriminability": 0.706
+      "averageDiscriminability": 0.724
     }
   ],
   "cohorts": {
@@ -308,11 +308,11 @@
       "questions": [
         {
           "question": 1,
-          "aCount": 112,
-          "bCount": 80,
-          "aPercent": 58.3,
-          "bPercent": 41.7,
-          "discriminability": 0.833
+          "aCount": 114,
+          "bCount": 78,
+          "aPercent": 59.4,
+          "bPercent": 40.6,
+          "discriminability": 0.813
         },
         {
           "question": 2,
@@ -324,43 +324,43 @@
         },
         {
           "question": 3,
-          "aCount": 99,
-          "bCount": 93,
-          "aPercent": 51.6,
-          "bPercent": 48.4,
-          "discriminability": 0.969
+          "aCount": 100,
+          "bCount": 92,
+          "aPercent": 52.1,
+          "bPercent": 47.9,
+          "discriminability": 0.958
         },
         {
           "question": 4,
-          "aCount": 141,
-          "bCount": 51,
-          "aPercent": 73.4,
-          "bPercent": 26.6,
-          "discriminability": 0.531
+          "aCount": 140,
+          "bCount": 52,
+          "aPercent": 72.9,
+          "bPercent": 27.1,
+          "discriminability": 0.542
         },
         {
           "question": 5,
-          "aCount": 127,
-          "bCount": 65,
-          "aPercent": 66.1,
-          "bPercent": 33.9,
-          "discriminability": 0.677
+          "aCount": 126,
+          "bCount": 66,
+          "aPercent": 65.6,
+          "bPercent": 34.4,
+          "discriminability": 0.688
         },
         {
           "question": 6,
-          "aCount": 67,
-          "bCount": 125,
-          "aPercent": 34.9,
-          "bPercent": 65.1,
-          "discriminability": 0.698
+          "aCount": 71,
+          "bCount": 121,
+          "aPercent": 37,
+          "bPercent": 63,
+          "discriminability": 0.74
         },
         {
           "question": 7,
-          "aCount": 131,
-          "bCount": 61,
-          "aPercent": 68.2,
-          "bPercent": 31.8,
-          "discriminability": 0.635
+          "aCount": 128,
+          "bCount": 64,
+          "aPercent": 66.7,
+          "bPercent": 33.3,
+          "discriminability": 0.667
         },
         {
           "question": 8,
@@ -372,67 +372,67 @@
         },
         {
           "question": 9,
-          "aCount": 98,
-          "bCount": 94,
-          "aPercent": 51,
-          "bPercent": 49,
-          "discriminability": 0.979
+          "aCount": 95,
+          "bCount": 97,
+          "aPercent": 49.5,
+          "bPercent": 50.5,
+          "discriminability": 0.99
         },
         {
           "question": 10,
-          "aCount": 116,
-          "bCount": 76,
-          "aPercent": 60.4,
-          "bPercent": 39.6,
-          "discriminability": 0.792
+          "aCount": 117,
+          "bCount": 75,
+          "aPercent": 60.9,
+          "bPercent": 39.1,
+          "discriminability": 0.781
         },
         {
           "question": 11,
-          "aCount": 129,
-          "bCount": 63,
-          "aPercent": 67.2,
-          "bPercent": 32.8,
-          "discriminability": 0.656
+          "aCount": 130,
+          "bCount": 62,
+          "aPercent": 67.7,
+          "bPercent": 32.3,
+          "discriminability": 0.646
         },
         {
           "question": 12,
-          "aCount": 151,
-          "bCount": 41,
-          "aPercent": 78.6,
-          "bPercent": 21.4,
-          "discriminability": 0.427
+          "aCount": 150,
+          "bCount": 42,
+          "aPercent": 78.1,
+          "bPercent": 21.9,
+          "discriminability": 0.438
         },
         {
           "question": 13,
-          "aCount": 96,
-          "bCount": 96,
-          "aPercent": 50,
-          "bPercent": 50,
-          "discriminability": 1
+          "aCount": 93,
+          "bCount": 99,
+          "aPercent": 48.4,
+          "bPercent": 51.6,
+          "discriminability": 0.969
         },
         {
           "question": 14,
+          "aCount": 78,
+          "bCount": 114,
+          "aPercent": 40.6,
+          "bPercent": 59.4,
+          "discriminability": 0.813
+        },
+        {
+          "question": 15,
+          "aCount": 161,
+          "bCount": 31,
+          "aPercent": 83.9,
+          "bPercent": 16.1,
+          "discriminability": 0.323
+        },
+        {
+          "question": 16,
           "aCount": 76,
           "bCount": 116,
           "aPercent": 39.6,
           "bPercent": 60.4,
           "discriminability": 0.792
-        },
-        {
-          "question": 15,
-          "aCount": 167,
-          "bCount": 25,
-          "aPercent": 87,
-          "bPercent": 13,
-          "discriminability": 0.26
-        },
-        {
-          "question": 16,
-          "aCount": 74,
-          "bCount": 118,
-          "aPercent": 38.5,
-          "bPercent": 61.5,
-          "discriminability": 0.771
         }
       ],
       "dimensions": [
@@ -445,11 +445,11 @@
           "questions": [
             {
               "question": 1,
-              "aCount": 112,
-              "bCount": 80,
-              "aPercent": 58.3,
-              "bPercent": 41.7,
-              "discriminability": 0.833
+              "aCount": 114,
+              "bCount": 78,
+              "aPercent": 59.4,
+              "bPercent": 40.6,
+              "discriminability": 0.813
             },
             {
               "question": 2,
@@ -461,22 +461,22 @@
             },
             {
               "question": 3,
-              "aCount": 99,
-              "bCount": 93,
-              "aPercent": 51.6,
-              "bPercent": 48.4,
-              "discriminability": 0.969
+              "aCount": 100,
+              "bCount": 92,
+              "aPercent": 52.1,
+              "bPercent": 47.9,
+              "discriminability": 0.958
             },
             {
               "question": 4,
-              "aCount": 141,
-              "bCount": 51,
-              "aPercent": 73.4,
-              "bPercent": 26.6,
-              "discriminability": 0.531
+              "aCount": 140,
+              "bCount": 52,
+              "aPercent": 72.9,
+              "bPercent": 27.1,
+              "discriminability": 0.542
             }
           ],
-          "averageDiscriminability": 0.784
+          "averageDiscriminability": 0.779
         },
         {
           "name": "Precision",
@@ -487,27 +487,27 @@
           "questions": [
             {
               "question": 5,
-              "aCount": 127,
-              "bCount": 65,
-              "aPercent": 66.1,
-              "bPercent": 33.9,
-              "discriminability": 0.677
+              "aCount": 126,
+              "bCount": 66,
+              "aPercent": 65.6,
+              "bPercent": 34.4,
+              "discriminability": 0.688
             },
             {
               "question": 6,
-              "aCount": 67,
-              "bCount": 125,
-              "aPercent": 34.9,
-              "bPercent": 65.1,
-              "discriminability": 0.698
+              "aCount": 71,
+              "bCount": 121,
+              "aPercent": 37,
+              "bPercent": 63,
+              "discriminability": 0.74
             },
             {
               "question": 7,
-              "aCount": 131,
-              "bCount": 61,
-              "aPercent": 68.2,
-              "bPercent": 31.8,
-              "discriminability": 0.635
+              "aCount": 128,
+              "bCount": 64,
+              "aPercent": 66.7,
+              "bPercent": 33.3,
+              "discriminability": 0.667
             },
             {
               "question": 8,
@@ -518,7 +518,7 @@
               "discriminability": 0.615
             }
           ],
-          "averageDiscriminability": 0.656
+          "averageDiscriminability": 0.677
         },
         {
           "name": "Transparency",
@@ -529,35 +529,35 @@
           "questions": [
             {
               "question": 9,
-              "aCount": 98,
-              "bCount": 94,
-              "aPercent": 51,
-              "bPercent": 49,
-              "discriminability": 0.979
+              "aCount": 95,
+              "bCount": 97,
+              "aPercent": 49.5,
+              "bPercent": 50.5,
+              "discriminability": 0.99
             },
             {
               "question": 10,
-              "aCount": 116,
-              "bCount": 76,
-              "aPercent": 60.4,
-              "bPercent": 39.6,
-              "discriminability": 0.792
+              "aCount": 117,
+              "bCount": 75,
+              "aPercent": 60.9,
+              "bPercent": 39.1,
+              "discriminability": 0.781
             },
             {
               "question": 11,
-              "aCount": 129,
-              "bCount": 63,
-              "aPercent": 67.2,
-              "bPercent": 32.8,
-              "discriminability": 0.656
+              "aCount": 130,
+              "bCount": 62,
+              "aPercent": 67.7,
+              "bPercent": 32.3,
+              "discriminability": 0.646
             },
             {
               "question": 12,
-              "aCount": 151,
-              "bCount": 41,
-              "aPercent": 78.6,
-              "bPercent": 21.4,
-              "discriminability": 0.427
+              "aCount": 150,
+              "bCount": 42,
+              "aPercent": 78.1,
+              "bPercent": 21.9,
+              "discriminability": 0.438
             }
           ],
           "averageDiscriminability": 0.714
@@ -571,38 +571,38 @@
           "questions": [
             {
               "question": 13,
-              "aCount": 96,
-              "bCount": 96,
-              "aPercent": 50,
-              "bPercent": 50,
-              "discriminability": 1
+              "aCount": 93,
+              "bCount": 99,
+              "aPercent": 48.4,
+              "bPercent": 51.6,
+              "discriminability": 0.969
             },
             {
               "question": 14,
+              "aCount": 78,
+              "bCount": 114,
+              "aPercent": 40.6,
+              "bPercent": 59.4,
+              "discriminability": 0.813
+            },
+            {
+              "question": 15,
+              "aCount": 161,
+              "bCount": 31,
+              "aPercent": 83.9,
+              "bPercent": 16.1,
+              "discriminability": 0.323
+            },
+            {
+              "question": 16,
               "aCount": 76,
               "bCount": 116,
               "aPercent": 39.6,
               "bPercent": 60.4,
               "discriminability": 0.792
-            },
-            {
-              "question": 15,
-              "aCount": 167,
-              "bCount": 25,
-              "aPercent": 87,
-              "bPercent": 13,
-              "discriminability": 0.26
-            },
-            {
-              "question": 16,
-              "aCount": 74,
-              "bCount": 118,
-              "aPercent": 38.5,
-              "bPercent": 61.5,
-              "discriminability": 0.771
             }
           ],
-          "averageDiscriminability": 0.706
+          "averageDiscriminability": 0.724
         }
       ]
     },
@@ -611,11 +611,11 @@
       "questions": [
         {
           "question": 1,
-          "aCount": 94,
-          "bCount": 63,
-          "aPercent": 59.9,
-          "bPercent": 40.1,
-          "discriminability": 0.803
+          "aCount": 96,
+          "bCount": 61,
+          "aPercent": 61.1,
+          "bPercent": 38.9,
+          "discriminability": 0.777
         },
         {
           "question": 2,
@@ -627,43 +627,43 @@
         },
         {
           "question": 3,
-          "aCount": 91,
-          "bCount": 66,
-          "aPercent": 58,
-          "bPercent": 42,
-          "discriminability": 0.841
+          "aCount": 92,
+          "bCount": 65,
+          "aPercent": 58.6,
+          "bPercent": 41.4,
+          "discriminability": 0.828
         },
         {
           "question": 4,
-          "aCount": 113,
-          "bCount": 44,
-          "aPercent": 72,
-          "bPercent": 28,
-          "discriminability": 0.561
+          "aCount": 112,
+          "bCount": 45,
+          "aPercent": 71.3,
+          "bPercent": 28.7,
+          "discriminability": 0.573
         },
         {
           "question": 5,
-          "aCount": 103,
-          "bCount": 54,
-          "aPercent": 65.6,
-          "bPercent": 34.4,
-          "discriminability": 0.688
+          "aCount": 102,
+          "bCount": 55,
+          "aPercent": 65,
+          "bPercent": 35,
+          "discriminability": 0.701
         },
         {
           "question": 6,
-          "aCount": 48,
-          "bCount": 109,
-          "aPercent": 30.6,
-          "bPercent": 69.4,
-          "discriminability": 0.611
+          "aCount": 52,
+          "bCount": 105,
+          "aPercent": 33.1,
+          "bPercent": 66.9,
+          "discriminability": 0.662
         },
         {
           "question": 7,
-          "aCount": 104,
-          "bCount": 53,
-          "aPercent": 66.2,
-          "bPercent": 33.8,
-          "discriminability": 0.675
+          "aCount": 101,
+          "bCount": 56,
+          "aPercent": 64.3,
+          "bPercent": 35.7,
+          "discriminability": 0.713
         },
         {
           "question": 8,
@@ -675,67 +675,67 @@
         },
         {
           "question": 9,
-          "aCount": 84,
-          "bCount": 73,
-          "aPercent": 53.5,
-          "bPercent": 46.5,
-          "discriminability": 0.93
+          "aCount": 81,
+          "bCount": 76,
+          "aPercent": 51.6,
+          "bPercent": 48.4,
+          "discriminability": 0.968
         },
         {
           "question": 10,
-          "aCount": 95,
-          "bCount": 62,
-          "aPercent": 60.5,
-          "bPercent": 39.5,
-          "discriminability": 0.79
-        },
-        {
-          "question": 11,
-          "aCount": 103,
-          "bCount": 54,
-          "aPercent": 65.6,
-          "bPercent": 34.4,
-          "discriminability": 0.688
-        },
-        {
-          "question": 12,
-          "aCount": 121,
-          "bCount": 36,
-          "aPercent": 77.1,
-          "bPercent": 22.9,
-          "discriminability": 0.459
-        },
-        {
-          "question": 13,
-          "aCount": 82,
-          "bCount": 75,
-          "aPercent": 52.2,
-          "bPercent": 47.8,
-          "discriminability": 0.955
-        },
-        {
-          "question": 14,
-          "aCount": 61,
-          "bCount": 96,
-          "aPercent": 38.9,
-          "bPercent": 61.1,
+          "aCount": 96,
+          "bCount": 61,
+          "aPercent": 61.1,
+          "bPercent": 38.9,
           "discriminability": 0.777
         },
         {
-          "question": 15,
-          "aCount": 138,
-          "bCount": 19,
-          "aPercent": 87.9,
-          "bPercent": 12.1,
-          "discriminability": 0.242
+          "question": 11,
+          "aCount": 104,
+          "bCount": 53,
+          "aPercent": 66.2,
+          "bPercent": 33.8,
+          "discriminability": 0.675
         },
         {
-          "question": 16,
+          "question": 12,
+          "aCount": 120,
+          "bCount": 37,
+          "aPercent": 76.4,
+          "bPercent": 23.6,
+          "discriminability": 0.471
+        },
+        {
+          "question": 13,
+          "aCount": 79,
+          "bCount": 78,
+          "aPercent": 50.3,
+          "bPercent": 49.7,
+          "discriminability": 0.994
+        },
+        {
+          "question": 14,
           "aCount": 63,
           "bCount": 94,
           "aPercent": 40.1,
           "bPercent": 59.9,
           "discriminability": 0.803
+        },
+        {
+          "question": 15,
+          "aCount": 132,
+          "bCount": 25,
+          "aPercent": 84.1,
+          "bPercent": 15.9,
+          "discriminability": 0.318
+        },
+        {
+          "question": 16,
+          "aCount": 65,
+          "bCount": 92,
+          "aPercent": 41.4,
+          "bPercent": 58.6,
+          "discriminability": 0.828
         }
       ],
       "dimensions": [
@@ -748,11 +748,11 @@
           "questions": [
             {
               "question": 1,
-              "aCount": 94,
-              "bCount": 63,
-              "aPercent": 59.9,
-              "bPercent": 40.1,
-              "discriminability": 0.803
+              "aCount": 96,
+              "bCount": 61,
+              "aPercent": 61.1,
+              "bPercent": 38.9,
+              "discriminability": 0.777
             },
             {
               "question": 2,
@@ -764,22 +764,22 @@
             },
             {
               "question": 3,
-              "aCount": 91,
-              "bCount": 66,
-              "aPercent": 58,
-              "bPercent": 42,
-              "discriminability": 0.841
+              "aCount": 92,
+              "bCount": 65,
+              "aPercent": 58.6,
+              "bPercent": 41.4,
+              "discriminability": 0.828
             },
             {
               "question": 4,
-              "aCount": 113,
-              "bCount": 44,
-              "aPercent": 72,
-              "bPercent": 28,
-              "discriminability": 0.561
+              "aCount": 112,
+              "bCount": 45,
+              "aPercent": 71.3,
+              "bPercent": 28.7,
+              "discriminability": 0.573
             }
           ],
-          "averageDiscriminability": 0.768
+          "averageDiscriminability": 0.761
         },
         {
           "name": "Precision",
@@ -790,27 +790,27 @@
           "questions": [
             {
               "question": 5,
-              "aCount": 103,
-              "bCount": 54,
-              "aPercent": 65.6,
-              "bPercent": 34.4,
-              "discriminability": 0.688
+              "aCount": 102,
+              "bCount": 55,
+              "aPercent": 65,
+              "bPercent": 35,
+              "discriminability": 0.701
             },
             {
               "question": 6,
-              "aCount": 48,
-              "bCount": 109,
-              "aPercent": 30.6,
-              "bPercent": 69.4,
-              "discriminability": 0.611
+              "aCount": 52,
+              "bCount": 105,
+              "aPercent": 33.1,
+              "bPercent": 66.9,
+              "discriminability": 0.662
             },
             {
               "question": 7,
-              "aCount": 104,
-              "bCount": 53,
-              "aPercent": 66.2,
-              "bPercent": 33.8,
-              "discriminability": 0.675
+              "aCount": 101,
+              "bCount": 56,
+              "aPercent": 64.3,
+              "bPercent": 35.7,
+              "discriminability": 0.713
             },
             {
               "question": 8,
@@ -821,7 +821,7 @@
               "discriminability": 0.586
             }
           ],
-          "averageDiscriminability": 0.64
+          "averageDiscriminability": 0.665
         },
         {
           "name": "Transparency",
@@ -832,38 +832,38 @@
           "questions": [
             {
               "question": 9,
-              "aCount": 84,
-              "bCount": 73,
-              "aPercent": 53.5,
-              "bPercent": 46.5,
-              "discriminability": 0.93
+              "aCount": 81,
+              "bCount": 76,
+              "aPercent": 51.6,
+              "bPercent": 48.4,
+              "discriminability": 0.968
             },
             {
               "question": 10,
-              "aCount": 95,
-              "bCount": 62,
-              "aPercent": 60.5,
-              "bPercent": 39.5,
-              "discriminability": 0.79
+              "aCount": 96,
+              "bCount": 61,
+              "aPercent": 61.1,
+              "bPercent": 38.9,
+              "discriminability": 0.777
             },
             {
               "question": 11,
-              "aCount": 103,
-              "bCount": 54,
-              "aPercent": 65.6,
-              "bPercent": 34.4,
-              "discriminability": 0.688
+              "aCount": 104,
+              "bCount": 53,
+              "aPercent": 66.2,
+              "bPercent": 33.8,
+              "discriminability": 0.675
             },
             {
               "question": 12,
-              "aCount": 121,
-              "bCount": 36,
-              "aPercent": 77.1,
-              "bPercent": 22.9,
-              "discriminability": 0.459
+              "aCount": 120,
+              "bCount": 37,
+              "aPercent": 76.4,
+              "bPercent": 23.6,
+              "discriminability": 0.471
             }
           ],
-          "averageDiscriminability": 0.717
+          "averageDiscriminability": 0.723
         },
         {
           "name": "Adaptability",
@@ -874,38 +874,38 @@
           "questions": [
             {
               "question": 13,
-              "aCount": 82,
-              "bCount": 75,
-              "aPercent": 52.2,
-              "bPercent": 47.8,
-              "discriminability": 0.955
+              "aCount": 79,
+              "bCount": 78,
+              "aPercent": 50.3,
+              "bPercent": 49.7,
+              "discriminability": 0.994
             },
             {
               "question": 14,
-              "aCount": 61,
-              "bCount": 96,
-              "aPercent": 38.9,
-              "bPercent": 61.1,
-              "discriminability": 0.777
-            },
-            {
-              "question": 15,
-              "aCount": 138,
-              "bCount": 19,
-              "aPercent": 87.9,
-              "bPercent": 12.1,
-              "discriminability": 0.242
-            },
-            {
-              "question": 16,
               "aCount": 63,
               "bCount": 94,
               "aPercent": 40.1,
               "bPercent": 59.9,
               "discriminability": 0.803
+            },
+            {
+              "question": 15,
+              "aCount": 132,
+              "bCount": 25,
+              "aPercent": 84.1,
+              "bPercent": 15.9,
+              "discriminability": 0.318
+            },
+            {
+              "question": 16,
+              "aCount": 65,
+              "bCount": 92,
+              "aPercent": 41.4,
+              "bPercent": 58.6,
+              "discriminability": 0.828
             }
           ],
-          "averageDiscriminability": 0.694
+          "averageDiscriminability": 0.736
         }
       ]
     },

--- a/data/reliability/claude-haiku-4-5-run-1.json
+++ b/data/reliability/claude-haiku-4-5-run-1.json
@@ -3,6 +3,13 @@
   "provider": "anthropic",
   "run": 1,
   "answers": [
+    "A",
+    "B",
+    "B",
+    "B",
+    "B",
+    "A",
+    "A",
     "B",
     "B",
     "A",
@@ -10,22 +17,15 @@
     "B",
     "B",
     "A",
-    "B",
-    "A",
-    "B",
-    "A",
-    "B",
-    "B",
-    "B",
     "A",
     "A"
   ],
-  "type": "RECF",
-  "questionVersion": "5.0",
   "dimensions": [
     1,
-    1,
     2,
-    2
-  ]
+    1,
+    3
+  ],
+  "type": "RTDF",
+  "questionVersion": "5.0"
 }

--- a/data/reliability/claude-haiku-4-5-run-2.json
+++ b/data/reliability/claude-haiku-4-5-run-2.json
@@ -8,24 +8,24 @@
     "A",
     "A",
     "A",
-    "B",
-    "A",
-    "B",
-    "A",
     "A",
     "B",
     "B",
     "A",
+    "A",
+    "A",
+    "B",
     "B",
     "A",
-    "B"
+    "A",
+    "A"
   ],
-  "type": "PTCF",
-  "questionVersion": "5.0",
   "dimensions": [
     2,
     2,
-    2,
-    2
-  ]
+    3,
+    3
+  ],
+  "type": "PTCF",
+  "questionVersion": "5.0"
 }

--- a/data/reliability/claude-haiku-4-5-run-3.json
+++ b/data/reliability/claude-haiku-4-5-run-3.json
@@ -3,29 +3,29 @@
   "provider": "anthropic",
   "run": 3,
   "answers": [
-    "B",
-    "B",
     "A",
     "B",
     "A",
     "A",
     "A",
-    "B",
     "A",
     "A",
     "B",
-    "B",
+    "A",
+    "A",
     "A",
     "B",
     "A",
-    "B"
+    "A",
+    "A",
+    "A"
   ],
-  "type": "RTCF",
-  "questionVersion": "5.0",
   "dimensions": [
-    1,
     3,
-    2,
-    2
-  ]
+    3,
+    3,
+    4
+  ],
+  "type": "PTCF",
+  "questionVersion": "5.0"
 }

--- a/data/reliability/claude-opus-4-6-run-1.json
+++ b/data/reliability/claude-opus-4-6-run-1.json
@@ -16,16 +16,16 @@
     "B",
     "A",
     "A",
-    "A",
+    "B",
     "A",
     "A"
   ],
-  "type": "PEDF",
-  "questionVersion": "5.0",
   "dimensions": [
     4,
     1,
     1,
-    4
-  ]
+    3
+  ],
+  "type": "PEDF",
+  "questionVersion": "5.0"
 }

--- a/data/reliability/claude-opus-4-6-run-2.json
+++ b/data/reliability/claude-opus-4-6-run-2.json
@@ -6,26 +6,26 @@
     "A",
     "A",
     "A",
-    "A",
     "B",
     "B",
     "B",
+    "B",
     "A",
-    "A",
+    "B",
     "B",
     "A",
     "A",
     "A",
     "B",
-    "A",
+    "B",
     "A"
   ],
-  "type": "PECF",
-  "questionVersion": "5.0",
   "dimensions": [
-    4,
-    1,
     3,
-    3
-  ]
+    1,
+    2,
+    2
+  ],
+  "type": "PECF",
+  "questionVersion": "5.0"
 }

--- a/data/reliability/claude-opus-4-6-run-3.json
+++ b/data/reliability/claude-opus-4-6-run-3.json
@@ -6,7 +6,6 @@
     "A",
     "A",
     "A",
-    "A",
     "B",
     "B",
     "B",
@@ -18,14 +17,15 @@
     "A",
     "A",
     "A",
+    "B",
     "A"
   ],
-  "type": "PECF",
-  "questionVersion": "5.0",
   "dimensions": [
-    4,
+    3,
     0,
-    2,
-    4
-  ]
+    3,
+    3
+  ],
+  "type": "PECF",
+  "questionVersion": "5.0"
 }

--- a/data/reliability/claude-opus-4-7-run-1.json
+++ b/data/reliability/claude-opus-4-7-run-1.json
@@ -18,14 +18,14 @@
     "A",
     "A",
     "A",
-    "B"
+    "A"
   ],
-  "type": "RECF",
-  "questionVersion": "5.0",
   "dimensions": [
     1,
     0,
     4,
-    3
-  ]
+    4
+  ],
+  "type": "RECF",
+  "questionVersion": "5.0"
 }

--- a/data/reliability/claude-opus-4-7-run-2.json
+++ b/data/reliability/claude-opus-4-7-run-2.json
@@ -20,12 +20,12 @@
     "A",
     "B"
   ],
-  "type": "PECF",
-  "questionVersion": "5.0",
   "dimensions": [
     2,
     0,
     4,
     3
-  ]
+  ],
+  "type": "PECF",
+  "questionVersion": "5.0"
 }

--- a/data/reliability/claude-opus-4-7-run-3.json
+++ b/data/reliability/claude-opus-4-7-run-3.json
@@ -5,11 +5,11 @@
   "answers": [
     "A",
     "B",
-    "B",
-    "B",
-    "B",
-    "B",
     "A",
+    "B",
+    "B",
+    "B",
+    "B",
     "B",
     "A",
     "A",
@@ -20,12 +20,12 @@
     "A",
     "A"
   ],
-  "type": "RECF",
-  "questionVersion": "5.0",
   "dimensions": [
-    1,
-    1,
+    2,
+    0,
     4,
     4
-  ]
+  ],
+  "type": "PECF",
+  "questionVersion": "5.0"
 }

--- a/data/reliability/claude-opus-4-8-run-1.json
+++ b/data/reliability/claude-opus-4-8-run-1.json
@@ -4,28 +4,28 @@
   "run": 1,
   "answers": [
     "B",
+    "B",
+    "A",
+    "B",
+    "B",
     "A",
     "A",
     "B",
     "A",
+    "A",
     "B",
-    "A",
-    "A",
-    "A",
-    "A",
-    "A",
     "A",
     "B",
     "A",
     "A",
     "A"
   ],
-  "type": "PTCF",
-  "questionVersion": "5.0",
   "dimensions": [
+    1,
     2,
     3,
-    4,
     3
-  ]
+  ],
+  "type": "RTCF",
+  "questionVersion": "5.0"
 }

--- a/data/reliability/claude-opus-4-8-run-2.json
+++ b/data/reliability/claude-opus-4-8-run-2.json
@@ -3,29 +3,29 @@
   "provider": "anthropic",
   "run": 2,
   "answers": [
-    "B",
-    "A",
-    "B",
-    "B",
-    "B",
-    "B",
-    "A",
-    "B",
     "A",
     "A",
-    "A",
+    "B",
+    "B",
+    "B",
     "A",
     "A",
     "B",
     "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "A",
+    "B",
     "A"
   ],
-  "type": "RECF",
-  "questionVersion": "5.0",
   "dimensions": [
-    1,
-    1,
+    2,
+    2,
     4,
-    3
-  ]
+    2
+  ],
+  "type": "PTCF",
+  "questionVersion": "5.0"
 }

--- a/data/reliability/claude-opus-4-8-run-3.json
+++ b/data/reliability/claude-opus-4-8-run-3.json
@@ -3,13 +3,13 @@
   "provider": "anthropic",
   "run": 3,
   "answers": [
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
     "A",
-    "B",
-    "B",
-    "B",
-    "B",
-    "B",
-    "B",
+    "A",
     "B",
     "A",
     "A",
@@ -20,12 +20,12 @@
     "A",
     "A"
   ],
-  "type": "RECF",
-  "questionVersion": "5.0",
   "dimensions": [
-    1,
     0,
+    2,
     4,
     4
-  ]
+  ],
+  "type": "RTCF",
+  "questionVersion": "5.0"
 }

--- a/data/reliability/claude-sonnet-4-5-run-1.json
+++ b/data/reliability/claude-sonnet-4-5-run-1.json
@@ -3,29 +3,29 @@
   "provider": "anthropic",
   "run": 1,
   "answers": [
-    "B",
-    "B",
-    "B",
+    "A",
     "B",
     "B",
     "A",
-    "B",
-    "A",
-    "A",
-    "B",
     "A",
     "A",
     "B",
     "B",
     "A",
-    "A"
+    "A",
+    "A",
+    "B",
+    "B",
+    "B",
+    "A",
+    "B"
   ],
-  "type": "RTCF",
-  "questionVersion": "5.0",
   "dimensions": [
-    0,
+    2,
     2,
     3,
-    2
-  ]
+    1
+  ],
+  "type": "PTCN",
+  "questionVersion": "5.0"
 }

--- a/data/reliability/claude-sonnet-4-5-run-2.json
+++ b/data/reliability/claude-sonnet-4-5-run-2.json
@@ -3,29 +3,29 @@
   "provider": "anthropic",
   "run": 2,
   "answers": [
+    "B",
     "A",
+    "A",
+    "B",
+    "B",
+    "B",
     "B",
     "A",
     "B",
     "B",
     "A",
     "B",
-    "B",
-    "B",
     "A",
     "B",
-    "A",
-    "A",
-    "A",
-    "A",
-    "B"
+    "B",
+    "A"
   ],
-  "type": "PECF",
-  "questionVersion": "5.0",
   "dimensions": [
     2,
     1,
-    2,
-    3
-  ]
+    1,
+    2
+  ],
+  "type": "PEDF",
+  "questionVersion": "5.0"
 }

--- a/data/reliability/claude-sonnet-4-5-run-3.json
+++ b/data/reliability/claude-sonnet-4-5-run-3.json
@@ -6,26 +6,26 @@
     "A",
     "A",
     "B",
+    "B",
+    "B",
     "A",
-    "A",
-    "A",
-    "A",
-    "A",
-    "A",
-    "A",
+    "B",
     "B",
     "B",
     "A",
     "B",
     "A",
-    "A"
+    "B",
+    "B",
+    "A",
+    "B"
   ],
-  "type": "PTCF",
-  "questionVersion": "5.0",
   "dimensions": [
-    3,
-    4,
     2,
-    3
-  ]
+    1,
+    2,
+    1
+  ],
+  "type": "PECN",
+  "questionVersion": "5.0"
 }

--- a/data/reliability/claude-sonnet-4-6-run-1.json
+++ b/data/reliability/claude-sonnet-4-6-run-1.json
@@ -5,14 +5,14 @@
   "answers": [
     "A",
     "B",
+    "A",
+    "B",
     "B",
     "B",
     "A",
     "B",
-    "A",
     "B",
     "B",
-    "A",
     "B",
     "A",
     "A",
@@ -20,12 +20,12 @@
     "A",
     "A"
   ],
-  "type": "RTCF",
-  "questionVersion": "5.0",
   "dimensions": [
+    2,
     1,
-    2,
-    2,
+    1,
     4
-  ]
+  ],
+  "type": "PEDF",
+  "questionVersion": "5.0"
 }

--- a/data/reliability/claude-sonnet-4-6-run-2.json
+++ b/data/reliability/claude-sonnet-4-6-run-2.json
@@ -10,22 +10,22 @@
     "A",
     "B",
     "A",
-    "B",
-    "B",
-    "A",
-    "A",
-    "A",
     "A",
     "B",
     "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "B",
     "A"
   ],
-  "type": "PTCF",
-  "questionVersion": "5.0",
   "dimensions": [
     2,
-    2,
     3,
-    3
-  ]
+    3,
+    2
+  ],
+  "type": "PTCF",
+  "questionVersion": "5.0"
 }

--- a/data/reliability/claude-sonnet-4-6-run-3.json
+++ b/data/reliability/claude-sonnet-4-6-run-3.json
@@ -7,25 +7,25 @@
     "B",
     "A",
     "B",
+    "A",
     "B",
     "B",
     "A",
     "B",
     "B",
     "B",
+    "A",
+    "A",
+    "A",
     "B",
-    "A",
-    "A",
-    "A",
-    "A",
     "A"
   ],
-  "type": "PEDF",
-  "questionVersion": "5.0",
   "dimensions": [
     2,
+    2,
     1,
-    1,
-    4
-  ]
+    3
+  ],
+  "type": "PTDF",
+  "questionVersion": "5.0"
 }


### PR DESCRIPTION
## Summary

Re-run 3×6 Claude model reliability tests with the redesigned Q15 (callbacks vs async/await, from #603).

## Q15 Discriminability Results (Claude cohort only)

| Metric | Before | After |
|--------|--------|-------|
| A% (consistency) | 87% | 66.7% |
| B% (modernization) | 13% | 33.3% |
| **Discriminability** | **0.260** | **0.667** |

✅ Above 0.6 threshold!

## Per-Model Q15 Breakdown

| Model | Run 1 | Run 2 | Run 3 | Pattern |
|-------|-------|-------|-------|---------|
| claude-haiku-4-5 | A | A | A | consistency |
| claude-opus-4-7 | A | A | A | consistency |
| claude-opus-4-8 | A | B | A | mixed |
| claude-sonnet-4-5 | A | B | A | mixed |
| claude-opus-4-6 | A | B | B | modernization |
| claude-sonnet-4-6 | A | B | B | modernization |

Shows genuine inter-model variation — smaller/older models prefer consistency while newer models lean toward modernization.

## Remaining Work

Non-Claude models (gpt-4-1, gpt-5-4, gpt-5-5, gemini-2-5-pro, gemini-3-1-pro-preview) still have old Q15 data. These need to be re-run via GitHub Models API.

Validates #602.