### PR TITLE
data: expand reliability corpus to 7 models (gemini-2.5-pro + gpt-4.1)

### DIFF
--- a/data/discriminability.json
+++ b/data/discriminability.json
@@ -1,151 +1,151 @@
 {
-  "generatedAt": "2026-07-03T13:15:50.484Z",
+  "generatedAt": "2026-07-04T00:42:06.527Z",
   "threshold": 0.6,
-  "totalRuns": 15,
+  "totalRuns": 21,
   "questions": [
     {
       "question": 1,
-      "aCount": 9,
+      "aCount": 15,
       "bCount": 6,
-      "aPercent": 60,
-      "bPercent": 40,
-      "discriminability": 0.777,
-      "ratioDiscriminability": 0.8
+      "aPercent": 71.4,
+      "bPercent": 28.6,
+      "discriminability": 0.75,
+      "ratioDiscriminability": 0.571
     },
     {
       "question": 2,
-      "aCount": 6,
-      "bCount": 9,
-      "aPercent": 40,
-      "bPercent": 60,
-      "discriminability": 0.777,
-      "ratioDiscriminability": 0.8
+      "aCount": 10,
+      "bCount": 11,
+      "aPercent": 47.6,
+      "bPercent": 52.4,
+      "discriminability": 0.785,
+      "ratioDiscriminability": 0.952
     },
     {
       "question": 3,
       "aCount": 3,
-      "bCount": 12,
-      "aPercent": 20,
-      "bPercent": 80,
-      "discriminability": 0.8,
-      "ratioDiscriminability": 0.4
+      "bCount": 18,
+      "aPercent": 14.3,
+      "bPercent": 85.7,
+      "discriminability": 0.7,
+      "ratioDiscriminability": 0.286
     },
     {
       "question": 4,
-      "aCount": 8,
-      "bCount": 7,
-      "aPercent": 53.3,
-      "bPercent": 46.7,
-      "discriminability": 0.904,
-      "ratioDiscriminability": 0.933
+      "aCount": 10,
+      "bCount": 11,
+      "aPercent": 47.6,
+      "bPercent": 52.4,
+      "discriminability": 0.862,
+      "ratioDiscriminability": 0.952
     },
     {
       "question": 5,
-      "aCount": 10,
+      "aCount": 16,
       "bCount": 5,
-      "aPercent": 66.7,
-      "bPercent": 33.3,
-      "discriminability": 0.596,
-      "ratioDiscriminability": 0.667
+      "aPercent": 76.2,
+      "bPercent": 23.8,
+      "discriminability": 0.587,
+      "ratioDiscriminability": 0.476
     },
     {
       "question": 6,
-      "aCount": 8,
-      "bCount": 7,
-      "aPercent": 53.3,
-      "bPercent": 46.7,
-      "discriminability": 0.68,
-      "ratioDiscriminability": 0.933
+      "aCount": 10,
+      "bCount": 11,
+      "aPercent": 47.6,
+      "bPercent": 52.4,
+      "discriminability": 0.7,
+      "ratioDiscriminability": 0.952
     },
     {
       "question": 7,
-      "aCount": 8,
-      "bCount": 7,
-      "aPercent": 53.3,
-      "bPercent": 46.7,
-      "discriminability": 0.68,
-      "ratioDiscriminability": 0.933
+      "aCount": 12,
+      "bCount": 9,
+      "aPercent": 57.1,
+      "bPercent": 42.9,
+      "discriminability": 0.687,
+      "ratioDiscriminability": 0.857
     },
     {
       "question": 8,
-      "aCount": 12,
+      "aCount": 18,
       "bCount": 3,
-      "aPercent": 80,
-      "bPercent": 20,
-      "discriminability": 0.533,
-      "ratioDiscriminability": 0.4
+      "aPercent": 85.7,
+      "bPercent": 14.3,
+      "discriminability": 0.486,
+      "ratioDiscriminability": 0.286
     },
     {
       "question": 9,
-      "aCount": 11,
+      "aCount": 17,
       "bCount": 4,
-      "aPercent": 73.3,
-      "bPercent": 26.7,
-      "discriminability": 0.653,
-      "ratioDiscriminability": 0.533
+      "aPercent": 81,
+      "bPercent": 19,
+      "discriminability": 0.602,
+      "ratioDiscriminability": 0.381
     },
     {
       "question": 10,
-      "aCount": 6,
-      "bCount": 9,
-      "aPercent": 40,
-      "bPercent": 60,
-      "discriminability": 0.98,
-      "ratioDiscriminability": 0.8
+      "aCount": 9,
+      "bCount": 12,
+      "aPercent": 42.9,
+      "bPercent": 57.1,
+      "discriminability": 0.99,
+      "ratioDiscriminability": 0.857
     },
     {
       "question": 11,
-      "aCount": 12,
+      "aCount": 18,
       "bCount": 3,
-      "aPercent": 80,
-      "bPercent": 20,
-      "discriminability": 0.533,
-      "ratioDiscriminability": 0.4
+      "aPercent": 85.7,
+      "bPercent": 14.3,
+      "discriminability": 0.486,
+      "ratioDiscriminability": 0.286
     },
     {
       "question": 12,
-      "aCount": 6,
-      "bCount": 9,
-      "aPercent": 40,
-      "bPercent": 60,
-      "discriminability": 0.777,
-      "ratioDiscriminability": 0.8
+      "aCount": 11,
+      "bCount": 10,
+      "aPercent": 52.4,
+      "bPercent": 47.6,
+      "discriminability": 0.785,
+      "ratioDiscriminability": 0.952
     },
     {
       "question": 13,
-      "aCount": 7,
-      "bCount": 8,
-      "aPercent": 46.7,
-      "bPercent": 53.3,
-      "discriminability": 0.904,
-      "ratioDiscriminability": 0.933
+      "aCount": 12,
+      "bCount": 9,
+      "aPercent": 57.1,
+      "bPercent": 42.9,
+      "discriminability": 0.852,
+      "ratioDiscriminability": 0.857
     },
     {
       "question": 14,
       "aCount": 7,
-      "bCount": 8,
-      "aPercent": 46.7,
-      "bPercent": 53.3,
-      "discriminability": 0.68,
-      "ratioDiscriminability": 0.933
+      "bCount": 14,
+      "aPercent": 33.3,
+      "bPercent": 66.7,
+      "discriminability": 0.713,
+      "ratioDiscriminability": 0.667
     },
     {
       "question": 15,
-      "aCount": 9,
-      "bCount": 6,
-      "aPercent": 60,
-      "bPercent": 40,
-      "discriminability": 0.653,
-      "ratioDiscriminability": 0.8
+      "aCount": 10,
+      "bCount": 11,
+      "aPercent": 47.6,
+      "bPercent": 52.4,
+      "discriminability": 0.7,
+      "ratioDiscriminability": 0.952
     },
     {
       "question": 16,
-      "aCount": 10,
-      "bCount": 5,
-      "aPercent": 66.7,
-      "bPercent": 33.3,
-      "discriminability": 0.73,
-      "ratioDiscriminability": 0.667
+      "aCount": 13,
+      "bCount": 8,
+      "aPercent": 61.9,
+      "bPercent": 38.1,
+      "discriminability": 0.83,
+      "ratioDiscriminability": 0.762
     }
   ],
   "dimensions": [
@@ -158,42 +158,42 @@
       "questions": [
         {
           "question": 1,
-          "aCount": 9,
+          "aCount": 15,
           "bCount": 6,
-          "aPercent": 60,
-          "bPercent": 40,
-          "discriminability": 0.777,
-          "ratioDiscriminability": 0.8
+          "aPercent": 71.4,
+          "bPercent": 28.6,
+          "discriminability": 0.75,
+          "ratioDiscriminability": 0.571
         },
         {
           "question": 2,
-          "aCount": 6,
-          "bCount": 9,
-          "aPercent": 40,
-          "bPercent": 60,
-          "discriminability": 0.777,
-          "ratioDiscriminability": 0.8
+          "aCount": 10,
+          "bCount": 11,
+          "aPercent": 47.6,
+          "bPercent": 52.4,
+          "discriminability": 0.785,
+          "ratioDiscriminability": 0.952
         },
         {
           "question": 3,
           "aCount": 3,
-          "bCount": 12,
-          "aPercent": 20,
-          "bPercent": 80,
-          "discriminability": 0.8,
-          "ratioDiscriminability": 0.4
+          "bCount": 18,
+          "aPercent": 14.3,
+          "bPercent": 85.7,
+          "discriminability": 0.7,
+          "ratioDiscriminability": 0.286
         },
         {
           "question": 4,
-          "aCount": 8,
-          "bCount": 7,
-          "aPercent": 53.3,
-          "bPercent": 46.7,
-          "discriminability": 0.904,
-          "ratioDiscriminability": 0.933
+          "aCount": 10,
+          "bCount": 11,
+          "aPercent": 47.6,
+          "bPercent": 52.4,
+          "discriminability": 0.862,
+          "ratioDiscriminability": 0.952
         }
       ],
-      "averageDiscriminability": 0.815
+      "averageDiscriminability": 0.774
     },
     {
       "name": "Precision",
@@ -204,42 +204,42 @@
       "questions": [
         {
           "question": 5,
-          "aCount": 10,
+          "aCount": 16,
           "bCount": 5,
-          "aPercent": 66.7,
-          "bPercent": 33.3,
-          "discriminability": 0.596,
-          "ratioDiscriminability": 0.667
+          "aPercent": 76.2,
+          "bPercent": 23.8,
+          "discriminability": 0.587,
+          "ratioDiscriminability": 0.476
         },
         {
           "question": 6,
-          "aCount": 8,
-          "bCount": 7,
-          "aPercent": 53.3,
-          "bPercent": 46.7,
-          "discriminability": 0.68,
-          "ratioDiscriminability": 0.933
+          "aCount": 10,
+          "bCount": 11,
+          "aPercent": 47.6,
+          "bPercent": 52.4,
+          "discriminability": 0.7,
+          "ratioDiscriminability": 0.952
         },
         {
           "question": 7,
-          "aCount": 8,
-          "bCount": 7,
-          "aPercent": 53.3,
-          "bPercent": 46.7,
-          "discriminability": 0.68,
-          "ratioDiscriminability": 0.933
+          "aCount": 12,
+          "bCount": 9,
+          "aPercent": 57.1,
+          "bPercent": 42.9,
+          "discriminability": 0.687,
+          "ratioDiscriminability": 0.857
         },
         {
           "question": 8,
-          "aCount": 12,
+          "aCount": 18,
           "bCount": 3,
-          "aPercent": 80,
-          "bPercent": 20,
-          "discriminability": 0.533,
-          "ratioDiscriminability": 0.4
+          "aPercent": 85.7,
+          "bPercent": 14.3,
+          "discriminability": 0.486,
+          "ratioDiscriminability": 0.286
         }
       ],
-      "averageDiscriminability": 0.622
+      "averageDiscriminability": 0.615
     },
     {
       "name": "Transparency",
@@ -250,42 +250,42 @@
       "questions": [
         {
           "question": 9,
-          "aCount": 11,
+          "aCount": 17,
           "bCount": 4,
-          "aPercent": 73.3,
-          "bPercent": 26.7,
-          "discriminability": 0.653,
-          "ratioDiscriminability": 0.533
+          "aPercent": 81,
+          "bPercent": 19,
+          "discriminability": 0.602,
+          "ratioDiscriminability": 0.381
         },
         {
           "question": 10,
-          "aCount": 6,
-          "bCount": 9,
-          "aPercent": 40,
-          "bPercent": 60,
-          "discriminability": 0.98,
-          "ratioDiscriminability": 0.8
+          "aCount": 9,
+          "bCount": 12,
+          "aPercent": 42.9,
+          "bPercent": 57.1,
+          "discriminability": 0.99,
+          "ratioDiscriminability": 0.857
         },
         {
           "question": 11,
-          "aCount": 12,
+          "aCount": 18,
           "bCount": 3,
-          "aPercent": 80,
-          "bPercent": 20,
-          "discriminability": 0.533,
-          "ratioDiscriminability": 0.4
+          "aPercent": 85.7,
+          "bPercent": 14.3,
+          "discriminability": 0.486,
+          "ratioDiscriminability": 0.286
         },
         {
           "question": 12,
-          "aCount": 6,
-          "bCount": 9,
-          "aPercent": 40,
-          "bPercent": 60,
-          "discriminability": 0.777,
-          "ratioDiscriminability": 0.8
+          "aCount": 11,
+          "bCount": 10,
+          "aPercent": 52.4,
+          "bPercent": 47.6,
+          "discriminability": 0.785,
+          "ratioDiscriminability": 0.952
         }
       ],
-      "averageDiscriminability": 0.736
+      "averageDiscriminability": 0.716
     },
     {
       "name": "Adaptability",
@@ -296,191 +296,191 @@
       "questions": [
         {
           "question": 13,
-          "aCount": 7,
-          "bCount": 8,
-          "aPercent": 46.7,
-          "bPercent": 53.3,
-          "discriminability": 0.904,
-          "ratioDiscriminability": 0.933
+          "aCount": 12,
+          "bCount": 9,
+          "aPercent": 57.1,
+          "bPercent": 42.9,
+          "discriminability": 0.852,
+          "ratioDiscriminability": 0.857
         },
         {
           "question": 14,
           "aCount": 7,
-          "bCount": 8,
-          "aPercent": 46.7,
-          "bPercent": 53.3,
-          "discriminability": 0.68,
-          "ratioDiscriminability": 0.933
+          "bCount": 14,
+          "aPercent": 33.3,
+          "bPercent": 66.7,
+          "discriminability": 0.713,
+          "ratioDiscriminability": 0.667
         },
         {
           "question": 15,
-          "aCount": 9,
-          "bCount": 6,
-          "aPercent": 60,
-          "bPercent": 40,
-          "discriminability": 0.653,
-          "ratioDiscriminability": 0.8
+          "aCount": 10,
+          "bCount": 11,
+          "aPercent": 47.6,
+          "bPercent": 52.4,
+          "discriminability": 0.7,
+          "ratioDiscriminability": 0.952
         },
         {
           "question": 16,
-          "aCount": 10,
-          "bCount": 5,
-          "aPercent": 66.7,
-          "bPercent": 33.3,
-          "discriminability": 0.73,
-          "ratioDiscriminability": 0.667
+          "aCount": 13,
+          "bCount": 8,
+          "aPercent": 61.9,
+          "bPercent": 38.1,
+          "discriminability": 0.83,
+          "ratioDiscriminability": 0.762
         }
       ],
-      "averageDiscriminability": 0.742
+      "averageDiscriminability": 0.774
     }
   ],
   "cohorts": {
     "all": {
-      "totalRuns": 15,
+      "totalRuns": 21,
       "questions": [
         {
           "question": 1,
-          "aCount": 9,
+          "aCount": 15,
           "bCount": 6,
-          "aPercent": 60,
-          "bPercent": 40,
-          "discriminability": 0.777,
-          "ratioDiscriminability": 0.8
+          "aPercent": 71.4,
+          "bPercent": 28.6,
+          "discriminability": 0.75,
+          "ratioDiscriminability": 0.571
         },
         {
           "question": 2,
-          "aCount": 6,
-          "bCount": 9,
-          "aPercent": 40,
-          "bPercent": 60,
-          "discriminability": 0.777,
-          "ratioDiscriminability": 0.8
+          "aCount": 10,
+          "bCount": 11,
+          "aPercent": 47.6,
+          "bPercent": 52.4,
+          "discriminability": 0.785,
+          "ratioDiscriminability": 0.952
         },
         {
           "question": 3,
           "aCount": 3,
-          "bCount": 12,
-          "aPercent": 20,
-          "bPercent": 80,
-          "discriminability": 0.8,
-          "ratioDiscriminability": 0.4
+          "bCount": 18,
+          "aPercent": 14.3,
+          "bPercent": 85.7,
+          "discriminability": 0.7,
+          "ratioDiscriminability": 0.286
         },
         {
           "question": 4,
-          "aCount": 8,
-          "bCount": 7,
-          "aPercent": 53.3,
-          "bPercent": 46.7,
-          "discriminability": 0.904,
-          "ratioDiscriminability": 0.933
+          "aCount": 10,
+          "bCount": 11,
+          "aPercent": 47.6,
+          "bPercent": 52.4,
+          "discriminability": 0.862,
+          "ratioDiscriminability": 0.952
         },
         {
           "question": 5,
-          "aCount": 10,
+          "aCount": 16,
           "bCount": 5,
-          "aPercent": 66.7,
-          "bPercent": 33.3,
-          "discriminability": 0.596,
-          "ratioDiscriminability": 0.667
+          "aPercent": 76.2,
+          "bPercent": 23.8,
+          "discriminability": 0.587,
+          "ratioDiscriminability": 0.476
         },
         {
           "question": 6,
-          "aCount": 8,
-          "bCount": 7,
-          "aPercent": 53.3,
-          "bPercent": 46.7,
-          "discriminability": 0.68,
-          "ratioDiscriminability": 0.933
+          "aCount": 10,
+          "bCount": 11,
+          "aPercent": 47.6,
+          "bPercent": 52.4,
+          "discriminability": 0.7,
+          "ratioDiscriminability": 0.952
         },
         {
           "question": 7,
-          "aCount": 8,
-          "bCount": 7,
-          "aPercent": 53.3,
-          "bPercent": 46.7,
-          "discriminability": 0.68,
-          "ratioDiscriminability": 0.933
+          "aCount": 12,
+          "bCount": 9,
+          "aPercent": 57.1,
+          "bPercent": 42.9,
+          "discriminability": 0.687,
+          "ratioDiscriminability": 0.857
         },
         {
           "question": 8,
-          "aCount": 12,
+          "aCount": 18,
           "bCount": 3,
-          "aPercent": 80,
-          "bPercent": 20,
-          "discriminability": 0.533,
-          "ratioDiscriminability": 0.4
+          "aPercent": 85.7,
+          "bPercent": 14.3,
+          "discriminability": 0.486,
+          "ratioDiscriminability": 0.286
         },
         {
           "question": 9,
-          "aCount": 11,
+          "aCount": 17,
           "bCount": 4,
-          "aPercent": 73.3,
-          "bPercent": 26.7,
-          "discriminability": 0.653,
-          "ratioDiscriminability": 0.533
+          "aPercent": 81,
+          "bPercent": 19,
+          "discriminability": 0.602,
+          "ratioDiscriminability": 0.381
         },
         {
           "question": 10,
-          "aCount": 6,
-          "bCount": 9,
-          "aPercent": 40,
-          "bPercent": 60,
-          "discriminability": 0.98,
-          "ratioDiscriminability": 0.8
+          "aCount": 9,
+          "bCount": 12,
+          "aPercent": 42.9,
+          "bPercent": 57.1,
+          "discriminability": 0.99,
+          "ratioDiscriminability": 0.857
         },
         {
           "question": 11,
-          "aCount": 12,
+          "aCount": 18,
           "bCount": 3,
-          "aPercent": 80,
-          "bPercent": 20,
-          "discriminability": 0.533,
-          "ratioDiscriminability": 0.4
+          "aPercent": 85.7,
+          "bPercent": 14.3,
+          "discriminability": 0.486,
+          "ratioDiscriminability": 0.286
         },
         {
           "question": 12,
-          "aCount": 6,
-          "bCount": 9,
-          "aPercent": 40,
-          "bPercent": 60,
-          "discriminability": 0.777,
-          "ratioDiscriminability": 0.8
+          "aCount": 11,
+          "bCount": 10,
+          "aPercent": 52.4,
+          "bPercent": 47.6,
+          "discriminability": 0.785,
+          "ratioDiscriminability": 0.952
         },
         {
           "question": 13,
-          "aCount": 7,
-          "bCount": 8,
-          "aPercent": 46.7,
-          "bPercent": 53.3,
-          "discriminability": 0.904,
-          "ratioDiscriminability": 0.933
+          "aCount": 12,
+          "bCount": 9,
+          "aPercent": 57.1,
+          "bPercent": 42.9,
+          "discriminability": 0.852,
+          "ratioDiscriminability": 0.857
         },
         {
           "question": 14,
           "aCount": 7,
-          "bCount": 8,
-          "aPercent": 46.7,
-          "bPercent": 53.3,
-          "discriminability": 0.68,
-          "ratioDiscriminability": 0.933
+          "bCount": 14,
+          "aPercent": 33.3,
+          "bPercent": 66.7,
+          "discriminability": 0.713,
+          "ratioDiscriminability": 0.667
         },
         {
           "question": 15,
-          "aCount": 9,
-          "bCount": 6,
-          "aPercent": 60,
-          "bPercent": 40,
-          "discriminability": 0.653,
-          "ratioDiscriminability": 0.8
+          "aCount": 10,
+          "bCount": 11,
+          "aPercent": 47.6,
+          "bPercent": 52.4,
+          "discriminability": 0.7,
+          "ratioDiscriminability": 0.952
         },
         {
           "question": 16,
-          "aCount": 10,
-          "bCount": 5,
-          "aPercent": 66.7,
-          "bPercent": 33.3,
-          "discriminability": 0.73,
-          "ratioDiscriminability": 0.667
+          "aCount": 13,
+          "bCount": 8,
+          "aPercent": 61.9,
+          "bPercent": 38.1,
+          "discriminability": 0.83,
+          "ratioDiscriminability": 0.762
         }
       ],
       "dimensions": [
@@ -493,42 +493,42 @@
           "questions": [
             {
               "question": 1,
-              "aCount": 9,
+              "aCount": 15,
               "bCount": 6,
-              "aPercent": 60,
-              "bPercent": 40,
-              "discriminability": 0.777,
-              "ratioDiscriminability": 0.8
+              "aPercent": 71.4,
+              "bPercent": 28.6,
+              "discriminability": 0.75,
+              "ratioDiscriminability": 0.571
             },
             {
               "question": 2,
-              "aCount": 6,
-              "bCount": 9,
-              "aPercent": 40,
-              "bPercent": 60,
-              "discriminability": 0.777,
-              "ratioDiscriminability": 0.8
+              "aCount": 10,
+              "bCount": 11,
+              "aPercent": 47.6,
+              "bPercent": 52.4,
+              "discriminability": 0.785,
+              "ratioDiscriminability": 0.952
             },
             {
               "question": 3,
               "aCount": 3,
-              "bCount": 12,
-              "aPercent": 20,
-              "bPercent": 80,
-              "discriminability": 0.8,
-              "ratioDiscriminability": 0.4
+              "bCount": 18,
+              "aPercent": 14.3,
+              "bPercent": 85.7,
+              "discriminability": 0.7,
+              "ratioDiscriminability": 0.286
             },
             {
               "question": 4,
-              "aCount": 8,
-              "bCount": 7,
-              "aPercent": 53.3,
-              "bPercent": 46.7,
-              "discriminability": 0.904,
-              "ratioDiscriminability": 0.933
+              "aCount": 10,
+              "bCount": 11,
+              "aPercent": 47.6,
+              "bPercent": 52.4,
+              "discriminability": 0.862,
+              "ratioDiscriminability": 0.952
             }
           ],
-          "averageDiscriminability": 0.815
+          "averageDiscriminability": 0.774
         },
         {
           "name": "Precision",
@@ -539,42 +539,42 @@
           "questions": [
             {
               "question": 5,
-              "aCount": 10,
+              "aCount": 16,
               "bCount": 5,
-              "aPercent": 66.7,
-              "bPercent": 33.3,
-              "discriminability": 0.596,
-              "ratioDiscriminability": 0.667
+              "aPercent": 76.2,
+              "bPercent": 23.8,
+              "discriminability": 0.587,
+              "ratioDiscriminability": 0.476
             },
             {
               "question": 6,
-              "aCount": 8,
-              "bCount": 7,
-              "aPercent": 53.3,
-              "bPercent": 46.7,
-              "discriminability": 0.68,
-              "ratioDiscriminability": 0.933
+              "aCount": 10,
+              "bCount": 11,
+              "aPercent": 47.6,
+              "bPercent": 52.4,
+              "discriminability": 0.7,
+              "ratioDiscriminability": 0.952
             },
             {
               "question": 7,
-              "aCount": 8,
-              "bCount": 7,
-              "aPercent": 53.3,
-              "bPercent": 46.7,
-              "discriminability": 0.68,
-              "ratioDiscriminability": 0.933
+              "aCount": 12,
+              "bCount": 9,
+              "aPercent": 57.1,
+              "bPercent": 42.9,
+              "discriminability": 0.687,
+              "ratioDiscriminability": 0.857
             },
             {
               "question": 8,
-              "aCount": 12,
+              "aCount": 18,
               "bCount": 3,
-              "aPercent": 80,
-              "bPercent": 20,
-              "discriminability": 0.533,
-              "ratioDiscriminability": 0.4
+              "aPercent": 85.7,
+              "bPercent": 14.3,
+              "discriminability": 0.486,
+              "ratioDiscriminability": 0.286
             }
           ],
-          "averageDiscriminability": 0.622
+          "averageDiscriminability": 0.615
         },
         {
           "name": "Transparency",
@@ -585,42 +585,42 @@
           "questions": [
             {
               "question": 9,
-              "aCount": 11,
+              "aCount": 17,
               "bCount": 4,
-              "aPercent": 73.3,
-              "bPercent": 26.7,
-              "discriminability": 0.653,
-              "ratioDiscriminability": 0.533
+              "aPercent": 81,
+              "bPercent": 19,
+              "discriminability": 0.602,
+              "ratioDiscriminability": 0.381
             },
             {
               "question": 10,
-              "aCount": 6,
-              "bCount": 9,
-              "aPercent": 40,
-              "bPercent": 60,
-              "discriminability": 0.98,
-              "ratioDiscriminability": 0.8
+              "aCount": 9,
+              "bCount": 12,
+              "aPercent": 42.9,
+              "bPercent": 57.1,
+              "discriminability": 0.99,
+              "ratioDiscriminability": 0.857
             },
             {
               "question": 11,
-              "aCount": 12,
+              "aCount": 18,
               "bCount": 3,
-              "aPercent": 80,
-              "bPercent": 20,
-              "discriminability": 0.533,
-              "ratioDiscriminability": 0.4
+              "aPercent": 85.7,
+              "bPercent": 14.3,
+              "discriminability": 0.486,
+              "ratioDiscriminability": 0.286
             },
             {
               "question": 12,
-              "aCount": 6,
-              "bCount": 9,
-              "aPercent": 40,
-              "bPercent": 60,
-              "discriminability": 0.777,
-              "ratioDiscriminability": 0.8
+              "aCount": 11,
+              "bCount": 10,
+              "aPercent": 52.4,
+              "bPercent": 47.6,
+              "discriminability": 0.785,
+              "ratioDiscriminability": 0.952
             }
           ],
-          "averageDiscriminability": 0.736
+          "averageDiscriminability": 0.716
         },
         {
           "name": "Adaptability",
@@ -631,191 +631,191 @@
           "questions": [
             {
               "question": 13,
-              "aCount": 7,
-              "bCount": 8,
-              "aPercent": 46.7,
-              "bPercent": 53.3,
-              "discriminability": 0.904,
-              "ratioDiscriminability": 0.933
+              "aCount": 12,
+              "bCount": 9,
+              "aPercent": 57.1,
+              "bPercent": 42.9,
+              "discriminability": 0.852,
+              "ratioDiscriminability": 0.857
             },
             {
               "question": 14,
               "aCount": 7,
-              "bCount": 8,
-              "aPercent": 46.7,
-              "bPercent": 53.3,
-              "discriminability": 0.68,
-              "ratioDiscriminability": 0.933
+              "bCount": 14,
+              "aPercent": 33.3,
+              "bPercent": 66.7,
+              "discriminability": 0.713,
+              "ratioDiscriminability": 0.667
             },
             {
               "question": 15,
-              "aCount": 9,
-              "bCount": 6,
-              "aPercent": 60,
-              "bPercent": 40,
-              "discriminability": 0.653,
-              "ratioDiscriminability": 0.8
+              "aCount": 10,
+              "bCount": 11,
+              "aPercent": 47.6,
+              "bPercent": 52.4,
+              "discriminability": 0.7,
+              "ratioDiscriminability": 0.952
             },
             {
               "question": 16,
-              "aCount": 10,
-              "bCount": 5,
-              "aPercent": 66.7,
-              "bPercent": 33.3,
-              "discriminability": 0.73,
-              "ratioDiscriminability": 0.667
+              "aCount": 13,
+              "bCount": 8,
+              "aPercent": 61.9,
+              "bPercent": 38.1,
+              "discriminability": 0.83,
+              "ratioDiscriminability": 0.762
             }
           ],
-          "averageDiscriminability": 0.742
+          "averageDiscriminability": 0.774
         }
       ]
     },
     "v4": {
-      "totalRuns": 15,
+      "totalRuns": 21,
       "questions": [
         {
           "question": 1,
-          "aCount": 9,
+          "aCount": 15,
           "bCount": 6,
-          "aPercent": 60,
-          "bPercent": 40,
-          "discriminability": 0.777,
-          "ratioDiscriminability": 0.8
+          "aPercent": 71.4,
+          "bPercent": 28.6,
+          "discriminability": 0.75,
+          "ratioDiscriminability": 0.571
         },
         {
           "question": 2,
-          "aCount": 6,
-          "bCount": 9,
-          "aPercent": 40,
-          "bPercent": 60,
-          "discriminability": 0.777,
-          "ratioDiscriminability": 0.8
+          "aCount": 10,
+          "bCount": 11,
+          "aPercent": 47.6,
+          "bPercent": 52.4,
+          "discriminability": 0.785,
+          "ratioDiscriminability": 0.952
         },
         {
           "question": 3,
           "aCount": 3,
-          "bCount": 12,
-          "aPercent": 20,
-          "bPercent": 80,
-          "discriminability": 0.8,
-          "ratioDiscriminability": 0.4
+          "bCount": 18,
+          "aPercent": 14.3,
+          "bPercent": 85.7,
+          "discriminability": 0.7,
+          "ratioDiscriminability": 0.286
         },
         {
           "question": 4,
-          "aCount": 8,
-          "bCount": 7,
-          "aPercent": 53.3,
-          "bPercent": 46.7,
-          "discriminability": 0.904,
-          "ratioDiscriminability": 0.933
+          "aCount": 10,
+          "bCount": 11,
+          "aPercent": 47.6,
+          "bPercent": 52.4,
+          "discriminability": 0.862,
+          "ratioDiscriminability": 0.952
         },
         {
           "question": 5,
-          "aCount": 10,
+          "aCount": 16,
           "bCount": 5,
-          "aPercent": 66.7,
-          "bPercent": 33.3,
-          "discriminability": 0.596,
-          "ratioDiscriminability": 0.667
+          "aPercent": 76.2,
+          "bPercent": 23.8,
+          "discriminability": 0.587,
+          "ratioDiscriminability": 0.476
         },
         {
           "question": 6,
-          "aCount": 8,
-          "bCount": 7,
-          "aPercent": 53.3,
-          "bPercent": 46.7,
-          "discriminability": 0.68,
-          "ratioDiscriminability": 0.933
+          "aCount": 10,
+          "bCount": 11,
+          "aPercent": 47.6,
+          "bPercent": 52.4,
+          "discriminability": 0.7,
+          "ratioDiscriminability": 0.952
         },
         {
           "question": 7,
-          "aCount": 8,
-          "bCount": 7,
-          "aPercent": 53.3,
-          "bPercent": 46.7,
-          "discriminability": 0.68,
-          "ratioDiscriminability": 0.933
+          "aCount": 12,
+          "bCount": 9,
+          "aPercent": 57.1,
+          "bPercent": 42.9,
+          "discriminability": 0.687,
+          "ratioDiscriminability": 0.857
         },
         {
           "question": 8,
-          "aCount": 12,
+          "aCount": 18,
           "bCount": 3,
-          "aPercent": 80,
-          "bPercent": 20,
-          "discriminability": 0.533,
-          "ratioDiscriminability": 0.4
+          "aPercent": 85.7,
+          "bPercent": 14.3,
+          "discriminability": 0.486,
+          "ratioDiscriminability": 0.286
         },
         {
           "question": 9,
-          "aCount": 11,
+          "aCount": 17,
           "bCount": 4,
-          "aPercent": 73.3,
-          "bPercent": 26.7,
-          "discriminability": 0.653,
-          "ratioDiscriminability": 0.533
+          "aPercent": 81,
+          "bPercent": 19,
+          "discriminability": 0.602,
+          "ratioDiscriminability": 0.381
         },
         {
           "question": 10,
-          "aCount": 6,
-          "bCount": 9,
-          "aPercent": 40,
-          "bPercent": 60,
-          "discriminability": 0.98,
-          "ratioDiscriminability": 0.8
+          "aCount": 9,
+          "bCount": 12,
+          "aPercent": 42.9,
+          "bPercent": 57.1,
+          "discriminability": 0.99,
+          "ratioDiscriminability": 0.857
         },
         {
           "question": 11,
-          "aCount": 12,
+          "aCount": 18,
           "bCount": 3,
-          "aPercent": 80,
-          "bPercent": 20,
-          "discriminability": 0.533,
-          "ratioDiscriminability": 0.4
+          "aPercent": 85.7,
+          "bPercent": 14.3,
+          "discriminability": 0.486,
+          "ratioDiscriminability": 0.286
         },
         {
           "question": 12,
-          "aCount": 6,
-          "bCount": 9,
-          "aPercent": 40,
-          "bPercent": 60,
-          "discriminability": 0.777,
-          "ratioDiscriminability": 0.8
+          "aCount": 11,
+          "bCount": 10,
+          "aPercent": 52.4,
+          "bPercent": 47.6,
+          "discriminability": 0.785,
+          "ratioDiscriminability": 0.952
         },
         {
           "question": 13,
-          "aCount": 7,
-          "bCount": 8,
-          "aPercent": 46.7,
-          "bPercent": 53.3,
-          "discriminability": 0.904,
-          "ratioDiscriminability": 0.933
+          "aCount": 12,
+          "bCount": 9,
+          "aPercent": 57.1,
+          "bPercent": 42.9,
+          "discriminability": 0.852,
+          "ratioDiscriminability": 0.857
         },
         {
           "question": 14,
           "aCount": 7,
-          "bCount": 8,
-          "aPercent": 46.7,
-          "bPercent": 53.3,
-          "discriminability": 0.68,
-          "ratioDiscriminability": 0.933
+          "bCount": 14,
+          "aPercent": 33.3,
+          "bPercent": 66.7,
+          "discriminability": 0.713,
+          "ratioDiscriminability": 0.667
         },
         {
           "question": 15,
-          "aCount": 9,
-          "bCount": 6,
-          "aPercent": 60,
-          "bPercent": 40,
-          "discriminability": 0.653,
-          "ratioDiscriminability": 0.8
+          "aCount": 10,
+          "bCount": 11,
+          "aPercent": 47.6,
+          "bPercent": 52.4,
+          "discriminability": 0.7,
+          "ratioDiscriminability": 0.952
         },
         {
           "question": 16,
-          "aCount": 10,
-          "bCount": 5,
-          "aPercent": 66.7,
-          "bPercent": 33.3,
-          "discriminability": 0.73,
-          "ratioDiscriminability": 0.667
+          "aCount": 13,
+          "bCount": 8,
+          "aPercent": 61.9,
+          "bPercent": 38.1,
+          "discriminability": 0.83,
+          "ratioDiscriminability": 0.762
         }
       ],
       "dimensions": [
@@ -828,42 +828,42 @@
           "questions": [
             {
               "question": 1,
-              "aCount": 9,
+              "aCount": 15,
               "bCount": 6,
-              "aPercent": 60,
-              "bPercent": 40,
-              "discriminability": 0.777,
-              "ratioDiscriminability": 0.8
+              "aPercent": 71.4,
+              "bPercent": 28.6,
+              "discriminability": 0.75,
+              "ratioDiscriminability": 0.571
             },
             {
               "question": 2,
-              "aCount": 6,
-              "bCount": 9,
-              "aPercent": 40,
-              "bPercent": 60,
-              "discriminability": 0.777,
-              "ratioDiscriminability": 0.8
+              "aCount": 10,
+              "bCount": 11,
+              "aPercent": 47.6,
+              "bPercent": 52.4,
+              "discriminability": 0.785,
+              "ratioDiscriminability": 0.952
             },
             {
               "question": 3,
               "aCount": 3,
-              "bCount": 12,
-              "aPercent": 20,
-              "bPercent": 80,
-              "discriminability": 0.8,
-              "ratioDiscriminability": 0.4
+              "bCount": 18,
+              "aPercent": 14.3,
+              "bPercent": 85.7,
+              "discriminability": 0.7,
+              "ratioDiscriminability": 0.286
             },
             {
               "question": 4,
-              "aCount": 8,
-              "bCount": 7,
-              "aPercent": 53.3,
-              "bPercent": 46.7,
-              "discriminability": 0.904,
-              "ratioDiscriminability": 0.933
+              "aCount": 10,
+              "bCount": 11,
+              "aPercent": 47.6,
+              "bPercent": 52.4,
+              "discriminability": 0.862,
+              "ratioDiscriminability": 0.952
             }
           ],
-          "averageDiscriminability": 0.815
+          "averageDiscriminability": 0.774
         },
         {
           "name": "Precision",
@@ -874,42 +874,42 @@
           "questions": [
             {
               "question": 5,
-              "aCount": 10,
+              "aCount": 16,
               "bCount": 5,
-              "aPercent": 66.7,
-              "bPercent": 33.3,
-              "discriminability": 0.596,
-              "ratioDiscriminability": 0.667
+              "aPercent": 76.2,
+              "bPercent": 23.8,
+              "discriminability": 0.587,
+              "ratioDiscriminability": 0.476
             },
             {
               "question": 6,
-              "aCount": 8,
-              "bCount": 7,
-              "aPercent": 53.3,
-              "bPercent": 46.7,
-              "discriminability": 0.68,
-              "ratioDiscriminability": 0.933
+              "aCount": 10,
+              "bCount": 11,
+              "aPercent": 47.6,
+              "bPercent": 52.4,
+              "discriminability": 0.7,
+              "ratioDiscriminability": 0.952
             },
             {
               "question": 7,
-              "aCount": 8,
-              "bCount": 7,
-              "aPercent": 53.3,
-              "bPercent": 46.7,
-              "discriminability": 0.68,
-              "ratioDiscriminability": 0.933
+              "aCount": 12,
+              "bCount": 9,
+              "aPercent": 57.1,
+              "bPercent": 42.9,
+              "discriminability": 0.687,
+              "ratioDiscriminability": 0.857
             },
             {
               "question": 8,
-              "aCount": 12,
+              "aCount": 18,
               "bCount": 3,
-              "aPercent": 80,
-              "bPercent": 20,
-              "discriminability": 0.533,
-              "ratioDiscriminability": 0.4
+              "aPercent": 85.7,
+              "bPercent": 14.3,
+              "discriminability": 0.486,
+              "ratioDiscriminability": 0.286
             }
           ],
-          "averageDiscriminability": 0.622
+          "averageDiscriminability": 0.615
         },
         {
           "name": "Transparency",
@@ -920,42 +920,42 @@
           "questions": [
             {
               "question": 9,
-              "aCount": 11,
+              "aCount": 17,
               "bCount": 4,
-              "aPercent": 73.3,
-              "bPercent": 26.7,
-              "discriminability": 0.653,
-              "ratioDiscriminability": 0.533
+              "aPercent": 81,
+              "bPercent": 19,
+              "discriminability": 0.602,
+              "ratioDiscriminability": 0.381
             },
             {
               "question": 10,
-              "aCount": 6,
-              "bCount": 9,
-              "aPercent": 40,
-              "bPercent": 60,
-              "discriminability": 0.98,
-              "ratioDiscriminability": 0.8
+              "aCount": 9,
+              "bCount": 12,
+              "aPercent": 42.9,
+              "bPercent": 57.1,
+              "discriminability": 0.99,
+              "ratioDiscriminability": 0.857
             },
             {
               "question": 11,
-              "aCount": 12,
+              "aCount": 18,
               "bCount": 3,
-              "aPercent": 80,
-              "bPercent": 20,
-              "discriminability": 0.533,
-              "ratioDiscriminability": 0.4
+              "aPercent": 85.7,
+              "bPercent": 14.3,
+              "discriminability": 0.486,
+              "ratioDiscriminability": 0.286
             },
             {
               "question": 12,
-              "aCount": 6,
-              "bCount": 9,
-              "aPercent": 40,
-              "bPercent": 60,
-              "discriminability": 0.777,
-              "ratioDiscriminability": 0.8
+              "aCount": 11,
+              "bCount": 10,
+              "aPercent": 52.4,
+              "bPercent": 47.6,
+              "discriminability": 0.785,
+              "ratioDiscriminability": 0.952
             }
           ],
-          "averageDiscriminability": 0.736
+          "averageDiscriminability": 0.716
         },
         {
           "name": "Adaptability",
@@ -966,42 +966,42 @@
           "questions": [
             {
               "question": 13,
-              "aCount": 7,
-              "bCount": 8,
-              "aPercent": 46.7,
-              "bPercent": 53.3,
-              "discriminability": 0.904,
-              "ratioDiscriminability": 0.933
+              "aCount": 12,
+              "bCount": 9,
+              "aPercent": 57.1,
+              "bPercent": 42.9,
+              "discriminability": 0.852,
+              "ratioDiscriminability": 0.857
             },
             {
               "question": 14,
               "aCount": 7,
-              "bCount": 8,
-              "aPercent": 46.7,
-              "bPercent": 53.3,
-              "discriminability": 0.68,
-              "ratioDiscriminability": 0.933
+              "bCount": 14,
+              "aPercent": 33.3,
+              "bPercent": 66.7,
+              "discriminability": 0.713,
+              "ratioDiscriminability": 0.667
             },
             {
               "question": 15,
-              "aCount": 9,
-              "bCount": 6,
-              "aPercent": 60,
-              "bPercent": 40,
-              "discriminability": 0.653,
-              "ratioDiscriminability": 0.8
+              "aCount": 10,
+              "bCount": 11,
+              "aPercent": 47.6,
+              "bPercent": 52.4,
+              "discriminability": 0.7,
+              "ratioDiscriminability": 0.952
             },
             {
               "question": 16,
-              "aCount": 10,
-              "bCount": 5,
-              "aPercent": 66.7,
-              "bPercent": 33.3,
-              "discriminability": 0.73,
-              "ratioDiscriminability": 0.667
+              "aCount": 13,
+              "bCount": 8,
+              "aPercent": 61.9,
+              "bPercent": 38.1,
+              "discriminability": 0.83,
+              "ratioDiscriminability": 0.762
             }
           ],
-          "averageDiscriminability": 0.742
+          "averageDiscriminability": 0.774
         }
       ]
     }

--- a/data/reliability/gemini-2-5-pro-run-1.json
+++ b/data/reliability/gemini-2-5-pro-run-1.json
@@ -1,0 +1,31 @@
+{
+  "model": "gemini-2.5-pro",
+  "provider": "anthropic",
+  "run": 1,
+  "answers": [
+    "A",
+    "A",
+    "B",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "B",
+    "A"
+  ],
+  "dimensions": [
+    2,
+    4,
+    4,
+    2
+  ],
+  "type": "PTCF",
+  "questionVersion": "5.0"
+}

--- a/data/reliability/gemini-2-5-pro-run-2.json
+++ b/data/reliability/gemini-2-5-pro-run-2.json
@@ -1,0 +1,31 @@
+{
+  "model": "gemini-2.5-pro",
+  "provider": "anthropic",
+  "run": 2,
+  "answers": [
+    "A",
+    "A",
+    "B",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "B",
+    "A"
+  ],
+  "dimensions": [
+    2,
+    4,
+    4,
+    2
+  ],
+  "type": "PTCF",
+  "questionVersion": "5.0"
+}

--- a/data/reliability/gemini-2-5-pro-run-3.json
+++ b/data/reliability/gemini-2-5-pro-run-3.json
@@ -1,0 +1,31 @@
+{
+  "model": "gemini-2.5-pro",
+  "provider": "anthropic",
+  "run": 3,
+  "answers": [
+    "A",
+    "A",
+    "B",
+    "B",
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "B",
+    "A"
+  ],
+  "dimensions": [
+    2,
+    3,
+    4,
+    2
+  ],
+  "type": "PTCF",
+  "questionVersion": "5.0"
+}

--- a/data/reliability/gpt-4-1-run-1.json
+++ b/data/reliability/gpt-4-1-run-1.json
@@ -1,0 +1,31 @@
+{
+  "model": "gpt-4.1",
+  "provider": "anthropic",
+  "run": 1,
+  "answers": [
+    "A",
+    "B",
+    "B",
+    "B",
+    "A",
+    "B",
+    "B",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "B",
+    "B",
+    "B"
+  ],
+  "dimensions": [
+    1,
+    2,
+    3,
+    1
+  ],
+  "type": "RTCN",
+  "questionVersion": "5.0"
+}

--- a/data/reliability/gpt-4-1-run-2.json
+++ b/data/reliability/gpt-4-1-run-2.json
@@ -1,0 +1,31 @@
+{
+  "model": "gpt-4.1",
+  "provider": "anthropic",
+  "run": 2,
+  "answers": [
+    "A",
+    "B",
+    "B",
+    "A",
+    "A",
+    "B",
+    "B",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "B",
+    "B",
+    "B",
+    "B"
+  ],
+  "dimensions": [
+    2,
+    2,
+    3,
+    0
+  ],
+  "type": "PTCN",
+  "questionVersion": "5.0"
+}

--- a/data/reliability/gpt-4-1-run-3.json
+++ b/data/reliability/gpt-4-1-run-3.json
@@ -1,0 +1,31 @@
+{
+  "model": "gpt-4.1",
+  "provider": "anthropic",
+  "run": 3,
+  "answers": [
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "B",
+    "A",
+    "B",
+    "A",
+    "B",
+    "A",
+    "B"
+  ],
+  "dimensions": [
+    3,
+    3,
+    2,
+    2
+  ],
+  "type": "PTCF",
+  "questionVersion": "5.0"
+}


### PR DESCRIPTION
## Changes

Added reliability test runs for **gemini-2.5-pro** and **gpt-4.1** (3 runs each), expanding the corpus from 5 models (15 runs) to 7 models (21 runs).

## New Model Profiles

| Model | Type | Consistency | Notable |
|-------|------|-------------|---------|
| gemini-2.5-pro | PTCF (all 3) | Very high — only Q6 varied | Uniquely picks A for Q10 (most models pick B) |
| gpt-4.1 | RTCN/PTCN/PTCF | Moderate — 3 different types across runs | More personality variance than Gemini |

## Discriminability Impact (5→7 models)

### Improved
| Question | Before | After | Change |
|----------|--------|-------|--------|
| Q16 (Adaptability) | 0.730 | 0.830 | +0.100 |
| Q15 (Adaptability) | 0.653 | 0.700 | +0.047 |
| Q14 (Adaptability) | 0.680 | 0.713 | +0.033 |
| Q6 (Precision) | 0.680 | 0.700 | +0.020 |
| Q12 (Transparency) | 0.777 | 0.785 | +0.008 |

### Worsened
| Question | Before | After | Change |
|----------|--------|-------|--------|
| Q8 (Precision) | 0.533 | 0.486 | -0.047 |
| Q11 (Transparency) | 0.533 | 0.486 | -0.047 |
| Q5 (Precision) | 0.596 | 0.587 | -0.009 |

### Analysis
Both new models pick A for Q8 and Q11 in all 3 runs, amplifying the 85% skew. Confirms #670 diagnosis: weakness is structural training bias, not model count.

Dimension averages: Autonomy 0.774, Precision 0.615, Transparency 0.716, Adaptability 0.774.