### PR TITLE
data: expand reliability baseline to 7 models (21 runs)

### DIFF
--- a/data/discriminability.json
+++ b/data/discriminability.json
@@ -1,135 +1,135 @@
 {
-  "generatedAt": "2026-06-30T10:23:02.848Z",
+  "generatedAt": "2026-06-30T11:09:33.072Z",
   "threshold": 0.6,
-  "totalRuns": 15,
+  "totalRuns": 21,
   "questions": [
     {
       "question": 1,
       "aCount": 2,
-      "bCount": 13,
-      "aPercent": 13.3,
-      "bPercent": 86.7,
-      "discriminability": 0.267
+      "bCount": 19,
+      "aPercent": 9.5,
+      "bPercent": 90.5,
+      "discriminability": 0.19
     },
     {
       "question": 2,
       "aCount": 3,
-      "bCount": 12,
-      "aPercent": 20,
-      "bPercent": 80,
-      "discriminability": 0.4
+      "bCount": 18,
+      "aPercent": 14.3,
+      "bPercent": 85.7,
+      "discriminability": 0.286
     },
     {
       "question": 3,
-      "aCount": 3,
-      "bCount": 12,
-      "aPercent": 20,
-      "bPercent": 80,
-      "discriminability": 0.4
+      "aCount": 5,
+      "bCount": 16,
+      "aPercent": 23.8,
+      "bPercent": 76.2,
+      "discriminability": 0.476
     },
     {
       "question": 4,
-      "aCount": 6,
-      "bCount": 9,
-      "aPercent": 40,
-      "bPercent": 60,
-      "discriminability": 0.8
-    },
-    {
-      "question": 5,
-      "aCount": 13,
-      "bCount": 2,
-      "aPercent": 86.7,
-      "bPercent": 13.3,
-      "discriminability": 0.267
-    },
-    {
-      "question": 6,
-      "aCount": 4,
-      "bCount": 11,
-      "aPercent": 26.7,
-      "bPercent": 73.3,
-      "discriminability": 0.533
-    },
-    {
-      "question": 7,
       "aCount": 7,
-      "bCount": 8,
-      "aPercent": 46.7,
-      "bPercent": 53.3,
-      "discriminability": 0.933
-    },
-    {
-      "question": 8,
-      "aCount": 3,
-      "bCount": 12,
-      "aPercent": 20,
-      "bPercent": 80,
-      "discriminability": 0.4
-    },
-    {
-      "question": 9,
-      "aCount": 8,
-      "bCount": 7,
-      "aPercent": 53.3,
-      "bPercent": 46.7,
-      "discriminability": 0.933
-    },
-    {
-      "question": 10,
-      "aCount": 6,
-      "bCount": 9,
-      "aPercent": 40,
-      "bPercent": 60,
-      "discriminability": 0.8
-    },
-    {
-      "question": 11,
-      "aCount": 4,
-      "bCount": 11,
-      "aPercent": 26.7,
-      "bPercent": 73.3,
-      "discriminability": 0.533
-    },
-    {
-      "question": 12,
-      "aCount": 5,
-      "bCount": 10,
+      "bCount": 14,
       "aPercent": 33.3,
       "bPercent": 66.7,
       "discriminability": 0.667
     },
     {
-      "question": 13,
+      "question": 5,
+      "aCount": 19,
+      "bCount": 2,
+      "aPercent": 90.5,
+      "bPercent": 9.5,
+      "discriminability": 0.19
+    },
+    {
+      "question": 6,
+      "aCount": 5,
+      "bCount": 16,
+      "aPercent": 23.8,
+      "bPercent": 76.2,
+      "discriminability": 0.476
+    },
+    {
+      "question": 7,
       "aCount": 10,
+      "bCount": 11,
+      "aPercent": 47.6,
+      "bPercent": 52.4,
+      "discriminability": 0.952
+    },
+    {
+      "question": 8,
+      "aCount": 3,
+      "bCount": 18,
+      "aPercent": 14.3,
+      "bPercent": 85.7,
+      "discriminability": 0.286
+    },
+    {
+      "question": 9,
+      "aCount": 8,
+      "bCount": 13,
+      "aPercent": 38.1,
+      "bPercent": 61.9,
+      "discriminability": 0.762
+    },
+    {
+      "question": 10,
+      "aCount": 11,
+      "bCount": 10,
+      "aPercent": 52.4,
+      "bPercent": 47.6,
+      "discriminability": 0.952
+    },
+    {
+      "question": 11,
+      "aCount": 4,
+      "bCount": 17,
+      "aPercent": 19,
+      "bPercent": 81,
+      "discriminability": 0.381
+    },
+    {
+      "question": 12,
+      "aCount": 10,
+      "bCount": 11,
+      "aPercent": 47.6,
+      "bPercent": 52.4,
+      "discriminability": 0.952
+    },
+    {
+      "question": 13,
+      "aCount": 16,
       "bCount": 5,
-      "aPercent": 66.7,
-      "bPercent": 33.3,
-      "discriminability": 0.667
+      "aPercent": 76.2,
+      "bPercent": 23.8,
+      "discriminability": 0.476
     },
     {
       "question": 14,
       "aCount": 7,
-      "bCount": 8,
-      "aPercent": 46.7,
-      "bPercent": 53.3,
-      "discriminability": 0.933
+      "bCount": 14,
+      "aPercent": 33.3,
+      "bPercent": 66.7,
+      "discriminability": 0.667
     },
     {
       "question": 15,
-      "aCount": 9,
+      "aCount": 15,
       "bCount": 6,
-      "aPercent": 60,
-      "bPercent": 40,
-      "discriminability": 0.8
+      "aPercent": 71.4,
+      "bPercent": 28.6,
+      "discriminability": 0.571
     },
     {
       "question": 16,
-      "aCount": 13,
-      "bCount": 2,
-      "aPercent": 86.7,
-      "bPercent": 13.3,
-      "discriminability": 0.267
+      "aCount": 18,
+      "bCount": 3,
+      "aPercent": 85.7,
+      "bPercent": 14.3,
+      "discriminability": 0.286
     }
   ],
   "dimensions": [
@@ -143,37 +143,37 @@
         {
           "question": 1,
           "aCount": 2,
-          "bCount": 13,
-          "aPercent": 13.3,
-          "bPercent": 86.7,
-          "discriminability": 0.267
+          "bCount": 19,
+          "aPercent": 9.5,
+          "bPercent": 90.5,
+          "discriminability": 0.19
         },
         {
           "question": 2,
           "aCount": 3,
-          "bCount": 12,
-          "aPercent": 20,
-          "bPercent": 80,
-          "discriminability": 0.4
+          "bCount": 18,
+          "aPercent": 14.3,
+          "bPercent": 85.7,
+          "discriminability": 0.286
         },
         {
           "question": 3,
-          "aCount": 3,
-          "bCount": 12,
-          "aPercent": 20,
-          "bPercent": 80,
-          "discriminability": 0.4
+          "aCount": 5,
+          "bCount": 16,
+          "aPercent": 23.8,
+          "bPercent": 76.2,
+          "discriminability": 0.476
         },
         {
           "question": 4,
-          "aCount": 6,
-          "bCount": 9,
-          "aPercent": 40,
-          "bPercent": 60,
-          "discriminability": 0.8
+          "aCount": 7,
+          "bCount": 14,
+          "aPercent": 33.3,
+          "bPercent": 66.7,
+          "discriminability": 0.667
         }
       ],
-      "averageDiscriminability": 0.467
+      "averageDiscriminability": 0.405
     },
     {
       "name": "Precision",
@@ -184,38 +184,38 @@
       "questions": [
         {
           "question": 5,
-          "aCount": 13,
+          "aCount": 19,
           "bCount": 2,
-          "aPercent": 86.7,
-          "bPercent": 13.3,
-          "discriminability": 0.267
+          "aPercent": 90.5,
+          "bPercent": 9.5,
+          "discriminability": 0.19
         },
         {
           "question": 6,
-          "aCount": 4,
-          "bCount": 11,
-          "aPercent": 26.7,
-          "bPercent": 73.3,
-          "discriminability": 0.533
+          "aCount": 5,
+          "bCount": 16,
+          "aPercent": 23.8,
+          "bPercent": 76.2,
+          "discriminability": 0.476
         },
         {
           "question": 7,
-          "aCount": 7,
-          "bCount": 8,
-          "aPercent": 46.7,
-          "bPercent": 53.3,
-          "discriminability": 0.933
+          "aCount": 10,
+          "bCount": 11,
+          "aPercent": 47.6,
+          "bPercent": 52.4,
+          "discriminability": 0.952
         },
         {
           "question": 8,
           "aCount": 3,
-          "bCount": 12,
-          "aPercent": 20,
-          "bPercent": 80,
-          "discriminability": 0.4
+          "bCount": 18,
+          "aPercent": 14.3,
+          "bPercent": 85.7,
+          "discriminability": 0.286
         }
       ],
-      "averageDiscriminability": 0.533
+      "averageDiscriminability": 0.476
     },
     {
       "name": "Transparency",
@@ -227,37 +227,37 @@
         {
           "question": 9,
           "aCount": 8,
-          "bCount": 7,
-          "aPercent": 53.3,
-          "bPercent": 46.7,
-          "discriminability": 0.933
+          "bCount": 13,
+          "aPercent": 38.1,
+          "bPercent": 61.9,
+          "discriminability": 0.762
         },
         {
           "question": 10,
-          "aCount": 6,
-          "bCount": 9,
-          "aPercent": 40,
-          "bPercent": 60,
-          "discriminability": 0.8
+          "aCount": 11,
+          "bCount": 10,
+          "aPercent": 52.4,
+          "bPercent": 47.6,
+          "discriminability": 0.952
         },
         {
           "question": 11,
           "aCount": 4,
-          "bCount": 11,
-          "aPercent": 26.7,
-          "bPercent": 73.3,
-          "discriminability": 0.533
+          "bCount": 17,
+          "aPercent": 19,
+          "bPercent": 81,
+          "discriminability": 0.381
         },
         {
           "question": 12,
-          "aCount": 5,
-          "bCount": 10,
-          "aPercent": 33.3,
-          "bPercent": 66.7,
-          "discriminability": 0.667
+          "aCount": 10,
+          "bCount": 11,
+          "aPercent": 47.6,
+          "bPercent": 52.4,
+          "discriminability": 0.952
         }
       ],
-      "averageDiscriminability": 0.733
+      "averageDiscriminability": 0.762
     },
     {
       "name": "Adaptability",
@@ -268,171 +268,171 @@
       "questions": [
         {
           "question": 13,
-          "aCount": 10,
+          "aCount": 16,
           "bCount": 5,
-          "aPercent": 66.7,
-          "bPercent": 33.3,
-          "discriminability": 0.667
+          "aPercent": 76.2,
+          "bPercent": 23.8,
+          "discriminability": 0.476
         },
         {
           "question": 14,
           "aCount": 7,
-          "bCount": 8,
-          "aPercent": 46.7,
-          "bPercent": 53.3,
-          "discriminability": 0.933
+          "bCount": 14,
+          "aPercent": 33.3,
+          "bPercent": 66.7,
+          "discriminability": 0.667
         },
         {
           "question": 15,
-          "aCount": 9,
+          "aCount": 15,
           "bCount": 6,
-          "aPercent": 60,
-          "bPercent": 40,
-          "discriminability": 0.8
+          "aPercent": 71.4,
+          "bPercent": 28.6,
+          "discriminability": 0.571
         },
         {
           "question": 16,
-          "aCount": 13,
-          "bCount": 2,
-          "aPercent": 86.7,
-          "bPercent": 13.3,
-          "discriminability": 0.267
+          "aCount": 18,
+          "bCount": 3,
+          "aPercent": 85.7,
+          "bPercent": 14.3,
+          "discriminability": 0.286
         }
       ],
-      "averageDiscriminability": 0.667
+      "averageDiscriminability": 0.5
     }
   ],
   "cohorts": {
     "all": {
-      "totalRuns": 15,
+      "totalRuns": 21,
       "questions": [
         {
           "question": 1,
           "aCount": 2,
-          "bCount": 13,
-          "aPercent": 13.3,
-          "bPercent": 86.7,
-          "discriminability": 0.267
+          "bCount": 19,
+          "aPercent": 9.5,
+          "bPercent": 90.5,
+          "discriminability": 0.19
         },
         {
           "question": 2,
           "aCount": 3,
-          "bCount": 12,
-          "aPercent": 20,
-          "bPercent": 80,
-          "discriminability": 0.4
+          "bCount": 18,
+          "aPercent": 14.3,
+          "bPercent": 85.7,
+          "discriminability": 0.286
         },
         {
           "question": 3,
-          "aCount": 3,
-          "bCount": 12,
-          "aPercent": 20,
-          "bPercent": 80,
-          "discriminability": 0.4
+          "aCount": 5,
+          "bCount": 16,
+          "aPercent": 23.8,
+          "bPercent": 76.2,
+          "discriminability": 0.476
         },
         {
           "question": 4,
-          "aCount": 6,
-          "bCount": 9,
-          "aPercent": 40,
-          "bPercent": 60,
-          "discriminability": 0.8
-        },
-        {
-          "question": 5,
-          "aCount": 13,
-          "bCount": 2,
-          "aPercent": 86.7,
-          "bPercent": 13.3,
-          "discriminability": 0.267
-        },
-        {
-          "question": 6,
-          "aCount": 4,
-          "bCount": 11,
-          "aPercent": 26.7,
-          "bPercent": 73.3,
-          "discriminability": 0.533
-        },
-        {
-          "question": 7,
           "aCount": 7,
-          "bCount": 8,
-          "aPercent": 46.7,
-          "bPercent": 53.3,
-          "discriminability": 0.933
-        },
-        {
-          "question": 8,
-          "aCount": 3,
-          "bCount": 12,
-          "aPercent": 20,
-          "bPercent": 80,
-          "discriminability": 0.4
-        },
-        {
-          "question": 9,
-          "aCount": 8,
-          "bCount": 7,
-          "aPercent": 53.3,
-          "bPercent": 46.7,
-          "discriminability": 0.933
-        },
-        {
-          "question": 10,
-          "aCount": 6,
-          "bCount": 9,
-          "aPercent": 40,
-          "bPercent": 60,
-          "discriminability": 0.8
-        },
-        {
-          "question": 11,
-          "aCount": 4,
-          "bCount": 11,
-          "aPercent": 26.7,
-          "bPercent": 73.3,
-          "discriminability": 0.533
-        },
-        {
-          "question": 12,
-          "aCount": 5,
-          "bCount": 10,
+          "bCount": 14,
           "aPercent": 33.3,
           "bPercent": 66.7,
           "discriminability": 0.667
         },
         {
-          "question": 13,
+          "question": 5,
+          "aCount": 19,
+          "bCount": 2,
+          "aPercent": 90.5,
+          "bPercent": 9.5,
+          "discriminability": 0.19
+        },
+        {
+          "question": 6,
+          "aCount": 5,
+          "bCount": 16,
+          "aPercent": 23.8,
+          "bPercent": 76.2,
+          "discriminability": 0.476
+        },
+        {
+          "question": 7,
           "aCount": 10,
+          "bCount": 11,
+          "aPercent": 47.6,
+          "bPercent": 52.4,
+          "discriminability": 0.952
+        },
+        {
+          "question": 8,
+          "aCount": 3,
+          "bCount": 18,
+          "aPercent": 14.3,
+          "bPercent": 85.7,
+          "discriminability": 0.286
+        },
+        {
+          "question": 9,
+          "aCount": 8,
+          "bCount": 13,
+          "aPercent": 38.1,
+          "bPercent": 61.9,
+          "discriminability": 0.762
+        },
+        {
+          "question": 10,
+          "aCount": 11,
+          "bCount": 10,
+          "aPercent": 52.4,
+          "bPercent": 47.6,
+          "discriminability": 0.952
+        },
+        {
+          "question": 11,
+          "aCount": 4,
+          "bCount": 17,
+          "aPercent": 19,
+          "bPercent": 81,
+          "discriminability": 0.381
+        },
+        {
+          "question": 12,
+          "aCount": 10,
+          "bCount": 11,
+          "aPercent": 47.6,
+          "bPercent": 52.4,
+          "discriminability": 0.952
+        },
+        {
+          "question": 13,
+          "aCount": 16,
           "bCount": 5,
-          "aPercent": 66.7,
-          "bPercent": 33.3,
-          "discriminability": 0.667
+          "aPercent": 76.2,
+          "bPercent": 23.8,
+          "discriminability": 0.476
         },
         {
           "question": 14,
           "aCount": 7,
-          "bCount": 8,
-          "aPercent": 46.7,
-          "bPercent": 53.3,
-          "discriminability": 0.933
+          "bCount": 14,
+          "aPercent": 33.3,
+          "bPercent": 66.7,
+          "discriminability": 0.667
         },
         {
           "question": 15,
-          "aCount": 9,
+          "aCount": 15,
           "bCount": 6,
-          "aPercent": 60,
-          "bPercent": 40,
-          "discriminability": 0.8
+          "aPercent": 71.4,
+          "bPercent": 28.6,
+          "discriminability": 0.571
         },
         {
           "question": 16,
-          "aCount": 13,
-          "bCount": 2,
-          "aPercent": 86.7,
-          "bPercent": 13.3,
-          "discriminability": 0.267
+          "aCount": 18,
+          "bCount": 3,
+          "aPercent": 85.7,
+          "bPercent": 14.3,
+          "discriminability": 0.286
         }
       ],
       "dimensions": [
@@ -446,37 +446,37 @@
             {
               "question": 1,
               "aCount": 2,
-              "bCount": 13,
-              "aPercent": 13.3,
-              "bPercent": 86.7,
-              "discriminability": 0.267
+              "bCount": 19,
+              "aPercent": 9.5,
+              "bPercent": 90.5,
+              "discriminability": 0.19
             },
             {
               "question": 2,
               "aCount": 3,
-              "bCount": 12,
-              "aPercent": 20,
-              "bPercent": 80,
-              "discriminability": 0.4
+              "bCount": 18,
+              "aPercent": 14.3,
+              "bPercent": 85.7,
+              "discriminability": 0.286
             },
             {
               "question": 3,
-              "aCount": 3,
-              "bCount": 12,
-              "aPercent": 20,
-              "bPercent": 80,
-              "discriminability": 0.4
+              "aCount": 5,
+              "bCount": 16,
+              "aPercent": 23.8,
+              "bPercent": 76.2,
+              "discriminability": 0.476
             },
             {
               "question": 4,
-              "aCount": 6,
-              "bCount": 9,
-              "aPercent": 40,
-              "bPercent": 60,
-              "discriminability": 0.8
+              "aCount": 7,
+              "bCount": 14,
+              "aPercent": 33.3,
+              "bPercent": 66.7,
+              "discriminability": 0.667
             }
           ],
-          "averageDiscriminability": 0.467
+          "averageDiscriminability": 0.405
         },
         {
           "name": "Precision",
@@ -487,38 +487,38 @@
           "questions": [
             {
               "question": 5,
-              "aCount": 13,
+              "aCount": 19,
               "bCount": 2,
-              "aPercent": 86.7,
-              "bPercent": 13.3,
-              "discriminability": 0.267
+              "aPercent": 90.5,
+              "bPercent": 9.5,
+              "discriminability": 0.19
             },
             {
               "question": 6,
-              "aCount": 4,
-              "bCount": 11,
-              "aPercent": 26.7,
-              "bPercent": 73.3,
-              "discriminability": 0.533
+              "aCount": 5,
+              "bCount": 16,
+              "aPercent": 23.8,
+              "bPercent": 76.2,
+              "discriminability": 0.476
             },
             {
               "question": 7,
-              "aCount": 7,
-              "bCount": 8,
-              "aPercent": 46.7,
-              "bPercent": 53.3,
-              "discriminability": 0.933
+              "aCount": 10,
+              "bCount": 11,
+              "aPercent": 47.6,
+              "bPercent": 52.4,
+              "discriminability": 0.952
             },
             {
               "question": 8,
               "aCount": 3,
-              "bCount": 12,
-              "aPercent": 20,
-              "bPercent": 80,
-              "discriminability": 0.4
+              "bCount": 18,
+              "aPercent": 14.3,
+              "bPercent": 85.7,
+              "discriminability": 0.286
             }
           ],
-          "averageDiscriminability": 0.533
+          "averageDiscriminability": 0.476
         },
         {
           "name": "Transparency",
@@ -530,37 +530,37 @@
             {
               "question": 9,
               "aCount": 8,
-              "bCount": 7,
-              "aPercent": 53.3,
-              "bPercent": 46.7,
-              "discriminability": 0.933
+              "bCount": 13,
+              "aPercent": 38.1,
+              "bPercent": 61.9,
+              "discriminability": 0.762
             },
             {
               "question": 10,
-              "aCount": 6,
-              "bCount": 9,
-              "aPercent": 40,
-              "bPercent": 60,
-              "discriminability": 0.8
+              "aCount": 11,
+              "bCount": 10,
+              "aPercent": 52.4,
+              "bPercent": 47.6,
+              "discriminability": 0.952
             },
             {
               "question": 11,
               "aCount": 4,
-              "bCount": 11,
-              "aPercent": 26.7,
-              "bPercent": 73.3,
-              "discriminability": 0.533
+              "bCount": 17,
+              "aPercent": 19,
+              "bPercent": 81,
+              "discriminability": 0.381
             },
             {
               "question": 12,
-              "aCount": 5,
-              "bCount": 10,
-              "aPercent": 33.3,
-              "bPercent": 66.7,
-              "discriminability": 0.667
+              "aCount": 10,
+              "bCount": 11,
+              "aPercent": 47.6,
+              "bPercent": 52.4,
+              "discriminability": 0.952
             }
           ],
-          "averageDiscriminability": 0.733
+          "averageDiscriminability": 0.762
         },
         {
           "name": "Adaptability",
@@ -571,171 +571,171 @@
           "questions": [
             {
               "question": 13,
-              "aCount": 10,
+              "aCount": 16,
               "bCount": 5,
-              "aPercent": 66.7,
-              "bPercent": 33.3,
-              "discriminability": 0.667
+              "aPercent": 76.2,
+              "bPercent": 23.8,
+              "discriminability": 0.476
             },
             {
               "question": 14,
               "aCount": 7,
-              "bCount": 8,
-              "aPercent": 46.7,
-              "bPercent": 53.3,
-              "discriminability": 0.933
+              "bCount": 14,
+              "aPercent": 33.3,
+              "bPercent": 66.7,
+              "discriminability": 0.667
             },
             {
               "question": 15,
-              "aCount": 9,
+              "aCount": 15,
               "bCount": 6,
-              "aPercent": 60,
-              "bPercent": 40,
-              "discriminability": 0.8
+              "aPercent": 71.4,
+              "bPercent": 28.6,
+              "discriminability": 0.571
             },
             {
               "question": 16,
-              "aCount": 13,
-              "bCount": 2,
-              "aPercent": 86.7,
-              "bPercent": 13.3,
-              "discriminability": 0.267
+              "aCount": 18,
+              "bCount": 3,
+              "aPercent": 85.7,
+              "bPercent": 14.3,
+              "discriminability": 0.286
             }
           ],
-          "averageDiscriminability": 0.667
+          "averageDiscriminability": 0.5
         }
       ]
     },
     "v4": {
-      "totalRuns": 15,
+      "totalRuns": 21,
       "questions": [
         {
           "question": 1,
           "aCount": 2,
-          "bCount": 13,
-          "aPercent": 13.3,
-          "bPercent": 86.7,
-          "discriminability": 0.267
+          "bCount": 19,
+          "aPercent": 9.5,
+          "bPercent": 90.5,
+          "discriminability": 0.19
         },
         {
           "question": 2,
           "aCount": 3,
-          "bCount": 12,
-          "aPercent": 20,
-          "bPercent": 80,
-          "discriminability": 0.4
+          "bCount": 18,
+          "aPercent": 14.3,
+          "bPercent": 85.7,
+          "discriminability": 0.286
         },
         {
           "question": 3,
-          "aCount": 3,
-          "bCount": 12,
-          "aPercent": 20,
-          "bPercent": 80,
-          "discriminability": 0.4
+          "aCount": 5,
+          "bCount": 16,
+          "aPercent": 23.8,
+          "bPercent": 76.2,
+          "discriminability": 0.476
         },
         {
           "question": 4,
-          "aCount": 6,
-          "bCount": 9,
-          "aPercent": 40,
-          "bPercent": 60,
-          "discriminability": 0.8
-        },
-        {
-          "question": 5,
-          "aCount": 13,
-          "bCount": 2,
-          "aPercent": 86.7,
-          "bPercent": 13.3,
-          "discriminability": 0.267
-        },
-        {
-          "question": 6,
-          "aCount": 4,
-          "bCount": 11,
-          "aPercent": 26.7,
-          "bPercent": 73.3,
-          "discriminability": 0.533
-        },
-        {
-          "question": 7,
           "aCount": 7,
-          "bCount": 8,
-          "aPercent": 46.7,
-          "bPercent": 53.3,
-          "discriminability": 0.933
-        },
-        {
-          "question": 8,
-          "aCount": 3,
-          "bCount": 12,
-          "aPercent": 20,
-          "bPercent": 80,
-          "discriminability": 0.4
-        },
-        {
-          "question": 9,
-          "aCount": 8,
-          "bCount": 7,
-          "aPercent": 53.3,
-          "bPercent": 46.7,
-          "discriminability": 0.933
-        },
-        {
-          "question": 10,
-          "aCount": 6,
-          "bCount": 9,
-          "aPercent": 40,
-          "bPercent": 60,
-          "discriminability": 0.8
-        },
-        {
-          "question": 11,
-          "aCount": 4,
-          "bCount": 11,
-          "aPercent": 26.7,
-          "bPercent": 73.3,
-          "discriminability": 0.533
-        },
-        {
-          "question": 12,
-          "aCount": 5,
-          "bCount": 10,
+          "bCount": 14,
           "aPercent": 33.3,
           "bPercent": 66.7,
           "discriminability": 0.667
         },
         {
-          "question": 13,
+          "question": 5,
+          "aCount": 19,
+          "bCount": 2,
+          "aPercent": 90.5,
+          "bPercent": 9.5,
+          "discriminability": 0.19
+        },
+        {
+          "question": 6,
+          "aCount": 5,
+          "bCount": 16,
+          "aPercent": 23.8,
+          "bPercent": 76.2,
+          "discriminability": 0.476
+        },
+        {
+          "question": 7,
           "aCount": 10,
+          "bCount": 11,
+          "aPercent": 47.6,
+          "bPercent": 52.4,
+          "discriminability": 0.952
+        },
+        {
+          "question": 8,
+          "aCount": 3,
+          "bCount": 18,
+          "aPercent": 14.3,
+          "bPercent": 85.7,
+          "discriminability": 0.286
+        },
+        {
+          "question": 9,
+          "aCount": 8,
+          "bCount": 13,
+          "aPercent": 38.1,
+          "bPercent": 61.9,
+          "discriminability": 0.762
+        },
+        {
+          "question": 10,
+          "aCount": 11,
+          "bCount": 10,
+          "aPercent": 52.4,
+          "bPercent": 47.6,
+          "discriminability": 0.952
+        },
+        {
+          "question": 11,
+          "aCount": 4,
+          "bCount": 17,
+          "aPercent": 19,
+          "bPercent": 81,
+          "discriminability": 0.381
+        },
+        {
+          "question": 12,
+          "aCount": 10,
+          "bCount": 11,
+          "aPercent": 47.6,
+          "bPercent": 52.4,
+          "discriminability": 0.952
+        },
+        {
+          "question": 13,
+          "aCount": 16,
           "bCount": 5,
-          "aPercent": 66.7,
-          "bPercent": 33.3,
-          "discriminability": 0.667
+          "aPercent": 76.2,
+          "bPercent": 23.8,
+          "discriminability": 0.476
         },
         {
           "question": 14,
           "aCount": 7,
-          "bCount": 8,
-          "aPercent": 46.7,
-          "bPercent": 53.3,
-          "discriminability": 0.933
+          "bCount": 14,
+          "aPercent": 33.3,
+          "bPercent": 66.7,
+          "discriminability": 0.667
         },
         {
           "question": 15,
-          "aCount": 9,
+          "aCount": 15,
           "bCount": 6,
-          "aPercent": 60,
-          "bPercent": 40,
-          "discriminability": 0.8
+          "aPercent": 71.4,
+          "bPercent": 28.6,
+          "discriminability": 0.571
         },
         {
           "question": 16,
-          "aCount": 13,
-          "bCount": 2,
-          "aPercent": 86.7,
-          "bPercent": 13.3,
-          "discriminability": 0.267
+          "aCount": 18,
+          "bCount": 3,
+          "aPercent": 85.7,
+          "bPercent": 14.3,
+          "discriminability": 0.286
         }
       ],
       "dimensions": [
@@ -749,37 +749,37 @@
             {
               "question": 1,
               "aCount": 2,
-              "bCount": 13,
-              "aPercent": 13.3,
-              "bPercent": 86.7,
-              "discriminability": 0.267
+              "bCount": 19,
+              "aPercent": 9.5,
+              "bPercent": 90.5,
+              "discriminability": 0.19
             },
             {
               "question": 2,
               "aCount": 3,
-              "bCount": 12,
-              "aPercent": 20,
-              "bPercent": 80,
-              "discriminability": 0.4
+              "bCount": 18,
+              "aPercent": 14.3,
+              "bPercent": 85.7,
+              "discriminability": 0.286
             },
             {
               "question": 3,
-              "aCount": 3,
-              "bCount": 12,
-              "aPercent": 20,
-              "bPercent": 80,
-              "discriminability": 0.4
+              "aCount": 5,
+              "bCount": 16,
+              "aPercent": 23.8,
+              "bPercent": 76.2,
+              "discriminability": 0.476
             },
             {
               "question": 4,
-              "aCount": 6,
-              "bCount": 9,
-              "aPercent": 40,
-              "bPercent": 60,
-              "discriminability": 0.8
+              "aCount": 7,
+              "bCount": 14,
+              "aPercent": 33.3,
+              "bPercent": 66.7,
+              "discriminability": 0.667
             }
           ],
-          "averageDiscriminability": 0.467
+          "averageDiscriminability": 0.405
         },
         {
           "name": "Precision",
@@ -790,38 +790,38 @@
           "questions": [
             {
               "question": 5,
-              "aCount": 13,
+              "aCount": 19,
               "bCount": 2,
-              "aPercent": 86.7,
-              "bPercent": 13.3,
-              "discriminability": 0.267
+              "aPercent": 90.5,
+              "bPercent": 9.5,
+              "discriminability": 0.19
             },
             {
               "question": 6,
-              "aCount": 4,
-              "bCount": 11,
-              "aPercent": 26.7,
-              "bPercent": 73.3,
-              "discriminability": 0.533
+              "aCount": 5,
+              "bCount": 16,
+              "aPercent": 23.8,
+              "bPercent": 76.2,
+              "discriminability": 0.476
             },
             {
               "question": 7,
-              "aCount": 7,
-              "bCount": 8,
-              "aPercent": 46.7,
-              "bPercent": 53.3,
-              "discriminability": 0.933
+              "aCount": 10,
+              "bCount": 11,
+              "aPercent": 47.6,
+              "bPercent": 52.4,
+              "discriminability": 0.952
             },
             {
               "question": 8,
               "aCount": 3,
-              "bCount": 12,
-              "aPercent": 20,
-              "bPercent": 80,
-              "discriminability": 0.4
+              "bCount": 18,
+              "aPercent": 14.3,
+              "bPercent": 85.7,
+              "discriminability": 0.286
             }
           ],
-          "averageDiscriminability": 0.533
+          "averageDiscriminability": 0.476
         },
         {
           "name": "Transparency",
@@ -833,37 +833,37 @@
             {
               "question": 9,
               "aCount": 8,
-              "bCount": 7,
-              "aPercent": 53.3,
-              "bPercent": 46.7,
-              "discriminability": 0.933
+              "bCount": 13,
+              "aPercent": 38.1,
+              "bPercent": 61.9,
+              "discriminability": 0.762
             },
             {
               "question": 10,
-              "aCount": 6,
-              "bCount": 9,
-              "aPercent": 40,
-              "bPercent": 60,
-              "discriminability": 0.8
+              "aCount": 11,
+              "bCount": 10,
+              "aPercent": 52.4,
+              "bPercent": 47.6,
+              "discriminability": 0.952
             },
             {
               "question": 11,
               "aCount": 4,
-              "bCount": 11,
-              "aPercent": 26.7,
-              "bPercent": 73.3,
-              "discriminability": 0.533
+              "bCount": 17,
+              "aPercent": 19,
+              "bPercent": 81,
+              "discriminability": 0.381
             },
             {
               "question": 12,
-              "aCount": 5,
-              "bCount": 10,
-              "aPercent": 33.3,
-              "bPercent": 66.7,
-              "discriminability": 0.667
+              "aCount": 10,
+              "bCount": 11,
+              "aPercent": 47.6,
+              "bPercent": 52.4,
+              "discriminability": 0.952
             }
           ],
-          "averageDiscriminability": 0.733
+          "averageDiscriminability": 0.762
         },
         {
           "name": "Adaptability",
@@ -874,38 +874,38 @@
           "questions": [
             {
               "question": 13,
-              "aCount": 10,
+              "aCount": 16,
               "bCount": 5,
-              "aPercent": 66.7,
-              "bPercent": 33.3,
-              "discriminability": 0.667
+              "aPercent": 76.2,
+              "bPercent": 23.8,
+              "discriminability": 0.476
             },
             {
               "question": 14,
               "aCount": 7,
-              "bCount": 8,
-              "aPercent": 46.7,
-              "bPercent": 53.3,
-              "discriminability": 0.933
+              "bCount": 14,
+              "aPercent": 33.3,
+              "bPercent": 66.7,
+              "discriminability": 0.667
             },
             {
               "question": 15,
-              "aCount": 9,
+              "aCount": 15,
               "bCount": 6,
-              "aPercent": 60,
-              "bPercent": 40,
-              "discriminability": 0.8
+              "aPercent": 71.4,
+              "bPercent": 28.6,
+              "discriminability": 0.571
             },
             {
               "question": 16,
-              "aCount": 13,
-              "bCount": 2,
-              "aPercent": 86.7,
-              "bPercent": 13.3,
-              "discriminability": 0.267
+              "aCount": 18,
+              "bCount": 3,
+              "aPercent": 85.7,
+              "bPercent": 14.3,
+              "discriminability": 0.286
             }
           ],
-          "averageDiscriminability": 0.667
+          "averageDiscriminability": 0.5
         }
       ]
     }

--- a/data/reliability/gemini-2-5-pro-run-1.json
+++ b/data/reliability/gemini-2-5-pro-run-1.json
@@ -1,0 +1,31 @@
+{
+  "model": "gemini-2.5-pro",
+  "provider": "anthropic",
+  "run": 1,
+  "answers": [
+    "B",
+    "B",
+    "B",
+    "B",
+    "A",
+    "A",
+    "A",
+    "B",
+    "B",
+    "A",
+    "B",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A"
+  ],
+  "dimensions": [
+    0,
+    3,
+    2,
+    3
+  ],
+  "type": "RTCF",
+  "questionVersion": "5.0"
+}

--- a/data/reliability/gemini-2-5-pro-run-2.json
+++ b/data/reliability/gemini-2-5-pro-run-2.json
@@ -1,0 +1,31 @@
+{
+  "model": "gemini-2.5-pro",
+  "provider": "anthropic",
+  "run": 2,
+  "answers": [
+    "B",
+    "B",
+    "B",
+    "B",
+    "A",
+    "B",
+    "A",
+    "B",
+    "B",
+    "A",
+    "B",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A"
+  ],
+  "dimensions": [
+    0,
+    2,
+    2,
+    3
+  ],
+  "type": "RTCF",
+  "questionVersion": "5.0"
+}

--- a/data/reliability/gemini-2-5-pro-run-3.json
+++ b/data/reliability/gemini-2-5-pro-run-3.json
@@ -1,0 +1,31 @@
+{
+  "model": "gemini-2.5-pro",
+  "provider": "anthropic",
+  "run": 3,
+  "answers": [
+    "B",
+    "B",
+    "B",
+    "B",
+    "A",
+    "B",
+    "A",
+    "B",
+    "B",
+    "A",
+    "B",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A"
+  ],
+  "dimensions": [
+    0,
+    2,
+    2,
+    3
+  ],
+  "type": "RTCF",
+  "questionVersion": "5.0"
+}

--- a/data/reliability/gpt-4-1-run-1.json
+++ b/data/reliability/gpt-4-1-run-1.json
@@ -1,0 +1,31 @@
+{
+  "model": "gpt-4.1",
+  "provider": "anthropic",
+  "run": 1,
+  "answers": [
+    "B",
+    "B",
+    "A",
+    "B",
+    "A",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A"
+  ],
+  "dimensions": [
+    1,
+    1,
+    1,
+    3
+  ],
+  "type": "REDF",
+  "questionVersion": "5.0"
+}

--- a/data/reliability/gpt-4-1-run-2.json
+++ b/data/reliability/gpt-4-1-run-2.json
@@ -1,0 +1,31 @@
+{
+  "model": "gpt-4.1",
+  "provider": "anthropic",
+  "run": 2,
+  "answers": [
+    "B",
+    "B",
+    "A",
+    "A",
+    "A",
+    "B",
+    "B",
+    "B",
+    "B",
+    "A",
+    "B",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A"
+  ],
+  "dimensions": [
+    2,
+    1,
+    2,
+    3
+  ],
+  "type": "PECF",
+  "questionVersion": "5.0"
+}

--- a/data/reliability/gpt-4-1-run-3.json
+++ b/data/reliability/gpt-4-1-run-3.json
@@ -1,0 +1,31 @@
+{
+  "model": "gpt-4.1",
+  "provider": "anthropic",
+  "run": 3,
+  "answers": [
+    "B",
+    "B",
+    "B",
+    "B",
+    "A",
+    "B",
+    "B",
+    "B",
+    "B",
+    "A",
+    "B",
+    "B",
+    "A",
+    "B",
+    "A",
+    "B"
+  ],
+  "dimensions": [
+    0,
+    1,
+    1,
+    2
+  ],
+  "type": "REDF",
+  "questionVersion": "5.0"
+}


### PR DESCRIPTION
## Summary

Expand the reliability dataset from 5 models (15 runs) to 7 models (21 runs) by adding:
- **gpt-4.1** (3 runs)
- **gemini-2.5-pro** (3 runs)

## Updated Discriminability Results

| Q | Disc | Bias | Status | Dimension |
|---|------|------|--------|-----------|
| Q1 | 0.190 | 90.5% B | ❌ Critical | Autonomy |
| Q2 | 0.286 | 85.7% B | ❌ | Autonomy |
| Q3 | 0.476 | 76.2% B | ❌ | Autonomy |
| Q4 | **0.667** | 33% A | ✅ | Autonomy |
| Q5 | 0.190 | 90.5% A | ❌ Critical | Precision |
| Q6 | 0.476 | 76.2% B | ❌ | Precision |
| Q7 | **0.952** | 48% A | ✅ | Precision |
| Q8 | 0.286 | 85.7% B | ❌ | Precision |
| Q9 | **0.762** | 38% A | ✅ | Transparency |
| Q10 | **0.952** | 52% A | ✅ | Transparency |
| Q11 | 0.381 | 81% B | ❌ | Transparency |
| Q12 | **0.952** | 48% A | ✅ | Transparency |
| Q13 | 0.476 | 76.2% A | ❌ ⬇️ | Adaptability |
| Q14 | **0.667** | 33% A | ✅ | Adaptability |
| Q15 | 0.571 | 71.4% A | ❌ ⬇️ | Adaptability |
| Q16 | 0.286 | 85.7% A | ❌ | Adaptability |

**6/16 above threshold** (was 8/16 with 5 models).

## Key Findings

1. gpt-4.1 and gemini-2.5-pro are highly consistent (low intra-model variance)
2. They agree on most biased questions, amplifying existing trends
3. Q13 and Q15 dropped below threshold — the 5-model split was partly lucky
4. **Only the Transparency dimension is healthy** (3/4 above threshold)
5. Autonomy and Precision each have only 1 working question

## New Model Patterns

**gpt-4.1:** Extremely B-biased on Autonomy (all B), mixed on Transparency (A-leaning Q10, B-leaning Q9/Q11), strongly A on Adaptability Q13/Q15/Q16.

**gemini-2.5-pro:** Nearly identical to gpt-4.1 on most questions. Very low variance (only 1 answer differs across 3 runs).

## Implications

The 5-model baseline was too optimistic. With broader model diversity, the instrument needs significant redesign on 3/4 dimensions. Separate issues track Q1 (#629) and Q16 (#627). Q5 has failed 3 redesign attempts today (see #626 comments).