### PR TITLE
data: re-run non-Claude reliability data with redesigned Q15/Q16

### DIFF
--- a/data/discriminability.json
+++ b/data/discriminability.json
@@ -1,23 +1,23 @@
 {
-  "generatedAt": "2026-06-26T12:10:29.923Z",
+  "generatedAt": "2026-06-26T15:00:37.214Z",
   "threshold": 0.6,
   "totalRuns": 192,
   "questions": [
     {
       "question": 1,
-      "aCount": 114,
-      "bCount": 78,
-      "aPercent": 59.4,
-      "bPercent": 40.6,
-      "discriminability": 0.813
+      "aCount": 117,
+      "bCount": 75,
+      "aPercent": 60.9,
+      "bPercent": 39.1,
+      "discriminability": 0.781
     },
     {
       "question": 2,
-      "aCount": 115,
-      "bCount": 77,
-      "aPercent": 59.9,
-      "bPercent": 40.1,
-      "discriminability": 0.802
+      "aCount": 116,
+      "bCount": 76,
+      "aPercent": 60.4,
+      "bPercent": 39.6,
+      "discriminability": 0.792
     },
     {
       "question": 3,
@@ -29,19 +29,19 @@
     },
     {
       "question": 4,
-      "aCount": 140,
-      "bCount": 52,
-      "aPercent": 72.9,
-      "bPercent": 27.1,
-      "discriminability": 0.542
+      "aCount": 139,
+      "bCount": 53,
+      "aPercent": 72.4,
+      "bPercent": 27.6,
+      "discriminability": 0.552
     },
     {
       "question": 5,
-      "aCount": 126,
-      "bCount": 66,
-      "aPercent": 65.6,
-      "bPercent": 34.4,
-      "discriminability": 0.688
+      "aCount": 130,
+      "bCount": 62,
+      "aPercent": 67.7,
+      "bPercent": 32.3,
+      "discriminability": 0.646
     },
     {
       "question": 6,
@@ -53,11 +53,11 @@
     },
     {
       "question": 7,
-      "aCount": 128,
-      "bCount": 64,
-      "aPercent": 66.7,
-      "bPercent": 33.3,
-      "discriminability": 0.667
+      "aCount": 126,
+      "bCount": 66,
+      "aPercent": 65.6,
+      "bPercent": 34.4,
+      "discriminability": 0.688
     },
     {
       "question": 8,
@@ -77,11 +77,11 @@
     },
     {
       "question": 10,
-      "aCount": 117,
-      "bCount": 75,
-      "aPercent": 60.9,
-      "bPercent": 39.1,
-      "discriminability": 0.781
+      "aCount": 116,
+      "bCount": 76,
+      "aPercent": 60.4,
+      "bPercent": 39.6,
+      "discriminability": 0.792
     },
     {
       "question": 11,
@@ -93,19 +93,19 @@
     },
     {
       "question": 12,
-      "aCount": 150,
-      "bCount": 42,
-      "aPercent": 78.1,
-      "bPercent": 21.9,
-      "discriminability": 0.438
+      "aCount": 151,
+      "bCount": 41,
+      "aPercent": 78.6,
+      "bPercent": 21.4,
+      "discriminability": 0.427
     },
     {
       "question": 13,
-      "aCount": 93,
-      "bCount": 99,
-      "aPercent": 48.4,
-      "bPercent": 51.6,
-      "discriminability": 0.969
+      "aCount": 97,
+      "bCount": 95,
+      "aPercent": 50.5,
+      "bPercent": 49.5,
+      "discriminability": 0.99
     },
     {
       "question": 14,
@@ -117,11 +117,11 @@
     },
     {
       "question": 15,
-      "aCount": 161,
-      "bCount": 31,
-      "aPercent": 83.9,
-      "bPercent": 16.1,
-      "discriminability": 0.323
+      "aCount": 162,
+      "bCount": 30,
+      "aPercent": 84.4,
+      "bPercent": 15.6,
+      "discriminability": 0.313
     },
     {
       "question": 16,
@@ -142,19 +142,19 @@
       "questions": [
         {
           "question": 1,
-          "aCount": 114,
-          "bCount": 78,
-          "aPercent": 59.4,
-          "bPercent": 40.6,
-          "discriminability": 0.813
+          "aCount": 117,
+          "bCount": 75,
+          "aPercent": 60.9,
+          "bPercent": 39.1,
+          "discriminability": 0.781
         },
         {
           "question": 2,
-          "aCount": 115,
-          "bCount": 77,
-          "aPercent": 59.9,
-          "bPercent": 40.1,
-          "discriminability": 0.802
+          "aCount": 116,
+          "bCount": 76,
+          "aPercent": 60.4,
+          "bPercent": 39.6,
+          "discriminability": 0.792
         },
         {
           "question": 3,
@@ -166,14 +166,14 @@
         },
         {
           "question": 4,
-          "aCount": 140,
-          "bCount": 52,
-          "aPercent": 72.9,
-          "bPercent": 27.1,
-          "discriminability": 0.542
+          "aCount": 139,
+          "bCount": 53,
+          "aPercent": 72.4,
+          "bPercent": 27.6,
+          "discriminability": 0.552
         }
       ],
-      "averageDiscriminability": 0.779
+      "averageDiscriminability": 0.771
     },
     {
       "name": "Precision",
@@ -184,11 +184,11 @@
       "questions": [
         {
           "question": 5,
-          "aCount": 126,
-          "bCount": 66,
-          "aPercent": 65.6,
-          "bPercent": 34.4,
-          "discriminability": 0.688
+          "aCount": 130,
+          "bCount": 62,
+          "aPercent": 67.7,
+          "bPercent": 32.3,
+          "discriminability": 0.646
         },
         {
           "question": 6,
@@ -200,11 +200,11 @@
         },
         {
           "question": 7,
-          "aCount": 128,
-          "bCount": 64,
-          "aPercent": 66.7,
-          "bPercent": 33.3,
-          "discriminability": 0.667
+          "aCount": 126,
+          "bCount": 66,
+          "aPercent": 65.6,
+          "bPercent": 34.4,
+          "discriminability": 0.688
         },
         {
           "question": 8,
@@ -215,7 +215,7 @@
           "discriminability": 0.615
         }
       ],
-      "averageDiscriminability": 0.677
+      "averageDiscriminability": 0.672
     },
     {
       "name": "Transparency",
@@ -234,11 +234,11 @@
         },
         {
           "question": 10,
-          "aCount": 117,
-          "bCount": 75,
-          "aPercent": 60.9,
-          "bPercent": 39.1,
-          "discriminability": 0.781
+          "aCount": 116,
+          "bCount": 76,
+          "aPercent": 60.4,
+          "bPercent": 39.6,
+          "discriminability": 0.792
         },
         {
           "question": 11,
@@ -250,11 +250,11 @@
         },
         {
           "question": 12,
-          "aCount": 150,
-          "bCount": 42,
-          "aPercent": 78.1,
-          "bPercent": 21.9,
-          "discriminability": 0.438
+          "aCount": 151,
+          "bCount": 41,
+          "aPercent": 78.6,
+          "bPercent": 21.4,
+          "discriminability": 0.427
         }
       ],
       "averageDiscriminability": 0.714
@@ -268,11 +268,11 @@
       "questions": [
         {
           "question": 13,
-          "aCount": 93,
-          "bCount": 99,
-          "aPercent": 48.4,
-          "bPercent": 51.6,
-          "discriminability": 0.969
+          "aCount": 97,
+          "bCount": 95,
+          "aPercent": 50.5,
+          "bPercent": 49.5,
+          "discriminability": 0.99
         },
         {
           "question": 14,
@@ -284,11 +284,11 @@
         },
         {
           "question": 15,
-          "aCount": 161,
-          "bCount": 31,
-          "aPercent": 83.9,
-          "bPercent": 16.1,
-          "discriminability": 0.323
+          "aCount": 162,
+          "bCount": 30,
+          "aPercent": 84.4,
+          "bPercent": 15.6,
+          "discriminability": 0.313
         },
         {
           "question": 16,
@@ -299,7 +299,7 @@
           "discriminability": 0.792
         }
       ],
-      "averageDiscriminability": 0.724
+      "averageDiscriminability": 0.727
     }
   ],
   "cohorts": {
@@ -308,19 +308,19 @@
       "questions": [
         {
           "question": 1,
-          "aCount": 114,
-          "bCount": 78,
-          "aPercent": 59.4,
-          "bPercent": 40.6,
-          "discriminability": 0.813
+          "aCount": 117,
+          "bCount": 75,
+          "aPercent": 60.9,
+          "bPercent": 39.1,
+          "discriminability": 0.781
         },
         {
           "question": 2,
-          "aCount": 115,
-          "bCount": 77,
-          "aPercent": 59.9,
-          "bPercent": 40.1,
-          "discriminability": 0.802
+          "aCount": 116,
+          "bCount": 76,
+          "aPercent": 60.4,
+          "bPercent": 39.6,
+          "discriminability": 0.792
         },
         {
           "question": 3,
@@ -332,19 +332,19 @@
         },
         {
           "question": 4,
-          "aCount": 140,
-          "bCount": 52,
-          "aPercent": 72.9,
-          "bPercent": 27.1,
-          "discriminability": 0.542
+          "aCount": 139,
+          "bCount": 53,
+          "aPercent": 72.4,
+          "bPercent": 27.6,
+          "discriminability": 0.552
         },
         {
           "question": 5,
-          "aCount": 126,
-          "bCount": 66,
-          "aPercent": 65.6,
-          "bPercent": 34.4,
-          "discriminability": 0.688
+          "aCount": 130,
+          "bCount": 62,
+          "aPercent": 67.7,
+          "bPercent": 32.3,
+          "discriminability": 0.646
         },
         {
           "question": 6,
@@ -356,11 +356,11 @@
         },
         {
           "question": 7,
-          "aCount": 128,
-          "bCount": 64,
-          "aPercent": 66.7,
-          "bPercent": 33.3,
-          "discriminability": 0.667
+          "aCount": 126,
+          "bCount": 66,
+          "aPercent": 65.6,
+          "bPercent": 34.4,
+          "discriminability": 0.688
         },
         {
           "question": 8,
@@ -380,11 +380,11 @@
         },
         {
           "question": 10,
-          "aCount": 117,
-          "bCount": 75,
-          "aPercent": 60.9,
-          "bPercent": 39.1,
-          "discriminability": 0.781
+          "aCount": 116,
+          "bCount": 76,
+          "aPercent": 60.4,
+          "bPercent": 39.6,
+          "discriminability": 0.792
         },
         {
           "question": 11,
@@ -396,19 +396,19 @@
         },
         {
           "question": 12,
-          "aCount": 150,
-          "bCount": 42,
-          "aPercent": 78.1,
-          "bPercent": 21.9,
-          "discriminability": 0.438
+          "aCount": 151,
+          "bCount": 41,
+          "aPercent": 78.6,
+          "bPercent": 21.4,
+          "discriminability": 0.427
         },
         {
           "question": 13,
-          "aCount": 93,
-          "bCount": 99,
-          "aPercent": 48.4,
-          "bPercent": 51.6,
-          "discriminability": 0.969
+          "aCount": 97,
+          "bCount": 95,
+          "aPercent": 50.5,
+          "bPercent": 49.5,
+          "discriminability": 0.99
         },
         {
           "question": 14,
@@ -420,11 +420,11 @@
         },
         {
           "question": 15,
-          "aCount": 161,
-          "bCount": 31,
-          "aPercent": 83.9,
-          "bPercent": 16.1,
-          "discriminability": 0.323
+          "aCount": 162,
+          "bCount": 30,
+          "aPercent": 84.4,
+          "bPercent": 15.6,
+          "discriminability": 0.313
         },
         {
           "question": 16,
@@ -445,19 +445,19 @@
           "questions": [
             {
               "question": 1,
-              "aCount": 114,
-              "bCount": 78,
-              "aPercent": 59.4,
-              "bPercent": 40.6,
-              "discriminability": 0.813
+              "aCount": 117,
+              "bCount": 75,
+              "aPercent": 60.9,
+              "bPercent": 39.1,
+              "discriminability": 0.781
             },
             {
               "question": 2,
-              "aCount": 115,
-              "bCount": 77,
-              "aPercent": 59.9,
-              "bPercent": 40.1,
-              "discriminability": 0.802
+              "aCount": 116,
+              "bCount": 76,
+              "aPercent": 60.4,
+              "bPercent": 39.6,
+              "discriminability": 0.792
             },
             {
               "question": 3,
@@ -469,14 +469,14 @@
             },
             {
               "question": 4,
-              "aCount": 140,
-              "bCount": 52,
-              "aPercent": 72.9,
-              "bPercent": 27.1,
-              "discriminability": 0.542
+              "aCount": 139,
+              "bCount": 53,
+              "aPercent": 72.4,
+              "bPercent": 27.6,
+              "discriminability": 0.552
             }
           ],
-          "averageDiscriminability": 0.779
+          "averageDiscriminability": 0.771
         },
         {
           "name": "Precision",
@@ -487,11 +487,11 @@
           "questions": [
             {
               "question": 5,
-              "aCount": 126,
-              "bCount": 66,
-              "aPercent": 65.6,
-              "bPercent": 34.4,
-              "discriminability": 0.688
+              "aCount": 130,
+              "bCount": 62,
+              "aPercent": 67.7,
+              "bPercent": 32.3,
+              "discriminability": 0.646
             },
             {
               "question": 6,
@@ -503,11 +503,11 @@
             },
             {
               "question": 7,
-              "aCount": 128,
-              "bCount": 64,
-              "aPercent": 66.7,
-              "bPercent": 33.3,
-              "discriminability": 0.667
+              "aCount": 126,
+              "bCount": 66,
+              "aPercent": 65.6,
+              "bPercent": 34.4,
+              "discriminability": 0.688
             },
             {
               "question": 8,
@@ -518,7 +518,7 @@
               "discriminability": 0.615
             }
           ],
-          "averageDiscriminability": 0.677
+          "averageDiscriminability": 0.672
         },
         {
           "name": "Transparency",
@@ -537,11 +537,11 @@
             },
             {
               "question": 10,
-              "aCount": 117,
-              "bCount": 75,
-              "aPercent": 60.9,
-              "bPercent": 39.1,
-              "discriminability": 0.781
+              "aCount": 116,
+              "bCount": 76,
+              "aPercent": 60.4,
+              "bPercent": 39.6,
+              "discriminability": 0.792
             },
             {
               "question": 11,
@@ -553,11 +553,11 @@
             },
             {
               "question": 12,
-              "aCount": 150,
-              "bCount": 42,
-              "aPercent": 78.1,
-              "bPercent": 21.9,
-              "discriminability": 0.438
+              "aCount": 151,
+              "bCount": 41,
+              "aPercent": 78.6,
+              "bPercent": 21.4,
+              "discriminability": 0.427
             }
           ],
           "averageDiscriminability": 0.714
@@ -571,11 +571,11 @@
           "questions": [
             {
               "question": 13,
-              "aCount": 93,
-              "bCount": 99,
-              "aPercent": 48.4,
-              "bPercent": 51.6,
-              "discriminability": 0.969
+              "aCount": 97,
+              "bCount": 95,
+              "aPercent": 50.5,
+              "bPercent": 49.5,
+              "discriminability": 0.99
             },
             {
               "question": 14,
@@ -587,11 +587,11 @@
             },
             {
               "question": 15,
-              "aCount": 161,
-              "bCount": 31,
-              "aPercent": 83.9,
-              "bPercent": 16.1,
-              "discriminability": 0.323
+              "aCount": 162,
+              "bCount": 30,
+              "aPercent": 84.4,
+              "bPercent": 15.6,
+              "discriminability": 0.313
             },
             {
               "question": 16,
@@ -602,7 +602,7 @@
               "discriminability": 0.792
             }
           ],
-          "averageDiscriminability": 0.724
+          "averageDiscriminability": 0.727
         }
       ]
     },
@@ -611,11 +611,11 @@
       "questions": [
         {
           "question": 1,
-          "aCount": 96,
-          "bCount": 61,
-          "aPercent": 61.1,
-          "bPercent": 38.9,
-          "discriminability": 0.777
+          "aCount": 99,
+          "bCount": 58,
+          "aPercent": 63.1,
+          "bPercent": 36.9,
+          "discriminability": 0.739
         },
         {
           "question": 2,
@@ -643,27 +643,27 @@
         },
         {
           "question": 5,
-          "aCount": 102,
-          "bCount": 55,
-          "aPercent": 65,
-          "bPercent": 35,
-          "discriminability": 0.701
+          "aCount": 103,
+          "bCount": 54,
+          "aPercent": 65.6,
+          "bPercent": 34.4,
+          "discriminability": 0.688
         },
         {
           "question": 6,
-          "aCount": 52,
-          "bCount": 105,
-          "aPercent": 33.1,
-          "bPercent": 66.9,
-          "discriminability": 0.662
+          "aCount": 53,
+          "bCount": 104,
+          "aPercent": 33.8,
+          "bPercent": 66.2,
+          "discriminability": 0.675
         },
         {
           "question": 7,
-          "aCount": 101,
-          "bCount": 56,
-          "aPercent": 64.3,
-          "bPercent": 35.7,
-          "discriminability": 0.713
+          "aCount": 99,
+          "bCount": 58,
+          "aPercent": 63.1,
+          "bPercent": 36.9,
+          "discriminability": 0.739
         },
         {
           "question": 8,
@@ -675,19 +675,19 @@
         },
         {
           "question": 9,
-          "aCount": 81,
-          "bCount": 76,
-          "aPercent": 51.6,
-          "bPercent": 48.4,
-          "discriminability": 0.968
+          "aCount": 80,
+          "bCount": 77,
+          "aPercent": 51,
+          "bPercent": 49,
+          "discriminability": 0.981
         },
         {
           "question": 10,
-          "aCount": 96,
-          "bCount": 61,
-          "aPercent": 61.1,
-          "bPercent": 38.9,
-          "discriminability": 0.777
+          "aCount": 95,
+          "bCount": 62,
+          "aPercent": 60.5,
+          "bPercent": 39.5,
+          "discriminability": 0.79
         },
         {
           "question": 11,
@@ -699,19 +699,19 @@
         },
         {
           "question": 12,
-          "aCount": 120,
-          "bCount": 37,
-          "aPercent": 76.4,
-          "bPercent": 23.6,
-          "discriminability": 0.471
+          "aCount": 121,
+          "bCount": 36,
+          "aPercent": 77.1,
+          "bPercent": 22.9,
+          "discriminability": 0.459
         },
         {
           "question": 13,
-          "aCount": 79,
-          "bCount": 78,
-          "aPercent": 50.3,
-          "bPercent": 49.7,
-          "discriminability": 0.994
+          "aCount": 82,
+          "bCount": 75,
+          "aPercent": 52.2,
+          "bPercent": 47.8,
+          "discriminability": 0.955
         },
         {
           "question": 14,
@@ -723,19 +723,19 @@
         },
         {
           "question": 15,
-          "aCount": 132,
-          "bCount": 25,
-          "aPercent": 84.1,
-          "bPercent": 15.9,
-          "discriminability": 0.318
+          "aCount": 133,
+          "bCount": 24,
+          "aPercent": 84.7,
+          "bPercent": 15.3,
+          "discriminability": 0.306
         },
         {
           "question": 16,
-          "aCount": 65,
-          "bCount": 92,
-          "aPercent": 41.4,
-          "bPercent": 58.6,
-          "discriminability": 0.828
+          "aCount": 64,
+          "bCount": 93,
+          "aPercent": 40.8,
+          "bPercent": 59.2,
+          "discriminability": 0.815
         }
       ],
       "dimensions": [
@@ -748,11 +748,11 @@
           "questions": [
             {
               "question": 1,
-              "aCount": 96,
-              "bCount": 61,
-              "aPercent": 61.1,
-              "bPercent": 38.9,
-              "discriminability": 0.777
+              "aCount": 99,
+              "bCount": 58,
+              "aPercent": 63.1,
+              "bPercent": 36.9,
+              "discriminability": 0.739
             },
             {
               "question": 2,
@@ -779,7 +779,7 @@
               "discriminability": 0.573
             }
           ],
-          "averageDiscriminability": 0.761
+          "averageDiscriminability": 0.751
         },
         {
           "name": "Precision",
@@ -790,27 +790,27 @@
           "questions": [
             {
               "question": 5,
-              "aCount": 102,
-              "bCount": 55,
-              "aPercent": 65,
-              "bPercent": 35,
-              "discriminability": 0.701
+              "aCount": 103,
+              "bCount": 54,
+              "aPercent": 65.6,
+              "bPercent": 34.4,
+              "discriminability": 0.688
             },
             {
               "question": 6,
-              "aCount": 52,
-              "bCount": 105,
-              "aPercent": 33.1,
-              "bPercent": 66.9,
-              "discriminability": 0.662
+              "aCount": 53,
+              "bCount": 104,
+              "aPercent": 33.8,
+              "bPercent": 66.2,
+              "discriminability": 0.675
             },
             {
               "question": 7,
-              "aCount": 101,
-              "bCount": 56,
-              "aPercent": 64.3,
-              "bPercent": 35.7,
-              "discriminability": 0.713
+              "aCount": 99,
+              "bCount": 58,
+              "aPercent": 63.1,
+              "bPercent": 36.9,
+              "discriminability": 0.739
             },
             {
               "question": 8,
@@ -821,7 +821,7 @@
               "discriminability": 0.586
             }
           ],
-          "averageDiscriminability": 0.665
+          "averageDiscriminability": 0.672
         },
         {
           "name": "Transparency",
@@ -832,19 +832,19 @@
           "questions": [
             {
               "question": 9,
-              "aCount": 81,
-              "bCount": 76,
-              "aPercent": 51.6,
-              "bPercent": 48.4,
-              "discriminability": 0.968
+              "aCount": 80,
+              "bCount": 77,
+              "aPercent": 51,
+              "bPercent": 49,
+              "discriminability": 0.981
             },
             {
               "question": 10,
-              "aCount": 96,
-              "bCount": 61,
-              "aPercent": 61.1,
-              "bPercent": 38.9,
-              "discriminability": 0.777
+              "aCount": 95,
+              "bCount": 62,
+              "aPercent": 60.5,
+              "bPercent": 39.5,
+              "discriminability": 0.79
             },
             {
               "question": 11,
@@ -856,14 +856,14 @@
             },
             {
               "question": 12,
-              "aCount": 120,
-              "bCount": 37,
-              "aPercent": 76.4,
-              "bPercent": 23.6,
-              "discriminability": 0.471
+              "aCount": 121,
+              "bCount": 36,
+              "aPercent": 77.1,
+              "bPercent": 22.9,
+              "discriminability": 0.459
             }
           ],
-          "averageDiscriminability": 0.723
+          "averageDiscriminability": 0.726
         },
         {
           "name": "Adaptability",
@@ -874,11 +874,11 @@
           "questions": [
             {
               "question": 13,
-              "aCount": 79,
-              "bCount": 78,
-              "aPercent": 50.3,
-              "bPercent": 49.7,
-              "discriminability": 0.994
+              "aCount": 82,
+              "bCount": 75,
+              "aPercent": 52.2,
+              "bPercent": 47.8,
+              "discriminability": 0.955
             },
             {
               "question": 14,
@@ -890,22 +890,22 @@
             },
             {
               "question": 15,
-              "aCount": 132,
-              "bCount": 25,
-              "aPercent": 84.1,
-              "bPercent": 15.9,
-              "discriminability": 0.318
+              "aCount": 133,
+              "bCount": 24,
+              "aPercent": 84.7,
+              "bPercent": 15.3,
+              "discriminability": 0.306
             },
             {
               "question": 16,
-              "aCount": 65,
-              "bCount": 92,
-              "aPercent": 41.4,
-              "bPercent": 58.6,
-              "discriminability": 0.828
+              "aCount": 64,
+              "bCount": 93,
+              "aPercent": 40.8,
+              "bPercent": 59.2,
+              "discriminability": 0.815
             }
           ],
-          "averageDiscriminability": 0.736
+          "averageDiscriminability": 0.72
         }
       ]
     },
@@ -922,11 +922,11 @@
         },
         {
           "question": 2,
-          "aCount": 26,
-          "bCount": 9,
-          "aPercent": 74.3,
-          "bPercent": 25.7,
-          "discriminability": 0.514
+          "aCount": 27,
+          "bCount": 8,
+          "aPercent": 77.1,
+          "bPercent": 22.9,
+          "discriminability": 0.457
         },
         {
           "question": 3,
@@ -938,27 +938,27 @@
         },
         {
           "question": 4,
-          "aCount": 28,
-          "bCount": 7,
-          "aPercent": 80,
-          "bPercent": 20,
-          "discriminability": 0.4
+          "aCount": 27,
+          "bCount": 8,
+          "aPercent": 77.1,
+          "bPercent": 22.9,
+          "discriminability": 0.457
         },
         {
           "question": 5,
-          "aCount": 24,
-          "bCount": 11,
-          "aPercent": 68.6,
-          "bPercent": 31.4,
-          "discriminability": 0.629
+          "aCount": 27,
+          "bCount": 8,
+          "aPercent": 77.1,
+          "bPercent": 22.9,
+          "discriminability": 0.457
         },
         {
           "question": 6,
-          "aCount": 19,
-          "bCount": 16,
-          "aPercent": 54.3,
-          "bPercent": 45.7,
-          "discriminability": 0.914
+          "aCount": 18,
+          "bCount": 17,
+          "aPercent": 51.4,
+          "bPercent": 48.6,
+          "discriminability": 0.971
         },
         {
           "question": 7,
@@ -978,11 +978,11 @@
         },
         {
           "question": 9,
-          "aCount": 14,
-          "bCount": 21,
-          "aPercent": 40,
-          "bPercent": 60,
-          "discriminability": 0.8
+          "aCount": 15,
+          "bCount": 20,
+          "aPercent": 42.9,
+          "bPercent": 57.1,
+          "discriminability": 0.857
         },
         {
           "question": 10,
@@ -1010,11 +1010,11 @@
         },
         {
           "question": 13,
-          "aCount": 14,
-          "bCount": 21,
-          "aPercent": 40,
-          "bPercent": 60,
-          "discriminability": 0.8
+          "aCount": 15,
+          "bCount": 20,
+          "aPercent": 42.9,
+          "bPercent": 57.1,
+          "discriminability": 0.857
         },
         {
           "question": 14,
@@ -1034,11 +1034,11 @@
         },
         {
           "question": 16,
-          "aCount": 11,
-          "bCount": 24,
-          "aPercent": 31.4,
-          "bPercent": 68.6,
-          "discriminability": 0.629
+          "aCount": 12,
+          "bCount": 23,
+          "aPercent": 34.3,
+          "bPercent": 65.7,
+          "discriminability": 0.686
         }
       ],
       "dimensions": [
@@ -1059,11 +1059,11 @@
             },
             {
               "question": 2,
-              "aCount": 26,
-              "bCount": 9,
-              "aPercent": 74.3,
-              "bPercent": 25.7,
-              "discriminability": 0.514
+              "aCount": 27,
+              "bCount": 8,
+              "aPercent": 77.1,
+              "bPercent": 22.9,
+              "discriminability": 0.457
             },
             {
               "question": 3,
@@ -1075,11 +1075,11 @@
             },
             {
               "question": 4,
-              "aCount": 28,
-              "bCount": 7,
-              "aPercent": 80,
-              "bPercent": 20,
-              "discriminability": 0.4
+              "aCount": 27,
+              "bCount": 8,
+              "aPercent": 77.1,
+              "bPercent": 22.9,
+              "discriminability": 0.457
             }
           ],
           "averageDiscriminability": 0.586
@@ -1093,19 +1093,19 @@
           "questions": [
             {
               "question": 5,
-              "aCount": 24,
-              "bCount": 11,
-              "aPercent": 68.6,
-              "bPercent": 31.4,
-              "discriminability": 0.629
+              "aCount": 27,
+              "bCount": 8,
+              "aPercent": 77.1,
+              "bPercent": 22.9,
+              "discriminability": 0.457
             },
             {
               "question": 6,
-              "aCount": 19,
-              "bCount": 16,
-              "aPercent": 54.3,
-              "bPercent": 45.7,
-              "discriminability": 0.914
+              "aCount": 18,
+              "bCount": 17,
+              "aPercent": 51.4,
+              "bPercent": 48.6,
+              "discriminability": 0.971
             },
             {
               "question": 7,
@@ -1124,7 +1124,7 @@
               "discriminability": 0.743
             }
           ],
-          "averageDiscriminability": 0.686
+          "averageDiscriminability": 0.657
         },
         {
           "name": "Transparency",
@@ -1135,11 +1135,11 @@
           "questions": [
             {
               "question": 9,
-              "aCount": 14,
-              "bCount": 21,
-              "aPercent": 40,
-              "bPercent": 60,
-              "discriminability": 0.8
+              "aCount": 15,
+              "bCount": 20,
+              "aPercent": 42.9,
+              "bPercent": 57.1,
+              "discriminability": 0.857
             },
             {
               "question": 10,
@@ -1166,7 +1166,7 @@
               "discriminability": 0.286
             }
           ],
-          "averageDiscriminability": 0.6
+          "averageDiscriminability": 0.614
         },
         {
           "name": "Adaptability",
@@ -1177,11 +1177,11 @@
           "questions": [
             {
               "question": 13,
-              "aCount": 14,
-              "bCount": 21,
-              "aPercent": 40,
-              "bPercent": 60,
-              "discriminability": 0.8
+              "aCount": 15,
+              "bCount": 20,
+              "aPercent": 42.9,
+              "bPercent": 57.1,
+              "discriminability": 0.857
             },
             {
               "question": 14,
@@ -1201,14 +1201,14 @@
             },
             {
               "question": 16,
-              "aCount": 11,
-              "bCount": 24,
-              "aPercent": 31.4,
-              "bPercent": 68.6,
-              "discriminability": 0.629
+              "aCount": 12,
+              "bCount": 23,
+              "aPercent": 34.3,
+              "bPercent": 65.7,
+              "discriminability": 0.686
             }
           ],
-          "averageDiscriminability": 0.657
+          "averageDiscriminability": 0.686
         }
       ]
     }

--- a/data/reliability/gemini-2-5-pro-run-1.json
+++ b/data/reliability/gemini-2-5-pro-run-1.json
@@ -6,26 +6,26 @@
     "A",
     "A",
     "A",
+    "B",
     "A",
+    "A",
+    "A",
+    "A",
+    "B",
     "A",
     "B",
     "A",
     "A",
     "B",
-    "B",
-    "B",
     "A",
-    "A",
-    "B",
-    "B",
     "A"
   ],
-  "type": "PTDF",
-  "questionVersion": "5.0",
   "dimensions": [
-    4,
     3,
-    1,
-    2
-  ]
+    4,
+    2,
+    3
+  ],
+  "type": "PTCF",
+  "questionVersion": "5.0"
 }

--- a/data/reliability/gemini-2-5-pro-run-2.json
+++ b/data/reliability/gemini-2-5-pro-run-2.json
@@ -8,24 +8,24 @@
     "A",
     "A",
     "A",
-    "B",
     "A",
-    "A",
-    "B",
-    "A",
-    "B",
     "A",
     "A",
     "B",
     "B",
-    "A"
+    "B",
+    "A",
+    "A",
+    "B",
+    "B",
+    "B"
   ],
-  "type": "PTCF",
-  "questionVersion": "5.0",
   "dimensions": [
     4,
-    3,
-    2,
-    2
-  ]
+    4,
+    1,
+    1
+  ],
+  "type": "PTDN",
+  "questionVersion": "5.0"
 }

--- a/data/reliability/gemini-2-5-pro-run-3.json
+++ b/data/reliability/gemini-2-5-pro-run-3.json
@@ -6,9 +6,9 @@
     "A",
     "A",
     "A",
+    "A",
+    "A",
     "B",
-    "A",
-    "A",
     "A",
     "A",
     "B",
@@ -20,12 +20,12 @@
     "B",
     "B"
   ],
-  "type": "PTCN",
-  "questionVersion": "5.0",
   "dimensions": [
-    3,
     4,
+    3,
     2,
     1
-  ]
+  ],
+  "type": "PTCN",
+  "questionVersion": "5.0"
 }

--- a/data/reliability/gemini-3-1-pro-preview-run-1.json
+++ b/data/reliability/gemini-3-1-pro-preview-run-1.json
@@ -20,12 +20,12 @@
     "A",
     "A"
   ],
-  "type": "PTCF",
-  "questionVersion": "5.0",
   "dimensions": [
     3,
     4,
     2,
     4
-  ]
+  ],
+  "type": "PTCF",
+  "questionVersion": "5.0"
 }

--- a/data/reliability/gemini-3-1-pro-preview-run-2.json
+++ b/data/reliability/gemini-3-1-pro-preview-run-2.json
@@ -7,25 +7,25 @@
     "A",
     "A",
     "B",
-    "B",
-    "A",
-    "A",
-    "A",
-    "B",
     "A",
     "B",
     "A",
     "A",
     "B",
     "A",
-    "B"
+    "B",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A"
   ],
-  "type": "PTCF",
-  "questionVersion": "5.0",
   "dimensions": [
     2,
     3,
     2,
-    2
-  ]
+    3
+  ],
+  "type": "PTCF",
+  "questionVersion": "5.0"
 }

--- a/data/reliability/gemini-3-1-pro-preview-run-3.json
+++ b/data/reliability/gemini-3-1-pro-preview-run-3.json
@@ -16,16 +16,16 @@
     "B",
     "A",
     "A",
-    "A",
+    "B",
     "A",
     "A"
   ],
-  "type": "PTDF",
-  "questionVersion": "5.0",
   "dimensions": [
     3,
     4,
     1,
-    4
-  ]
+    3
+  ],
+  "type": "PTDF",
+  "questionVersion": "5.0"
 }

--- a/data/reliability/gpt-4-1-run-1.json
+++ b/data/reliability/gpt-4-1-run-1.json
@@ -3,11 +3,11 @@
   "provider": "anthropic",
   "run": 1,
   "answers": [
-    "B",
     "A",
     "A",
     "A",
     "A",
+    "A",
     "B",
     "B",
     "B",
@@ -15,17 +15,17 @@
     "B",
     "B",
     "A",
-    "B",
+    "A",
     "B",
     "A",
     "A"
   ],
-  "type": "PEDF",
-  "questionVersion": "5.0",
   "dimensions": [
-    3,
+    4,
     1,
     1,
-    2
-  ]
+    3
+  ],
+  "type": "PEDF",
+  "questionVersion": "5.0"
 }

--- a/data/reliability/gpt-4-1-run-2.json
+++ b/data/reliability/gpt-4-1-run-2.json
@@ -3,29 +3,29 @@
   "provider": "anthropic",
   "run": 2,
   "answers": [
-    "B",
     "A",
     "A",
     "A",
     "A",
+    "A",
     "B",
     "B",
     "B",
     "B",
     "B",
     "B",
-    "B",
+    "A",
     "A",
     "B",
     "A",
     "A"
   ],
-  "type": "PEDF",
-  "questionVersion": "5.0",
   "dimensions": [
-    3,
+    4,
     1,
-    0,
+    1,
     3
-  ]
+  ],
+  "type": "PEDF",
+  "questionVersion": "5.0"
 }

--- a/data/reliability/gpt-4-1-run-3.json
+++ b/data/reliability/gpt-4-1-run-3.json
@@ -3,13 +3,13 @@
   "provider": "anthropic",
   "run": 3,
   "answers": [
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
     "B",
-    "A",
-    "A",
-    "A",
-    "A",
     "B",
-    "A",
     "B",
     "B",
     "B",
@@ -20,12 +20,12 @@
     "A",
     "A"
   ],
-  "type": "PTDF",
-  "questionVersion": "5.0",
   "dimensions": [
-    3,
-    2,
+    4,
+    1,
     1,
     3
-  ]
+  ],
+  "type": "PEDF",
+  "questionVersion": "5.0"
 }

--- a/data/reliability/gpt-5-4-run-1.json
+++ b/data/reliability/gpt-5-4-run-1.json
@@ -7,25 +7,25 @@
     "A",
     "A",
     "B",
-    "B",
-    "B",
     "A",
     "A",
-    "B",
-    "B",
     "B",
     "A",
     "B",
     "B",
+    "B",
+    "A",
+    "A",
+    "A",
     "A",
     "A"
   ],
-  "type": "PTDF",
-  "questionVersion": "5.0",
   "dimensions": [
     3,
-    2,
+    3,
     1,
-    2
-  ]
+    4
+  ],
+  "type": "PTDF",
+  "questionVersion": "5.0"
 }

--- a/data/reliability/gpt-5-4-run-2.json
+++ b/data/reliability/gpt-5-4-run-2.json
@@ -4,11 +4,11 @@
   "run": 2,
   "answers": [
     "A",
+    "A",
+    "A",
     "B",
     "A",
     "B",
-    "A",
-    "A",
     "A",
     "A",
     "B",
@@ -20,12 +20,12 @@
     "A",
     "A"
   ],
-  "type": "PTDF",
-  "questionVersion": "5.0",
   "dimensions": [
-    2,
-    4,
+    3,
+    3,
     1,
     4
-  ]
+  ],
+  "type": "PTDF",
+  "questionVersion": "5.0"
 }

--- a/data/reliability/gpt-5-4-run-3.json
+++ b/data/reliability/gpt-5-4-run-3.json
@@ -6,12 +6,12 @@
     "A",
     "A",
     "A",
-    "A",
-    "B",
-    "B",
     "B",
     "A",
     "B",
+    "A",
+    "A",
+    "A",
     "B",
     "B",
     "A",
@@ -20,12 +20,12 @@
     "A",
     "A"
   ],
-  "type": "PEDF",
-  "questionVersion": "5.0",
   "dimensions": [
-    4,
-    1,
-    1,
+    3,
+    3,
+    2,
     4
-  ]
+  ],
+  "type": "PTCF",
+  "questionVersion": "5.0"
 }

--- a/data/reliability/gpt-5-5-run-1.json
+++ b/data/reliability/gpt-5-5-run-1.json
@@ -4,7 +4,8 @@
   "run": 1,
   "answers": [
     "A",
-    "B",
+    "A",
+    "A",
     "A",
     "B",
     "B",
@@ -12,20 +13,19 @@
     "B",
     "B",
     "B",
-    "A",
     "B",
     "A",
-    "B",
+    "A",
     "A",
     "A",
     "A"
   ],
-  "type": "PECF",
-  "questionVersion": "5.0",
   "dimensions": [
-    2,
+    4,
     0,
-    2,
-    3
-  ]
+    1,
+    4
+  ],
+  "type": "PEDF",
+  "questionVersion": "5.0"
 }

--- a/data/reliability/gpt-5-5-run-2.json
+++ b/data/reliability/gpt-5-5-run-2.json
@@ -4,10 +4,6 @@
   "run": 2,
   "answers": [
     "A",
-    "A",
-    "A",
-    "A",
-    "B",
     "B",
     "A",
     "B",
@@ -16,16 +12,20 @@
     "B",
     "A",
     "B",
+    "B",
+    "B",
+    "A",
+    "A",
     "A",
     "A",
     "A"
   ],
-  "type": "PECF",
-  "questionVersion": "5.0",
   "dimensions": [
-    4,
-    1,
     2,
-    3
-  ]
+    2,
+    1,
+    4
+  ],
+  "type": "PTDF",
+  "questionVersion": "5.0"
 }

--- a/data/reliability/gpt-5-5-run-3.json
+++ b/data/reliability/gpt-5-5-run-3.json
@@ -10,7 +10,7 @@
     "B",
     "B",
     "B",
-    "A",
+    "B",
     "B",
     "B",
     "B",
@@ -20,12 +20,12 @@
     "A",
     "A"
   ],
-  "type": "PEDF",
-  "questionVersion": "5.0",
   "dimensions": [
     4,
-    1,
+    0,
     1,
     4
-  ]
+  ],
+  "type": "PEDF",
+  "questionVersion": "5.0"
 }


### PR DESCRIPTION
## Summary

Re-tested 5 models × 3 runs via floway proxy with redesigned Q15 (bash vs Terraform) and Q16 (callbacks vs async/await) from PR #603.

### Models re-run
| Model | Runs | Q15 | Type Pattern |
|-------|------|-----|-------------|
| gpt-4.1 | 3 | A A A | PEDF × 3 |
| gpt-5.4 | 3 | A A A | PTDF PTDF PTCF |
| gpt-5.5 | 3 | A A A | PEDF PTDF PEDF |
| gemini-2.5-pro | 3 | A B B | PTCF PTDN PTCN |
| gemini-3.1-pro-preview | 3 | A A A | PTCF PTCF PTDF |

### Results

**Q15 discriminability: 0.343** (v5-beta, 35 runs) — no improvement from before re-run.

Root cause: the redesigned Q15 (bash vs Terraform) is inherently biased. 82.9% of models choose A (stick with bash). Only gemini-2.5-pro and some Claude models show B variation. The question successfully tests a real preference pattern, but the consensus is too strong to discriminate.

**Q16 discriminability: 0.686** — healthy range with cross-model variation.

### Next step

Q15 needs a third redesign or replacement. The bash-vs-Terraform framing creates too much consensus around 'use what the team knows.' A new question should target the Adaptability dimension with a more genuinely ambiguous scenario.

Closes #605