### PR TITLE
data: expand reliability to non-core GitHub Models (v5.15-beta)

### DIFF
--- a/data/discriminability.json
+++ b/data/discriminability.json
@@ -1,152 +1,151 @@
 {
-  "generatedAt": "2026-07-08T01:16:00.101Z",
+  "generatedAt": "2026-07-09T01:49:07.729Z",
   "threshold": 0.6,
-  "totalRuns": 141,
+  "totalRuns": 83,
   "questions": [
     {
       "question": 1,
-      "aCount": 73,
-      "bCount": 68,
-      "aPercent": 51.8,
-      "bPercent": 48.2,
-      "discriminability": 0.59,
-      "ratioDiscriminability": 0.965
+      "aCount": 48,
+      "bCount": 35,
+      "aPercent": 57.8,
+      "bPercent": 42.2,
+      "discriminability": 0.687,
+      "ratioDiscriminability": 0.843
     },
     {
       "question": 2,
-      "aCount": 51,
-      "bCount": 90,
-      "aPercent": 36.2,
-      "bPercent": 63.8,
-      "discriminability": 0.69,
-      "ratioDiscriminability": 0.723
+      "aCount": 29,
+      "bCount": 54,
+      "aPercent": 34.9,
+      "bPercent": 65.1,
+      "discriminability": 0.792,
+      "ratioDiscriminability": 0.699
     },
     {
       "question": 3,
-      "aCount": 101,
-      "bCount": 40,
-      "aPercent": 71.6,
-      "bPercent": 28.4,
-      "discriminability": 0.558,
-      "ratioDiscriminability": 0.567
+      "aCount": 60,
+      "bCount": 23,
+      "aPercent": 72.3,
+      "bPercent": 27.7,
+      "discriminability": 0.699,
+      "ratioDiscriminability": 0.554
     },
     {
       "question": 4,
-      "aCount": 35,
-      "bCount": 106,
-      "aPercent": 24.8,
-      "bPercent": 75.2,
-      "discriminability": 0.673,
-      "ratioDiscriminability": 0.496
+      "aCount": 26,
+      "bCount": 57,
+      "aPercent": 31.3,
+      "bPercent": 68.7,
+      "discriminability": 0.761,
+      "ratioDiscriminability": 0.627
     },
     {
       "question": 5,
-      "aCount": 64,
-      "bCount": 77,
-      "aPercent": 45.4,
-      "bPercent": 54.6,
-      "discriminability": 0.426,
-      "ratioDiscriminability": 0.908
+      "aCount": 50,
+      "bCount": 33,
+      "aPercent": 60.2,
+      "bPercent": 39.8,
+      "discriminability": 0.488,
+      "ratioDiscriminability": 0.795
     },
     {
       "question": 6,
-      "aCount": 93,
-      "bCount": 48,
-      "aPercent": 66,
-      "bPercent": 34,
-      "discriminability": 0.371,
-      "ratioDiscriminability": 0.681
+      "aCount": 47,
+      "bCount": 36,
+      "aPercent": 56.6,
+      "bPercent": 43.4,
+      "discriminability": 0.545,
+      "ratioDiscriminability": 0.867
     },
     {
       "question": 7,
-      "aCount": 109,
-      "bCount": 32,
-      "aPercent": 77.3,
-      "bPercent": 22.7,
-      "discriminability": 0.523,
-      "ratioDiscriminability": 0.454
+      "aCount": 62,
+      "bCount": 21,
+      "aPercent": 74.7,
+      "bPercent": 25.3,
+      "discriminability": 0.482,
+      "ratioDiscriminability": 0.506
     },
     {
       "question": 8,
-      "aCount": 48,
-      "bCount": 93,
-      "aPercent": 34,
-      "bPercent": 66,
-      "discriminability": 0.365,
-      "ratioDiscriminability": 0.681
+      "aCount": 29,
+      "bCount": 54,
+      "aPercent": 34.9,
+      "bPercent": 65.1,
+      "discriminability": 0.732,
+      "ratioDiscriminability": 0.699
     },
     {
       "question": 9,
-      "aCount": 83,
-      "bCount": 58,
-      "aPercent": 58.9,
-      "bPercent": 41.1,
-      "discriminability": 0.503,
-      "ratioDiscriminability": 0.823
+      "aCount": 56,
+      "bCount": 27,
+      "aPercent": 67.5,
+      "bPercent": 32.5,
+      "discriminability": 0.502,
+      "ratioDiscriminability": 0.651
     },
     {
       "question": 10,
-      "aCount": 61,
-      "bCount": 80,
-      "aPercent": 43.3,
-      "bPercent": 56.7,
-      "discriminability": 0.787,
-      "ratioDiscriminability": 0.865
+      "aCount": 34,
+      "bCount": 49,
+      "aPercent": 41,
+      "bPercent": 59,
+      "discriminability": 0.811,
+      "ratioDiscriminability": 0.819
     },
     {
       "question": 11,
-      "aCount": 37,
-      "bCount": 104,
-      "aPercent": 26.2,
-      "bPercent": 73.8,
-      "discriminability": 0.547,
-      "ratioDiscriminability": 0.525
+      "aCount": 28,
+      "bCount": 55,
+      "aPercent": 33.7,
+      "bPercent": 66.3,
+      "discriminability": 0.664,
+      "ratioDiscriminability": 0.675
     },
     {
       "question": 12,
-      "aCount": 73,
-      "bCount": 68,
-      "aPercent": 51.8,
-      "bPercent": 48.2,
-      "discriminability": 0.594,
-      "ratioDiscriminability": 0.965
+      "aCount": 49,
+      "bCount": 34,
+      "aPercent": 59,
+      "bPercent": 41,
+      "discriminability": 0.568,
+      "ratioDiscriminability": 0.819
     },
     {
       "question": 13,
-      "aCount": 84,
-      "bCount": 57,
-      "aPercent": 59.6,
-      "bPercent": 40.4,
-      "discriminability": 0.711,
-      "ratioDiscriminability": 0.809
+      "aCount": 55,
+      "bCount": 28,
+      "aPercent": 66.3,
+      "bPercent": 33.7,
+      "discriminability": 0.659,
+      "ratioDiscriminability": 0.675
     },
     {
       "question": 14,
-      "aCount": 58,
-      "bCount": 83,
-      "aPercent": 41.1,
-      "bPercent": 58.9,
-      "discriminability": 0.664,
-      "ratioDiscriminability": 0.823
+      "aCount": 34,
+      "bCount": 49,
+      "aPercent": 41,
+      "bPercent": 59,
+      "discriminability": 0.607,
+      "ratioDiscriminability": 0.819
     },
     {
       "question": 15,
-      "aCount": 76,
-      "bCount": 65,
-      "aPercent": 53.9,
-      "bPercent": 46.1,
-      "discriminability": 0.695,
-      "ratioDiscriminability": 0.922
+      "aCount": 48,
+      "bCount": 35,
+      "aPercent": 57.8,
+      "bPercent": 42.2,
+      "discriminability": 0.681,
+      "ratioDiscriminability": 0.843
     },
     {
       "question": 16,
-      "aCount": 104,
-      "bCount": 37,
-      "aPercent": 73.8,
-      "bPercent": 26.2,
-      "discriminability": 0.474,
-      "ratioDiscriminability": 0.525
-
+      "aCount": 59,
+      "bCount": 24,
+      "aPercent": 71.1,
+      "bPercent": 28.9,
+      "discriminability": 0.528,
+      "ratioDiscriminability": 0.578
     }
   ],
   "dimensions": [
@@ -159,43 +158,42 @@
       "questions": [
         {
           "question": 1,
-          "aCount": 73,
-          "bCount": 68,
-          "aPercent": 51.8,
-          "bPercent": 48.2,
-          "discriminability": 0.59,
-          "ratioDiscriminability": 0.965
+          "aCount": 48,
+          "bCount": 35,
+          "aPercent": 57.8,
+          "bPercent": 42.2,
+          "discriminability": 0.687,
+          "ratioDiscriminability": 0.843
         },
         {
           "question": 2,
-          "aCount": 51,
-          "bCount": 90,
-          "aPercent": 36.2,
-          "bPercent": 63.8,
-          "discriminability": 0.69,
-          "ratioDiscriminability": 0.723
+          "aCount": 29,
+          "bCount": 54,
+          "aPercent": 34.9,
+          "bPercent": 65.1,
+          "discriminability": 0.792,
+          "ratioDiscriminability": 0.699
         },
         {
           "question": 3,
-          "aCount": 101,
-          "bCount": 40,
-          "aPercent": 71.6,
-          "bPercent": 28.4,
-          "discriminability": 0.558,
-          "ratioDiscriminability": 0.567
+          "aCount": 60,
+          "bCount": 23,
+          "aPercent": 72.3,
+          "bPercent": 27.7,
+          "discriminability": 0.699,
+          "ratioDiscriminability": 0.554
         },
         {
           "question": 4,
-          "aCount": 35,
-          "bCount": 106,
-          "aPercent": 24.8,
-          "bPercent": 75.2,
-          "discriminability": 0.673,
-          "ratioDiscriminability": 0.496
+          "aCount": 26,
+          "bCount": 57,
+          "aPercent": 31.3,
+          "bPercent": 68.7,
+          "discriminability": 0.761,
+          "ratioDiscriminability": 0.627
         }
       ],
-      "averageDiscriminability": 0.628
-
+      "averageDiscriminability": 0.735
     },
     {
       "name": "Precision",
@@ -206,43 +204,42 @@
       "questions": [
         {
           "question": 5,
-          "aCount": 64,
-          "bCount": 77,
-          "aPercent": 45.4,
-          "bPercent": 54.6,
-          "discriminability": 0.426,
-          "ratioDiscriminability": 0.908
+          "aCount": 50,
+          "bCount": 33,
+          "aPercent": 60.2,
+          "bPercent": 39.8,
+          "discriminability": 0.488,
+          "ratioDiscriminability": 0.795
         },
         {
           "question": 6,
-          "aCount": 93,
-          "bCount": 48,
-          "aPercent": 66,
-          "bPercent": 34,
-          "discriminability": 0.371,
-          "ratioDiscriminability": 0.681
+          "aCount": 47,
+          "bCount": 36,
+          "aPercent": 56.6,
+          "bPercent": 43.4,
+          "discriminability": 0.545,
+          "ratioDiscriminability": 0.867
         },
         {
           "question": 7,
-          "aCount": 109,
-          "bCount": 32,
-          "aPercent": 77.3,
-          "bPercent": 22.7,
-          "discriminability": 0.523,
-          "ratioDiscriminability": 0.454
+          "aCount": 62,
+          "bCount": 21,
+          "aPercent": 74.7,
+          "bPercent": 25.3,
+          "discriminability": 0.482,
+          "ratioDiscriminability": 0.506
         },
         {
           "question": 8,
-          "aCount": 48,
-          "bCount": 93,
-          "aPercent": 34,
-          "bPercent": 66,
-          "discriminability": 0.365,
-          "ratioDiscriminability": 0.681
+          "aCount": 29,
+          "bCount": 54,
+          "aPercent": 34.9,
+          "bPercent": 65.1,
+          "discriminability": 0.732,
+          "ratioDiscriminability": 0.699
         }
       ],
-      "averageDiscriminability": 0.421
-
+      "averageDiscriminability": 0.562
     },
     {
       "name": "Transparency",
@@ -253,43 +250,42 @@
       "questions": [
         {
           "question": 9,
-          "aCount": 83,
-          "bCount": 58,
-          "aPercent": 58.9,
-          "bPercent": 41.1,
-          "discriminability": 0.503,
-          "ratioDiscriminability": 0.823
+          "aCount": 56,
+          "bCount": 27,
+          "aPercent": 67.5,
+          "bPercent": 32.5,
+          "discriminability": 0.502,
+          "ratioDiscriminability": 0.651
         },
         {
           "question": 10,
-          "aCount": 61,
-          "bCount": 80,
-          "aPercent": 43.3,
-          "bPercent": 56.7,
-          "discriminability": 0.787,
-          "ratioDiscriminability": 0.865
+          "aCount": 34,
+          "bCount": 49,
+          "aPercent": 41,
+          "bPercent": 59,
+          "discriminability": 0.811,
+          "ratioDiscriminability": 0.819
         },
         {
           "question": 11,
-          "aCount": 37,
-          "bCount": 104,
-          "aPercent": 26.2,
-          "bPercent": 73.8,
-          "discriminability": 0.547,
-          "ratioDiscriminability": 0.525
+          "aCount": 28,
+          "bCount": 55,
+          "aPercent": 33.7,
+          "bPercent": 66.3,
+          "discriminability": 0.664,
+          "ratioDiscriminability": 0.675
         },
         {
           "question": 12,
-          "aCount": 73,
-          "bCount": 68,
-          "aPercent": 51.8,
-          "bPercent": 48.2,
-          "discriminability": 0.594,
-          "ratioDiscriminability": 0.965
+          "aCount": 49,
+          "bCount": 34,
+          "aPercent": 59,
+          "bPercent": 41,
+          "discriminability": 0.568,
+          "ratioDiscriminability": 0.819
         }
       ],
-      "averageDiscriminability": 0.608
-
+      "averageDiscriminability": 0.636
     },
     {
       "name": "Adaptability",
@@ -300,193 +296,191 @@
       "questions": [
         {
           "question": 13,
-          "aCount": 84,
-          "bCount": 57,
-          "aPercent": 59.6,
-          "bPercent": 40.4,
-          "discriminability": 0.711,
-          "ratioDiscriminability": 0.809
+          "aCount": 55,
+          "bCount": 28,
+          "aPercent": 66.3,
+          "bPercent": 33.7,
+          "discriminability": 0.659,
+          "ratioDiscriminability": 0.675
         },
         {
           "question": 14,
-          "aCount": 58,
-          "bCount": 83,
-          "aPercent": 41.1,
-          "bPercent": 58.9,
-          "discriminability": 0.664,
-          "ratioDiscriminability": 0.823
+          "aCount": 34,
+          "bCount": 49,
+          "aPercent": 41,
+          "bPercent": 59,
+          "discriminability": 0.607,
+          "ratioDiscriminability": 0.819
         },
         {
           "question": 15,
-          "aCount": 76,
-          "bCount": 65,
-          "aPercent": 53.9,
-          "bPercent": 46.1,
-          "discriminability": 0.695,
-          "ratioDiscriminability": 0.922
+          "aCount": 48,
+          "bCount": 35,
+          "aPercent": 57.8,
+          "bPercent": 42.2,
+          "discriminability": 0.681,
+          "ratioDiscriminability": 0.843
         },
         {
           "question": 16,
-          "aCount": 104,
-          "bCount": 37,
-          "aPercent": 73.8,
-          "bPercent": 26.2,
-          "discriminability": 0.474,
-          "ratioDiscriminability": 0.525
+          "aCount": 59,
+          "bCount": 24,
+          "aPercent": 71.1,
+          "bPercent": 28.9,
+          "discriminability": 0.528,
+          "ratioDiscriminability": 0.578
         }
       ],
-      "averageDiscriminability": 0.636
-
+      "averageDiscriminability": 0.619
     }
   ],
   "cohorts": {
     "all": {
-      "totalRuns": 141,
+      "totalRuns": 83,
       "questions": [
         {
           "question": 1,
-          "aCount": 73,
-          "bCount": 68,
-          "aPercent": 51.8,
-          "bPercent": 48.2,
-          "discriminability": 0.59,
-          "ratioDiscriminability": 0.965
+          "aCount": 48,
+          "bCount": 35,
+          "aPercent": 57.8,
+          "bPercent": 42.2,
+          "discriminability": 0.687,
+          "ratioDiscriminability": 0.843
         },
         {
           "question": 2,
-          "aCount": 51,
-          "bCount": 90,
-          "aPercent": 36.2,
-          "bPercent": 63.8,
-          "discriminability": 0.69,
-          "ratioDiscriminability": 0.723
+          "aCount": 29,
+          "bCount": 54,
+          "aPercent": 34.9,
+          "bPercent": 65.1,
+          "discriminability": 0.792,
+          "ratioDiscriminability": 0.699
         },
         {
           "question": 3,
-          "aCount": 101,
-          "bCount": 40,
-          "aPercent": 71.6,
-          "bPercent": 28.4,
-          "discriminability": 0.558,
-          "ratioDiscriminability": 0.567
+          "aCount": 60,
+          "bCount": 23,
+          "aPercent": 72.3,
+          "bPercent": 27.7,
+          "discriminability": 0.699,
+          "ratioDiscriminability": 0.554
         },
         {
           "question": 4,
-          "aCount": 35,
-          "bCount": 106,
-          "aPercent": 24.8,
-          "bPercent": 75.2,
-          "discriminability": 0.673,
-          "ratioDiscriminability": 0.496
+          "aCount": 26,
+          "bCount": 57,
+          "aPercent": 31.3,
+          "bPercent": 68.7,
+          "discriminability": 0.761,
+          "ratioDiscriminability": 0.627
         },
         {
           "question": 5,
-          "aCount": 64,
-          "bCount": 77,
-          "aPercent": 45.4,
-          "bPercent": 54.6,
-          "discriminability": 0.426,
-          "ratioDiscriminability": 0.908
+          "aCount": 50,
+          "bCount": 33,
+          "aPercent": 60.2,
+          "bPercent": 39.8,
+          "discriminability": 0.488,
+          "ratioDiscriminability": 0.795
         },
         {
           "question": 6,
-          "aCount": 93,
-          "bCount": 48,
-          "aPercent": 66,
-          "bPercent": 34,
-          "discriminability": 0.371,
-          "ratioDiscriminability": 0.681
+          "aCount": 47,
+          "bCount": 36,
+          "aPercent": 56.6,
+          "bPercent": 43.4,
+          "discriminability": 0.545,
+          "ratioDiscriminability": 0.867
         },
         {
           "question": 7,
-          "aCount": 109,
-          "bCount": 32,
-          "aPercent": 77.3,
-          "bPercent": 22.7,
-          "discriminability": 0.523,
-          "ratioDiscriminability": 0.454
+          "aCount": 62,
+          "bCount": 21,
+          "aPercent": 74.7,
+          "bPercent": 25.3,
+          "discriminability": 0.482,
+          "ratioDiscriminability": 0.506
         },
         {
           "question": 8,
-          "aCount": 48,
-          "bCount": 93,
-          "aPercent": 34,
-          "bPercent": 66,
-          "discriminability": 0.365,
-          "ratioDiscriminability": 0.681
+          "aCount": 29,
+          "bCount": 54,
+          "aPercent": 34.9,
+          "bPercent": 65.1,
+          "discriminability": 0.732,
+          "ratioDiscriminability": 0.699
         },
         {
           "question": 9,
-          "aCount": 83,
-          "bCount": 58,
-          "aPercent": 58.9,
-          "bPercent": 41.1,
-          "discriminability": 0.503,
-          "ratioDiscriminability": 0.823
+          "aCount": 56,
+          "bCount": 27,
+          "aPercent": 67.5,
+          "bPercent": 32.5,
+          "discriminability": 0.502,
+          "ratioDiscriminability": 0.651
         },
         {
           "question": 10,
-          "aCount": 61,
-          "bCount": 80,
-          "aPercent": 43.3,
-          "bPercent": 56.7,
-          "discriminability": 0.787,
-          "ratioDiscriminability": 0.865
+          "aCount": 34,
+          "bCount": 49,
+          "aPercent": 41,
+          "bPercent": 59,
+          "discriminability": 0.811,
+          "ratioDiscriminability": 0.819
         },
         {
           "question": 11,
-          "aCount": 37,
-          "bCount": 104,
-          "aPercent": 26.2,
-          "bPercent": 73.8,
-          "discriminability": 0.547,
-          "ratioDiscriminability": 0.525
+          "aCount": 28,
+          "bCount": 55,
+          "aPercent": 33.7,
+          "bPercent": 66.3,
+          "discriminability": 0.664,
+          "ratioDiscriminability": 0.675
         },
         {
           "question": 12,
-          "aCount": 73,
-          "bCount": 68,
-          "aPercent": 51.8,
-          "bPercent": 48.2,
-          "discriminability": 0.594,
-          "ratioDiscriminability": 0.965
+          "aCount": 49,
+          "bCount": 34,
+          "aPercent": 59,
+          "bPercent": 41,
+          "discriminability": 0.568,
+          "ratioDiscriminability": 0.819
         },
         {
           "question": 13,
-          "aCount": 84,
-          "bCount": 57,
-          "aPercent": 59.6,
-          "bPercent": 40.4,
-          "discriminability": 0.711,
-          "ratioDiscriminability": 0.809
+          "aCount": 55,
+          "bCount": 28,
+          "aPercent": 66.3,
+          "bPercent": 33.7,
+          "discriminability": 0.659,
+          "ratioDiscriminability": 0.675
         },
         {
           "question": 14,
-          "aCount": 58,
-          "bCount": 83,
-          "aPercent": 41.1,
-          "bPercent": 58.9,
-          "discriminability": 0.664,
-          "ratioDiscriminability": 0.823
+          "aCount": 34,
+          "bCount": 49,
+          "aPercent": 41,
+          "bPercent": 59,
+          "discriminability": 0.607,
+          "ratioDiscriminability": 0.819
         },
         {
           "question": 15,
-          "aCount": 76,
-          "bCount": 65,
-          "aPercent": 53.9,
-          "bPercent": 46.1,
-          "discriminability": 0.695,
-          "ratioDiscriminability": 0.922
+          "aCount": 48,
+          "bCount": 35,
+          "aPercent": 57.8,
+          "bPercent": 42.2,
+          "discriminability": 0.681,
+          "ratioDiscriminability": 0.843
         },
         {
           "question": 16,
-          "aCount": 104,
-          "bCount": 37,
-          "aPercent": 73.8,
-          "bPercent": 26.2,
-          "discriminability": 0.474,
-          "ratioDiscriminability": 0.525
-
+          "aCount": 59,
+          "bCount": 24,
+          "aPercent": 71.1,
+          "bPercent": 28.9,
+          "discriminability": 0.528,
+          "ratioDiscriminability": 0.578
         }
       ],
       "dimensions": [
@@ -499,43 +493,42 @@
           "questions": [
             {
               "question": 1,
-              "aCount": 73,
-              "bCount": 68,
-              "aPercent": 51.8,
-              "bPercent": 48.2,
-              "discriminability": 0.59,
-              "ratioDiscriminability": 0.965
+              "aCount": 48,
+              "bCount": 35,
+              "aPercent": 57.8,
+              "bPercent": 42.2,
+              "discriminability": 0.687,
+              "ratioDiscriminability": 0.843
             },
             {
               "question": 2,
-              "aCount": 51,
-              "bCount": 90,
-              "aPercent": 36.2,
-              "bPercent": 63.8,
-              "discriminability": 0.69,
-              "ratioDiscriminability": 0.723
+              "aCount": 29,
+              "bCount": 54,
+              "aPercent": 34.9,
+              "bPercent": 65.1,
+              "discriminability": 0.792,
+              "ratioDiscriminability": 0.699
             },
             {
               "question": 3,
-              "aCount": 101,
-              "bCount": 40,
-              "aPercent": 71.6,
-              "bPercent": 28.4,
-              "discriminability": 0.558,
-              "ratioDiscriminability": 0.567
+              "aCount": 60,
+              "bCount": 23,
+              "aPercent": 72.3,
+              "bPercent": 27.7,
+              "discriminability": 0.699,
+              "ratioDiscriminability": 0.554
             },
             {
               "question": 4,
-              "aCount": 35,
-              "bCount": 106,
-              "aPercent": 24.8,
-              "bPercent": 75.2,
-              "discriminability": 0.673,
-              "ratioDiscriminability": 0.496
+              "aCount": 26,
+              "bCount": 57,
+              "aPercent": 31.3,
+              "bPercent": 68.7,
+              "discriminability": 0.761,
+              "ratioDiscriminability": 0.627
             }
           ],
-          "averageDiscriminability": 0.628
-
+          "averageDiscriminability": 0.735
         },
         {
           "name": "Precision",
@@ -546,43 +539,42 @@
           "questions": [
             {
               "question": 5,
-              "aCount": 64,
-              "bCount": 77,
-              "aPercent": 45.4,
-              "bPercent": 54.6,
-              "discriminability": 0.426,
-              "ratioDiscriminability": 0.908
+              "aCount": 50,
+              "bCount": 33,
+              "aPercent": 60.2,
+              "bPercent": 39.8,
+              "discriminability": 0.488,
+              "ratioDiscriminability": 0.795
             },
             {
               "question": 6,
-              "aCount": 93,
-              "bCount": 48,
-              "aPercent": 66,
-              "bPercent": 34,
-              "discriminability": 0.371,
-              "ratioDiscriminability": 0.681
+              "aCount": 47,
+              "bCount": 36,
+              "aPercent": 56.6,
+              "bPercent": 43.4,
+              "discriminability": 0.545,
+              "ratioDiscriminability": 0.867
             },
             {
               "question": 7,
-              "aCount": 109,
-              "bCount": 32,
-              "aPercent": 77.3,
-              "bPercent": 22.7,
-              "discriminability": 0.523,
-              "ratioDiscriminability": 0.454
+              "aCount": 62,
+              "bCount": 21,
+              "aPercent": 74.7,
+              "bPercent": 25.3,
+              "discriminability": 0.482,
+              "ratioDiscriminability": 0.506
             },
             {
               "question": 8,
-              "aCount": 48,
-              "bCount": 93,
-              "aPercent": 34,
-              "bPercent": 66,
-              "discriminability": 0.365,
-              "ratioDiscriminability": 0.681
+              "aCount": 29,
+              "bCount": 54,
+              "aPercent": 34.9,
+              "bPercent": 65.1,
+              "discriminability": 0.732,
+              "ratioDiscriminability": 0.699
             }
           ],
-          "averageDiscriminability": 0.421
-
+          "averageDiscriminability": 0.562
         },
         {
           "name": "Transparency",
@@ -593,43 +585,42 @@
           "questions": [
             {
               "question": 9,
-              "aCount": 83,
-              "bCount": 58,
-              "aPercent": 58.9,
-              "bPercent": 41.1,
-              "discriminability": 0.503,
-              "ratioDiscriminability": 0.823
+              "aCount": 56,
+              "bCount": 27,
+              "aPercent": 67.5,
+              "bPercent": 32.5,
+              "discriminability": 0.502,
+              "ratioDiscriminability": 0.651
             },
             {
               "question": 10,
-              "aCount": 61,
-              "bCount": 80,
-              "aPercent": 43.3,
-              "bPercent": 56.7,
-              "discriminability": 0.787,
-              "ratioDiscriminability": 0.865
+              "aCount": 34,
+              "bCount": 49,
+              "aPercent": 41,
+              "bPercent": 59,
+              "discriminability": 0.811,
+              "ratioDiscriminability": 0.819
             },
             {
               "question": 11,
-              "aCount": 37,
-              "bCount": 104,
-              "aPercent": 26.2,
-              "bPercent": 73.8,
-              "discriminability": 0.547,
-              "ratioDiscriminability": 0.525
+              "aCount": 28,
+              "bCount": 55,
+              "aPercent": 33.7,
+              "bPercent": 66.3,
+              "discriminability": 0.664,
+              "ratioDiscriminability": 0.675
             },
             {
               "question": 12,
-              "aCount": 73,
-              "bCount": 68,
-              "aPercent": 51.8,
-              "bPercent": 48.2,
-              "discriminability": 0.594,
-              "ratioDiscriminability": 0.965
+              "aCount": 49,
+              "bCount": 34,
+              "aPercent": 59,
+              "bPercent": 41,
+              "discriminability": 0.568,
+              "ratioDiscriminability": 0.819
             }
           ],
-          "averageDiscriminability": 0.608
-
+          "averageDiscriminability": 0.636
         },
         {
           "name": "Adaptability",
@@ -640,193 +631,526 @@
           "questions": [
             {
               "question": 13,
-              "aCount": 84,
-              "bCount": 57,
-              "aPercent": 59.6,
-              "bPercent": 40.4,
-              "discriminability": 0.711,
-              "ratioDiscriminability": 0.809
+              "aCount": 55,
+              "bCount": 28,
+              "aPercent": 66.3,
+              "bPercent": 33.7,
+              "discriminability": 0.659,
+              "ratioDiscriminability": 0.675
             },
             {
               "question": 14,
-              "aCount": 58,
-              "bCount": 83,
-              "aPercent": 41.1,
-              "bPercent": 58.9,
-              "discriminability": 0.664,
-              "ratioDiscriminability": 0.823
+              "aCount": 34,
+              "bCount": 49,
+              "aPercent": 41,
+              "bPercent": 59,
+              "discriminability": 0.607,
+              "ratioDiscriminability": 0.819
             },
             {
               "question": 15,
-              "aCount": 76,
-              "bCount": 65,
-              "aPercent": 53.9,
-              "bPercent": 46.1,
-              "discriminability": 0.695,
-              "ratioDiscriminability": 0.922
+              "aCount": 48,
+              "bCount": 35,
+              "aPercent": 57.8,
+              "bPercent": 42.2,
+              "discriminability": 0.681,
+              "ratioDiscriminability": 0.843
             },
             {
               "question": 16,
-              "aCount": 104,
-              "bCount": 37,
-              "aPercent": 73.8,
-              "bPercent": 26.2,
-              "discriminability": 0.474,
-              "ratioDiscriminability": 0.525
+              "aCount": 59,
+              "bCount": 24,
+              "aPercent": 71.1,
+              "bPercent": 28.9,
+              "discriminability": 0.528,
+              "ratioDiscriminability": 0.578
             }
           ],
-          "averageDiscriminability": 0.636
-
+          "averageDiscriminability": 0.619
+        }
+      ]
+    },
+    "v4": {
+      "totalRuns": 24,
+      "questions": [
+        {
+          "question": 1,
+          "aCount": 9,
+          "bCount": 15,
+          "aPercent": 37.5,
+          "bPercent": 62.5,
+          "discriminability": 0.702,
+          "ratioDiscriminability": 0.75
+        },
+        {
+          "question": 2,
+          "aCount": 10,
+          "bCount": 14,
+          "aPercent": 41.7,
+          "bPercent": 58.3,
+          "discriminability": 0.866,
+          "ratioDiscriminability": 0.833
+        },
+        {
+          "question": 3,
+          "aCount": 16,
+          "bCount": 8,
+          "aPercent": 66.7,
+          "bPercent": 33.3,
+          "discriminability": 0.882,
+          "ratioDiscriminability": 0.667
+        },
+        {
+          "question": 4,
+          "aCount": 10,
+          "bCount": 14,
+          "aPercent": 41.7,
+          "bPercent": 58.3,
+          "discriminability": 0.726,
+          "ratioDiscriminability": 0.833
+        },
+        {
+          "question": 5,
+          "aCount": 18,
+          "bCount": 6,
+          "aPercent": 75,
+          "bPercent": 25,
+          "discriminability": 0.645,
+          "ratioDiscriminability": 0.5
+        },
+        {
+          "question": 6,
+          "aCount": 12,
+          "bCount": 12,
+          "aPercent": 50,
+          "bPercent": 50,
+          "discriminability": 0.667,
+          "ratioDiscriminability": 1
+        },
+        {
+          "question": 7,
+          "aCount": 20,
+          "bCount": 4,
+          "aPercent": 83.3,
+          "bPercent": 16.7,
+          "discriminability": 0.577,
+          "ratioDiscriminability": 0.333
+        },
+        {
+          "question": 8,
+          "aCount": 9,
+          "bCount": 15,
+          "aPercent": 37.5,
+          "bPercent": 62.5,
+          "discriminability": 0.846,
+          "ratioDiscriminability": 0.75
+        },
+        {
+          "question": 9,
+          "aCount": 16,
+          "bCount": 8,
+          "aPercent": 66.7,
+          "bPercent": 33.3,
+          "discriminability": 0.667,
+          "ratioDiscriminability": 0.667
+        },
+        {
+          "question": 10,
+          "aCount": 8,
+          "bCount": 16,
+          "aPercent": 33.3,
+          "bPercent": 66.7,
+          "discriminability": 0.816,
+          "ratioDiscriminability": 0.667
+        },
+        {
+          "question": 11,
+          "aCount": 8,
+          "bCount": 16,
+          "aPercent": 33.3,
+          "bPercent": 66.7,
+          "discriminability": 0.745,
+          "ratioDiscriminability": 0.667
+        },
+        {
+          "question": 12,
+          "aCount": 13,
+          "bCount": 11,
+          "aPercent": 54.2,
+          "bPercent": 45.8,
+          "discriminability": 0.661,
+          "ratioDiscriminability": 0.917
+        },
+        {
+          "question": 13,
+          "aCount": 16,
+          "bCount": 8,
+          "aPercent": 66.7,
+          "bPercent": 33.3,
+          "discriminability": 0.816,
+          "ratioDiscriminability": 0.667
+        },
+        {
+          "question": 14,
+          "aCount": 10,
+          "bCount": 14,
+          "aPercent": 41.7,
+          "bPercent": 58.3,
+          "discriminability": 0.553,
+          "ratioDiscriminability": 0.833
+        },
+        {
+          "question": 15,
+          "aCount": 15,
+          "bCount": 9,
+          "aPercent": 62.5,
+          "bPercent": 37.5,
+          "discriminability": 0.618,
+          "ratioDiscriminability": 0.75
+        },
+        {
+          "question": 16,
+          "aCount": 17,
+          "bCount": 7,
+          "aPercent": 70.8,
+          "bPercent": 29.2,
+          "discriminability": 0.618,
+          "ratioDiscriminability": 0.583
+        }
+      ],
+      "dimensions": [
+        {
+          "name": "Autonomy",
+          "poles": [
+            "P",
+            "R"
+          ],
+          "questions": [
+            {
+              "question": 1,
+              "aCount": 9,
+              "bCount": 15,
+              "aPercent": 37.5,
+              "bPercent": 62.5,
+              "discriminability": 0.702,
+              "ratioDiscriminability": 0.75
+            },
+            {
+              "question": 2,
+              "aCount": 10,
+              "bCount": 14,
+              "aPercent": 41.7,
+              "bPercent": 58.3,
+              "discriminability": 0.866,
+              "ratioDiscriminability": 0.833
+            },
+            {
+              "question": 3,
+              "aCount": 16,
+              "bCount": 8,
+              "aPercent": 66.7,
+              "bPercent": 33.3,
+              "discriminability": 0.882,
+              "ratioDiscriminability": 0.667
+            },
+            {
+              "question": 4,
+              "aCount": 10,
+              "bCount": 14,
+              "aPercent": 41.7,
+              "bPercent": 58.3,
+              "discriminability": 0.726,
+              "ratioDiscriminability": 0.833
+            }
+          ],
+          "averageDiscriminability": 0.794
+        },
+        {
+          "name": "Precision",
+          "poles": [
+            "T",
+            "E"
+          ],
+          "questions": [
+            {
+              "question": 5,
+              "aCount": 18,
+              "bCount": 6,
+              "aPercent": 75,
+              "bPercent": 25,
+              "discriminability": 0.645,
+              "ratioDiscriminability": 0.5
+            },
+            {
+              "question": 6,
+              "aCount": 12,
+              "bCount": 12,
+              "aPercent": 50,
+              "bPercent": 50,
+              "discriminability": 0.667,
+              "ratioDiscriminability": 1
+            },
+            {
+              "question": 7,
+              "aCount": 20,
+              "bCount": 4,
+              "aPercent": 83.3,
+              "bPercent": 16.7,
+              "discriminability": 0.577,
+              "ratioDiscriminability": 0.333
+            },
+            {
+              "question": 8,
+              "aCount": 9,
+              "bCount": 15,
+              "aPercent": 37.5,
+              "bPercent": 62.5,
+              "discriminability": 0.846,
+              "ratioDiscriminability": 0.75
+            }
+          ],
+          "averageDiscriminability": 0.684
+        },
+        {
+          "name": "Transparency",
+          "poles": [
+            "C",
+            "D"
+          ],
+          "questions": [
+            {
+              "question": 9,
+              "aCount": 16,
+              "bCount": 8,
+              "aPercent": 66.7,
+              "bPercent": 33.3,
+              "discriminability": 0.667,
+              "ratioDiscriminability": 0.667
+            },
+            {
+              "question": 10,
+              "aCount": 8,
+              "bCount": 16,
+              "aPercent": 33.3,
+              "bPercent": 66.7,
+              "discriminability": 0.816,
+              "ratioDiscriminability": 0.667
+            },
+            {
+              "question": 11,
+              "aCount": 8,
+              "bCount": 16,
+              "aPercent": 33.3,
+              "bPercent": 66.7,
+              "discriminability": 0.745,
+              "ratioDiscriminability": 0.667
+            },
+            {
+              "question": 12,
+              "aCount": 13,
+              "bCount": 11,
+              "aPercent": 54.2,
+              "bPercent": 45.8,
+              "discriminability": 0.661,
+              "ratioDiscriminability": 0.917
+            }
+          ],
+          "averageDiscriminability": 0.722
+        },
+        {
+          "name": "Adaptability",
+          "poles": [
+            "F",
+            "N"
+          ],
+          "questions": [
+            {
+              "question": 13,
+              "aCount": 16,
+              "bCount": 8,
+              "aPercent": 66.7,
+              "bPercent": 33.3,
+              "discriminability": 0.816,
+              "ratioDiscriminability": 0.667
+            },
+            {
+              "question": 14,
+              "aCount": 10,
+              "bCount": 14,
+              "aPercent": 41.7,
+              "bPercent": 58.3,
+              "discriminability": 0.553,
+              "ratioDiscriminability": 0.833
+            },
+            {
+              "question": 15,
+              "aCount": 15,
+              "bCount": 9,
+              "aPercent": 62.5,
+              "bPercent": 37.5,
+              "discriminability": 0.618,
+              "ratioDiscriminability": 0.75
+            },
+            {
+              "question": 16,
+              "aCount": 17,
+              "bCount": 7,
+              "aPercent": 70.8,
+              "bPercent": 29.2,
+              "discriminability": 0.618,
+              "ratioDiscriminability": 0.583
+            }
+          ],
+          "averageDiscriminability": 0.651
         }
       ]
     },
     "v5-beta": {
-      "totalRuns": 141,
+      "totalRuns": 59,
       "questions": [
         {
           "question": 1,
-          "aCount": 73,
-          "bCount": 68,
-          "aPercent": 51.8,
-          "bPercent": 48.2,
-          "discriminability": 0.59,
-          "ratioDiscriminability": 0.965
+          "aCount": 39,
+          "bCount": 20,
+          "aPercent": 66.1,
+          "bPercent": 33.9,
+          "discriminability": 0.596,
+          "ratioDiscriminability": 0.678
         },
         {
           "question": 2,
-          "aCount": 51,
-          "bCount": 90,
-          "aPercent": 36.2,
-          "bPercent": 63.8,
-          "discriminability": 0.69,
-          "ratioDiscriminability": 0.723
+          "aCount": 19,
+          "bCount": 40,
+          "aPercent": 32.2,
+          "bPercent": 67.8,
+          "discriminability": 0.666,
+          "ratioDiscriminability": 0.644
         },
         {
           "question": 3,
-          "aCount": 101,
-          "bCount": 40,
-          "aPercent": 71.6,
-          "bPercent": 28.4,
-          "discriminability": 0.558,
-          "ratioDiscriminability": 0.567
+          "aCount": 44,
+          "bCount": 15,
+          "aPercent": 74.6,
+          "bPercent": 25.4,
+          "discriminability": 0.551,
+          "ratioDiscriminability": 0.508
         },
         {
           "question": 4,
-          "aCount": 35,
-          "bCount": 106,
-          "aPercent": 24.8,
-          "bPercent": 75.2,
-          "discriminability": 0.673,
-          "ratioDiscriminability": 0.496
+          "aCount": 16,
+          "bCount": 43,
+          "aPercent": 27.1,
+          "bPercent": 72.9,
+          "discriminability": 0.742,
+          "ratioDiscriminability": 0.542
         },
         {
           "question": 5,
-          "aCount": 64,
-          "bCount": 77,
-          "aPercent": 45.4,
-          "bPercent": 54.6,
-          "discriminability": 0.426,
-          "ratioDiscriminability": 0.908
+          "aCount": 32,
+          "bCount": 27,
+          "aPercent": 54.2,
+          "bPercent": 45.8,
+          "discriminability": 0.436,
+          "ratioDiscriminability": 0.915
         },
         {
           "question": 6,
-          "aCount": 93,
-          "bCount": 48,
-          "aPercent": 66,
-          "bPercent": 34,
-          "discriminability": 0.371,
-          "ratioDiscriminability": 0.681
+          "aCount": 35,
+          "bCount": 24,
+          "aPercent": 59.3,
+          "bPercent": 40.7,
+          "discriminability": 0.226,
+          "ratioDiscriminability": 0.814
         },
         {
           "question": 7,
-          "aCount": 109,
-          "bCount": 32,
-          "aPercent": 77.3,
-          "bPercent": 22.7,
-          "discriminability": 0.523,
-          "ratioDiscriminability": 0.454
+          "aCount": 42,
+          "bCount": 17,
+          "aPercent": 71.2,
+          "bPercent": 28.8,
+          "discriminability": 0.416,
+          "ratioDiscriminability": 0.576
         },
         {
           "question": 8,
-          "aCount": 48,
-          "bCount": 93,
-          "aPercent": 34,
-          "bPercent": 66,
-          "discriminability": 0.365,
-          "ratioDiscriminability": 0.681
+          "aCount": 20,
+          "bCount": 39,
+          "aPercent": 33.9,
+          "bPercent": 66.1,
+          "discriminability": 0.627,
+          "ratioDiscriminability": 0.678
         },
         {
           "question": 9,
-          "aCount": 83,
-          "bCount": 58,
-          "aPercent": 58.9,
-          "bPercent": 41.1,
-          "discriminability": 0.503,
-          "ratioDiscriminability": 0.823
+          "aCount": 40,
+          "bCount": 19,
+          "aPercent": 67.8,
+          "bPercent": 32.2,
+          "discriminability": 0.408,
+          "ratioDiscriminability": 0.644
         },
         {
           "question": 10,
-          "aCount": 61,
-          "bCount": 80,
-          "aPercent": 43.3,
-          "bPercent": 56.7,
-          "discriminability": 0.787,
-          "ratioDiscriminability": 0.865
+          "aCount": 26,
+          "bCount": 33,
+          "aPercent": 44.1,
+          "bPercent": 55.9,
+          "discriminability": 0.898,
+          "ratioDiscriminability": 0.881
         },
         {
           "question": 11,
-          "aCount": 37,
-          "bCount": 104,
-          "aPercent": 26.2,
-          "bPercent": 73.8,
-          "discriminability": 0.547,
-          "ratioDiscriminability": 0.525
+          "aCount": 20,
+          "bCount": 39,
+          "aPercent": 33.9,
+          "bPercent": 66.1,
+          "discriminability": 0.69,
+          "ratioDiscriminability": 0.678
         },
         {
           "question": 12,
-          "aCount": 73,
-          "bCount": 68,
-          "aPercent": 51.8,
-          "bPercent": 48.2,
-          "discriminability": 0.594,
-          "ratioDiscriminability": 0.965
+          "aCount": 36,
+          "bCount": 23,
+          "aPercent": 61,
+          "bPercent": 39,
+          "discriminability": 0.38,
+          "ratioDiscriminability": 0.78
         },
         {
           "question": 13,
-          "aCount": 84,
-          "bCount": 57,
-          "aPercent": 59.6,
-          "bPercent": 40.4,
-          "discriminability": 0.711,
-          "ratioDiscriminability": 0.809
+          "aCount": 39,
+          "bCount": 20,
+          "aPercent": 66.1,
+          "bPercent": 33.9,
+          "discriminability": 0.674,
+          "ratioDiscriminability": 0.678
         },
         {
           "question": 14,
-          "aCount": 58,
-          "bCount": 83,
-          "aPercent": 41.1,
-          "bPercent": 58.9,
-          "discriminability": 0.664,
-          "ratioDiscriminability": 0.823
+          "aCount": 24,
+          "bCount": 35,
+          "aPercent": 40.7,
+          "bPercent": 59.3,
+          "discriminability": 0.736,
+          "ratioDiscriminability": 0.814
         },
         {
           "question": 15,
-          "aCount": 76,
-          "bCount": 65,
-          "aPercent": 53.9,
-          "bPercent": 46.1,
-          "discriminability": 0.695,
-          "ratioDiscriminability": 0.922
+          "aCount": 33,
+          "bCount": 26,
+          "aPercent": 55.9,
+          "bPercent": 44.1,
+          "discriminability": 0.68,
+          "ratioDiscriminability": 0.881
         },
         {
           "question": 16,
-          "aCount": 104,
-          "bCount": 37,
-          "aPercent": 73.8,
-          "bPercent": 26.2,
-          "discriminability": 0.474,
-          "ratioDiscriminability": 0.525
-
+          "aCount": 42,
+          "bCount": 17,
+          "aPercent": 71.2,
+          "bPercent": 28.8,
+          "discriminability": 0.429,
+          "ratioDiscriminability": 0.576
         }
       ],
       "dimensions": [
@@ -839,43 +1163,42 @@
           "questions": [
             {
               "question": 1,
-              "aCount": 73,
-              "bCount": 68,
-              "aPercent": 51.8,
-              "bPercent": 48.2,
-              "discriminability": 0.59,
-              "ratioDiscriminability": 0.965
+              "aCount": 39,
+              "bCount": 20,
+              "aPercent": 66.1,
+              "bPercent": 33.9,
+              "discriminability": 0.596,
+              "ratioDiscriminability": 0.678
             },
             {
               "question": 2,
-              "aCount": 51,
-              "bCount": 90,
-              "aPercent": 36.2,
-              "bPercent": 63.8,
-              "discriminability": 0.69,
-              "ratioDiscriminability": 0.723
+              "aCount": 19,
+              "bCount": 40,
+              "aPercent": 32.2,
+              "bPercent": 67.8,
+              "discriminability": 0.666,
+              "ratioDiscriminability": 0.644
             },
             {
               "question": 3,
-              "aCount": 101,
-              "bCount": 40,
-              "aPercent": 71.6,
-              "bPercent": 28.4,
-              "discriminability": 0.558,
-              "ratioDiscriminability": 0.567
+              "aCount": 44,
+              "bCount": 15,
+              "aPercent": 74.6,
+              "bPercent": 25.4,
+              "discriminability": 0.551,
+              "ratioDiscriminability": 0.508
             },
             {
               "question": 4,
-              "aCount": 35,
-              "bCount": 106,
-              "aPercent": 24.8,
-              "bPercent": 75.2,
-              "discriminability": 0.673,
-              "ratioDiscriminability": 0.496
+              "aCount": 16,
+              "bCount": 43,
+              "aPercent": 27.1,
+              "bPercent": 72.9,
+              "discriminability": 0.742,
+              "ratioDiscriminability": 0.542
             }
           ],
-          "averageDiscriminability": 0.628
-
+          "averageDiscriminability": 0.639
         },
         {
           "name": "Precision",
@@ -886,43 +1209,42 @@
           "questions": [
             {
               "question": 5,
-              "aCount": 64,
-              "bCount": 77,
-              "aPercent": 45.4,
-              "bPercent": 54.6,
-              "discriminability": 0.426,
-              "ratioDiscriminability": 0.908
+              "aCount": 32,
+              "bCount": 27,
+              "aPercent": 54.2,
+              "bPercent": 45.8,
+              "discriminability": 0.436,
+              "ratioDiscriminability": 0.915
             },
             {
               "question": 6,
-              "aCount": 93,
-              "bCount": 48,
-              "aPercent": 66,
-              "bPercent": 34,
-              "discriminability": 0.371,
-              "ratioDiscriminability": 0.681
+              "aCount": 35,
+              "bCount": 24,
+              "aPercent": 59.3,
+              "bPercent": 40.7,
+              "discriminability": 0.226,
+              "ratioDiscriminability": 0.814
             },
             {
               "question": 7,
-              "aCount": 109,
-              "bCount": 32,
-              "aPercent": 77.3,
-              "bPercent": 22.7,
-              "discriminability": 0.523,
-              "ratioDiscriminability": 0.454
+              "aCount": 42,
+              "bCount": 17,
+              "aPercent": 71.2,
+              "bPercent": 28.8,
+              "discriminability": 0.416,
+              "ratioDiscriminability": 0.576
             },
             {
               "question": 8,
-              "aCount": 48,
-              "bCount": 93,
-              "aPercent": 34,
-              "bPercent": 66,
-              "discriminability": 0.365,
-              "ratioDiscriminability": 0.681
+              "aCount": 20,
+              "bCount": 39,
+              "aPercent": 33.9,
+              "bPercent": 66.1,
+              "discriminability": 0.627,
+              "ratioDiscriminability": 0.678
             }
           ],
-          "averageDiscriminability": 0.421
-
+          "averageDiscriminability": 0.426
         },
         {
           "name": "Transparency",
@@ -933,43 +1255,42 @@
           "questions": [
             {
               "question": 9,
-              "aCount": 83,
-              "bCount": 58,
-              "aPercent": 58.9,
-              "bPercent": 41.1,
-              "discriminability": 0.503,
-              "ratioDiscriminability": 0.823
+              "aCount": 40,
+              "bCount": 19,
+              "aPercent": 67.8,
+              "bPercent": 32.2,
+              "discriminability": 0.408,
+              "ratioDiscriminability": 0.644
             },
             {
               "question": 10,
-              "aCount": 61,
-              "bCount": 80,
-              "aPercent": 43.3,
-              "bPercent": 56.7,
-              "discriminability": 0.787,
-              "ratioDiscriminability": 0.865
+              "aCount": 26,
+              "bCount": 33,
+              "aPercent": 44.1,
+              "bPercent": 55.9,
+              "discriminability": 0.898,
+              "ratioDiscriminability": 0.881
             },
             {
               "question": 11,
-              "aCount": 37,
-              "bCount": 104,
-              "aPercent": 26.2,
-              "bPercent": 73.8,
-              "discriminability": 0.547,
-              "ratioDiscriminability": 0.525
+              "aCount": 20,
+              "bCount": 39,
+              "aPercent": 33.9,
+              "bPercent": 66.1,
+              "discriminability": 0.69,
+              "ratioDiscriminability": 0.678
             },
             {
               "question": 12,
-              "aCount": 73,
-              "bCount": 68,
-              "aPercent": 51.8,
-              "bPercent": 48.2,
-              "discriminability": 0.594,
-              "ratioDiscriminability": 0.965
+              "aCount": 36,
+              "bCount": 23,
+              "aPercent": 61,
+              "bPercent": 39,
+              "discriminability": 0.38,
+              "ratioDiscriminability": 0.78
             }
           ],
-          "averageDiscriminability": 0.608
-
+          "averageDiscriminability": 0.594
         },
         {
           "name": "Adaptability",
@@ -980,43 +1301,42 @@
           "questions": [
             {
               "question": 13,
-              "aCount": 84,
-              "bCount": 57,
-              "aPercent": 59.6,
-              "bPercent": 40.4,
-              "discriminability": 0.711,
-              "ratioDiscriminability": 0.809
+              "aCount": 39,
+              "bCount": 20,
+              "aPercent": 66.1,
+              "bPercent": 33.9,
+              "discriminability": 0.674,
+              "ratioDiscriminability": 0.678
             },
             {
               "question": 14,
-              "aCount": 58,
-              "bCount": 83,
-              "aPercent": 41.1,
-              "bPercent": 58.9,
-              "discriminability": 0.664,
-              "ratioDiscriminability": 0.823
+              "aCount": 24,
+              "bCount": 35,
+              "aPercent": 40.7,
+              "bPercent": 59.3,
+              "discriminability": 0.736,
+              "ratioDiscriminability": 0.814
             },
             {
               "question": 15,
-              "aCount": 76,
-              "bCount": 65,
-              "aPercent": 53.9,
-              "bPercent": 46.1,
-              "discriminability": 0.695,
-              "ratioDiscriminability": 0.922
+              "aCount": 33,
+              "bCount": 26,
+              "aPercent": 55.9,
+              "bPercent": 44.1,
+              "discriminability": 0.68,
+              "ratioDiscriminability": 0.881
             },
             {
               "question": 16,
-              "aCount": 104,
-              "bCount": 37,
-              "aPercent": 73.8,
-              "bPercent": 26.2,
-              "discriminability": 0.474,
-              "ratioDiscriminability": 0.525
+              "aCount": 42,
+              "bCount": 17,
+              "aPercent": 71.2,
+              "bPercent": 28.8,
+              "discriminability": 0.429,
+              "ratioDiscriminability": 0.576
             }
           ],
-          "averageDiscriminability": 0.636
-
+          "averageDiscriminability": 0.63
         }
       ]
     }

--- a/data/reliability/gpt-4-1-mini-run-1.json
+++ b/data/reliability/gpt-4-1-mini-run-1.json
@@ -1,0 +1,31 @@
+{
+  "model": "gpt-4.1-mini",
+  "provider": "github",
+  "run": 1,
+  "answers": [
+    "A",
+    "A",
+    "B",
+    "B",
+    "A",
+    "B",
+    "A",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "A",
+    "B",
+    "A",
+    "B"
+  ],
+  "dimensions": [
+    2,
+    2,
+    0,
+    2
+  ],
+  "type": "PTDF",
+  "questionVersion": "5.15-beta"
+}

--- a/data/reliability/gpt-4-1-mini-run-2.json
+++ b/data/reliability/gpt-4-1-mini-run-2.json
@@ -1,0 +1,31 @@
+{
+  "model": "gpt-4.1-mini",
+  "provider": "github",
+  "run": 2,
+  "answers": [
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "B",
+    "A",
+    "B",
+    "A",
+    "B",
+    "B",
+    "B",
+    "A",
+    "A",
+    "A",
+    "B"
+  ],
+  "dimensions": [
+    3,
+    2,
+    1,
+    3
+  ],
+  "type": "PTDF",
+  "questionVersion": "5.15-beta"
+}

--- a/data/reliability/gpt-4-1-mini-run-3.json
+++ b/data/reliability/gpt-4-1-mini-run-3.json
@@ -1,0 +1,31 @@
+{
+  "model": "gpt-4.1-mini",
+  "provider": "github",
+  "run": 3,
+  "answers": [
+    "B",
+    "A",
+    "B",
+    "B",
+    "A",
+    "B",
+    "A",
+    "B",
+    "A",
+    "B",
+    "B",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A"
+  ],
+  "dimensions": [
+    1,
+    2,
+    1,
+    4
+  ],
+  "type": "RTDF",
+  "questionVersion": "5.15-beta"
+}

--- a/data/reliability/gpt-4-1-nano-run-1.json
+++ b/data/reliability/gpt-4-1-nano-run-1.json
@@ -1,0 +1,31 @@
+{
+  "model": "gpt-4.1-nano",
+  "provider": "github",
+  "run": 1,
+  "answers": [
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "B",
+    "B",
+    "B",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A"
+  ],
+  "dimensions": [
+    4,
+    3,
+    1,
+    3
+  ],
+  "type": "PTDF",
+  "questionVersion": "5.15-beta"
+}

--- a/data/reliability/gpt-4-1-nano-run-2.json
+++ b/data/reliability/gpt-4-1-nano-run-2.json
@@ -1,0 +1,31 @@
+{
+  "model": "gpt-4.1-nano",
+  "provider": "github",
+  "run": 2,
+  "answers": [
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "B",
+    "B",
+    "B",
+    "A",
+    "A",
+    "A",
+    "B",
+    "A"
+  ],
+  "dimensions": [
+    4,
+    3,
+    1,
+    3
+  ],
+  "type": "PTDF",
+  "questionVersion": "5.15-beta"
+}

--- a/data/reliability/gpt-4-1-nano-run-3.json
+++ b/data/reliability/gpt-4-1-nano-run-3.json
@@ -1,0 +1,31 @@
+{
+  "model": "gpt-4.1-nano",
+  "provider": "github",
+  "run": 3,
+  "answers": [
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "B",
+    "B",
+    "B",
+    "A",
+    "A",
+    "B",
+    "B",
+    "A"
+  ],
+  "dimensions": [
+    4,
+    3,
+    1,
+    2
+  ],
+  "type": "PTDF",
+  "questionVersion": "5.15-beta"
+}

--- a/data/reliability/gpt-4o-mini-run-1.json
+++ b/data/reliability/gpt-4o-mini-run-1.json
@@ -1,0 +1,31 @@
+{
+  "model": "gpt-4o-mini",
+  "provider": "github",
+  "run": 1,
+  "answers": [
+    "B",
+    "A",
+    "A",
+    "A",
+    "B",
+    "B",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A"
+  ],
+  "dimensions": [
+    3,
+    1,
+    3,
+    4
+  ],
+  "type": "PECF",
+  "questionVersion": "5.15-beta"
+}

--- a/data/reliability/gpt-4o-mini-run-2.json
+++ b/data/reliability/gpt-4o-mini-run-2.json
@@ -1,0 +1,31 @@
+{
+  "model": "gpt-4o-mini",
+  "provider": "github",
+  "run": 2,
+  "answers": [
+    "B",
+    "A",
+    "A",
+    "A",
+    "B",
+    "B",
+    "A",
+    "B",
+    "A",
+    "B",
+    "A",
+    "B",
+    "A",
+    "B",
+    "A",
+    "A"
+  ],
+  "dimensions": [
+    3,
+    1,
+    2,
+    3
+  ],
+  "type": "PECF",
+  "questionVersion": "5.15-beta"
+}

--- a/data/reliability/gpt-4o-mini-run-3.json
+++ b/data/reliability/gpt-4o-mini-run-3.json
@@ -1,0 +1,31 @@
+{
+  "model": "gpt-4o-mini",
+  "provider": "github",
+  "run": 3,
+  "answers": [
+    "B",
+    "B",
+    "A",
+    "B",
+    "A",
+    "A",
+    "B",
+    "A",
+    "B",
+    "B",
+    "B",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A"
+  ],
+  "dimensions": [
+    1,
+    3,
+    1,
+    3
+  ],
+  "type": "RTDF",
+  "questionVersion": "5.15-beta"
+}

--- a/data/results.json
+++ b/data/results.json
@@ -103,17 +103,98 @@
       ],
       "model": "claude-haiku-4.5",
       "provider": "anthropic",
-      "consistency": 88,
-      "runs": 3,
-      "reliability": 0.875,
+      "consistency": 75,
+      "runs": 13,
+      "reliability": 0.7548,
       "reliabilityRuns": [
         {
-          "type": "PTDF",
+          "type": "RTCN",
           "scores": [
+            1,
             3,
+            3,
+            1
+          ]
+        },
+        {
+          "type": "RTCN",
+          "scores": [
+            1,
+            2,
+            3,
+            1
+          ]
+        },
+        {
+          "type": "RTCF",
+          "scores": [
+            0,
+            2,
+            2,
+            3
+          ]
+        },
+        {
+          "type": "PTCN",
+          "scores": [
+            2,
+            2,
+            4,
+            1
+          ]
+        },
+        {
+          "type": "RECF",
+          "scores": [
+            1,
+            1,
+            4,
+            4
+          ]
+        },
+        {
+          "type": "RTCF",
+          "scores": [
+            1,
+            2,
+            2,
+            3
+          ]
+        },
+        {
+          "type": "PTCF",
+          "scores": [
+            2,
+            2,
+            2,
+            2
+          ]
+        },
+        {
+          "type": "PECF",
+          "scores": [
             2,
             1,
+            2,
+            3
+          ]
+        },
+        {
+          "type": "PECF",
+          "scores": [
+            2,
+            0,
+            2,
             2
+          ]
+        },
+        {
+          "type": "PTCN",
+          "scores": [
+            2,
+            2,
+            2,
+            1
           ]
         },
         {
@@ -128,8 +209,17 @@
         {
           "type": "PTCF",
           "scores": [
-            3,
             2,
+            2,
+            4,
+            2
+          ]
+        },
+        {
+          "type": "RECF",
+          "scores": [
+            1,
+            1,
             2,
             3
           ]
@@ -287,25 +377,88 @@
       ],
       "model": "claude-opus-4.6",
       "provider": "anthropic",
-      "consistency": 90,
-      "runs": 3,
-      "reliability": 0.8958,
+      "consistency": 81,
+      "runs": 13,
+      "reliability": 0.8125,
       "reliabilityRuns": [
         {
-          "type": "PEDF",
+          "type": "PTCN",
           "scores": [
             2,
-            0,
-            1,
-            3
+            3,
+            4,
+            1
           ]
         },
         {
-          "type": "PECF",
+          "type": "PTCN",
           "scores": [
             2,
-            0,
+            3,
+            3,
+            1
+          ]
+        },
+        {
+          "type": "RTDF",
+          "scores": [
+            1,
+            3,
+            1,
+            2
+          ]
+        },
+        {
+          "type": "PTCF",
+          "scores": [
             2,
+            2,
+            3,
+            2
+          ]
+        },
+        {
+          "type": "PTCN",
+          "scores": [
+            2,
+            3,
+            3,
+            0
+          ]
+        },
+        {
+          "type": "PTCN",
+          "scores": [
+            2,
+            2,
+            2,
+            1
+          ]
+        },
+        {
+          "type": "PTCN",
+          "scores": [
+            2,
+            2,
+            3,
+            1
+          ]
+        },
+        {
+          "type": "PTCN",
+          "scores": [
+            2,
+            2,
+            2,
+            1
+          ]
+        },
+        {
+          "type": "PTCF",
+          "scores": [
+            2,
+            3,
+            3,
             2
           ]
         },
@@ -315,7 +468,34 @@
             2,
             2,
             2,
-            3
+            2
+          ]
+        },
+        {
+          "type": "RECF",
+          "scores": [
+            1,
+            1,
+            3,
+            2
+          ]
+        },
+        {
+          "type": "PTCF",
+          "scores": [
+            2,
+            2,
+            3,
+            2
+          ]
+        },
+        {
+          "type": "RECN",
+          "scores": [
+            1,
+            1,
+            2,
+            1
           ]
         }
       ]
@@ -423,26 +603,17 @@
       ],
       "model": "claude-sonnet-4.5",
       "provider": "anthropic",
-      "consistency": 69,
-      "runs": 3,
-      "reliability": 0.6875,
+      "consistency": 61,
+      "runs": 13,
+      "reliability": 0.6106,
       "reliabilityRuns": [
         {
-          "type": "PTCN",
+          "type": "RECN",
           "scores": [
-            2,
-            2,
-            2,
-            0
-          ]
-        },
-        {
-          "type": "PTCF",
-          "scores": [
+            1,
+            1,
             3,
-            3,
-            3,
-            2
+            1
           ]
         },
         {
@@ -452,6 +623,105 @@
             2,
             2,
             3
+          ]
+        },
+        {
+          "type": "RECN",
+          "scores": [
+            1,
+            1,
+            2,
+            1
+          ]
+        },
+        {
+          "type": "RECF",
+          "scores": [
+            1,
+            1,
+            4,
+            3
+          ]
+        },
+        {
+          "type": "RTCF",
+          "scores": [
+            1,
+            3,
+            2,
+            3
+          ]
+        },
+        {
+          "type": "PTDF",
+          "scores": [
+            3,
+            2,
+            1,
+            3
+          ]
+        },
+        {
+          "type": "PTCN",
+          "scores": [
+            4,
+            2,
+            2,
+            1
+          ]
+        },
+        {
+          "type": "PTCF",
+          "scores": [
+            2,
+            2,
+            3,
+            3
+          ]
+        },
+        {
+          "type": "PTCF",
+          "scores": [
+            3,
+            3,
+            2,
+            3
+          ]
+        },
+        {
+          "type": "PTCN",
+          "scores": [
+            2,
+            3,
+            2,
+            1
+          ]
+        },
+        {
+          "type": "PECF",
+          "scores": [
+            2,
+            0,
+            3,
+            4
+          ]
+        },
+        {
+          "type": "PTDF",
+          "scores": [
+            3,
+            2,
+            1,
+            2
+          ]
+        },
+        {
+          "type": "PTCN",
+          "scores": [
+            2,
+            3,
+            3,
+            1
           ]
         }
       ]
@@ -1300,33 +1570,105 @@
           "type": "PTCF",
           "scores": [
             2,
+            4,
+            2,
+            2
+          ]
+        },
+        {
+          "type": "PTCF",
+          "scores": [
+            3,
+            4,
+            3,
+            2
+          ]
+        },
+        {
+          "type": "PTCF",
+          "scores": [
+            3,
+            4,
+            3,
+            2
+          ]
+        },
+        {
+          "type": "PTCF",
+          "scores": [
+            3,
+            4,
+            2,
+            2
+          ]
+        },
+        {
+          "type": "PTDF",
+          "scores": [
+            3,
+            4,
+            1,
+            2
+          ]
+        },
+        {
+          "type": "PTCF",
+          "scores": [
             3,
             2,
-            3
+            3,
+            2
+          ]
+        },
+        {
+          "type": "PTDF",
+          "scores": [
+            3,
+            3,
+            1,
+            2
+          ]
+        },
+        {
+          "type": "PTCF",
+          "scores": [
+            3,
+            3,
+            3,
+            2
+          ]
+        },
+        {
+          "type": "PTCF",
+          "scores": [
+            3,
+            3,
+            3,
+            2
           ]
         },
         {
           "type": "PTCF",
           "scores": [
             2,
+            4,
             3,
-            2,
-            3
+            2
           ]
         },
         {
           "type": "PTCF",
           "scores": [
-            2,
             3,
-            2,
-            3
+            4,
+            3,
+            2
           ]
         }
       ],
-      "runs": 3,
-      "reliability": 1,
-      "consistency": 100
+      "runs": 11,
+      "reliability": 0.9261,
+      "consistency": 93
     },
     {
       "name": "Gemma 2 2B",
@@ -1643,10 +1985,110 @@
           "runs": 3
         }
       ],
-      "reliability": 0.9375,
-      "reliabilityRuns": 0,
-      "consistency": 94,
-      "runs": 1
+      "reliability": 0.75,
+      "reliabilityRuns": [
+        {
+          "type": "RTCF",
+          "scores": [
+            1,
+            3,
+            2,
+            2
+          ]
+        },
+        {
+          "type": "PTCF",
+          "scores": [
+            2,
+            4,
+            2,
+            4
+          ]
+        },
+        {
+          "type": "RTCF",
+          "scores": [
+            1,
+            4,
+            2,
+            3
+          ]
+        },
+        {
+          "type": "PTDF",
+          "scores": [
+            2,
+            2,
+            0,
+            2
+          ]
+        },
+        {
+          "type": "PTDF",
+          "scores": [
+            2,
+            3,
+            1,
+            3
+          ]
+        },
+        {
+          "type": "PEDF",
+          "scores": [
+            3,
+            1,
+            1,
+            4
+          ]
+        },
+        {
+          "type": "PTDF",
+          "scores": [
+            2,
+            3,
+            0,
+            3
+          ]
+        },
+        {
+          "type": "PTDF",
+          "scores": [
+            4,
+            2,
+            0,
+            4
+          ]
+        },
+        {
+          "type": "PTDF",
+          "scores": [
+            2,
+            2,
+            1,
+            4
+          ]
+        },
+        {
+          "type": "REDF",
+          "scores": [
+            1,
+            1,
+            1,
+            2
+          ]
+        },
+        {
+          "type": "PTCF",
+          "scores": [
+            2,
+            2,
+            2,
+            4
+          ]
+        }
+      ],
+      "consistency": 75,
+      "runs": 11
     },
     {
       "name": "GPT-4o",
@@ -1745,14 +2187,59 @@
           "provider": "openai"
         }
       ],
-      "reliability": 0.9583,
+      "reliability": 0.8029,
       "reliabilityRuns": [
         {
-          "type": "PTDF",
+          "type": "RTCF",
+          "scores": [
+            1,
+            2,
+            2,
+            3
+          ]
+        },
+        {
+          "type": "PTCF",
           "scores": [
             2,
             3,
-            0,
+            2,
+            2
+          ]
+        },
+        {
+          "type": "RTDF",
+          "scores": [
+            1,
+            3,
+            1,
+            3
+          ]
+        },
+        {
+          "type": "RTCF",
+          "scores": [
+            1,
+            3,
+            2,
+            2
+          ]
+        },
+        {
+          "type": "RTDF",
+          "scores": [
+            1,
+            2,
+            1,
+            2
+          ]
+        },
+        {
+          "type": "RTCF",
+          "scores": [
+            1,
+            2,
+            2,
             3
           ]
         },
@@ -1760,23 +2247,68 @@
           "type": "PTDF",
           "scores": [
             2,
-            3,
+            2,
             0,
-            2
+            3
           ]
         },
         {
-          "type": "PTDF",
+          "type": "RTDF",
           "scores": [
-            2,
+            1,
             2,
             0,
+            3
+          ]
+        },
+        {
+          "type": "REDF",
+          "scores": [
+            1,
+            1,
+            1,
+            3
+          ]
+        },
+        {
+          "type": "REDF",
+          "scores": [
+            1,
+            1,
+            1,
+            3
+          ]
+        },
+        {
+          "type": "RECF",
+          "scores": [
+            0,
+            1,
+            2,
+            4
+          ]
+        },
+        {
+          "type": "PTCF",
+          "scores": [
+            2,
+            3,
+            2,
+            3
+          ]
+        },
+        {
+          "type": "PECF",
+          "scores": [
+            2,
+            1,
+            2,
             2
           ]
         }
       ],
-      "consistency": 96,
-      "runs": 3
+      "consistency": 80,
+      "runs": 13
     },
     {
       "name": "GPT-4o mini",
@@ -1827,37 +2359,37 @@
       ],
       "model": "gpt-4o-mini",
       "provider": "openai",
-      "reliability": 0.875,
+      "reliability": 0.7708,
       "reliabilityRuns": [
         {
-          "type": "PEDF",
+          "type": "PECF",
           "scores": [
-            2,
+            3,
             1,
-            1,
-            2
+            3,
+            4
           ]
         },
         {
-          "type": "PTDN",
+          "type": "PECF",
           "scores": [
+            3,
+            1,
             2,
-            2,
-            0,
-            1
+            3
           ]
         },
         {
-          "type": "PEDN",
+          "type": "RTDF",
           "scores": [
-            2,
             1,
+            3,
             1,
-            1
+            3
           ]
         }
       ],
-      "consistency": 88,
+      "consistency": 77,
       "runs": 3
     },
     {
@@ -3177,9 +3709,37 @@
       "provider": "github",
       "desc": "Proactive, efficient, candid, flexible. Fast-moving generalist who says what they think and adapts on the fly.",
       "reliability": 0.8958,
-      "reliabilityRuns": 0,
+      "reliabilityRuns": [
+        {
+          "type": "PTDF",
+          "scores": [
+            2,
+            2,
+            0,
+            2
+          ]
+        },
+        {
+          "type": "PTDF",
+          "scores": [
+            3,
+            2,
+            1,
+            3
+          ]
+        },
+        {
+          "type": "RTDF",
+          "scores": [
+            1,
+            2,
+            1,
+            4
+          ]
+        }
+      ],
       "consistency": 90,
-      "runs": 1
+      "runs": 3
     },
     {
       "name": "GPT-4.1 nano",
@@ -3231,10 +3791,38 @@
       "model": "gpt-4.1-nano",
       "provider": "github",
       "desc": "Proactive, efficient, candid, principled. All gas, no brakes, no filter, no exceptions.",
-      "reliability": 0.9375,
-      "reliabilityRuns": 0,
-      "consistency": 94,
-      "runs": 1
+      "reliability": 0.9583,
+      "reliabilityRuns": [
+        {
+          "type": "PTDF",
+          "scores": [
+            4,
+            3,
+            1,
+            3
+          ]
+        },
+        {
+          "type": "PTDF",
+          "scores": [
+            4,
+            3,
+            1,
+            3
+          ]
+        },
+        {
+          "type": "PTDF",
+          "scores": [
+            4,
+            3,
+            1,
+            2
+          ]
+        }
+      ],
+      "consistency": 96,
+      "runs": 3
     },
     {
       "name": "Phi 4",


### PR DESCRIPTION
## Summary

Adds 3 reliability test runs each for 3 non-core GitHub Models on v5.15-beta:

| Model | Runs | Type Pattern | Reliability |
|-------|------|-------------|-------------|
| gpt-4.1-mini | 3 | PTDF/PTDF/RTDF | new |
| gpt-4o-mini | 3 | PECF/PECF/RTDF | 0.7708 |
| gpt-4.1-nano | 3 | PTDF/PTDF/PTDF | 0.9583 |

### Notable findings
- **gpt-4.1-nano** has highest reliability (0.9583) among the three — very consistent PTDF type
- **gpt-4o-mini** shows lower reliability (0.7708) with varying types across runs
- **gpt-4.1-mini** is moderately consistent (2/3 PTDF, 1 RTDF)

### Changes
- 9 new reliability run files
- results.json updated via sync-reliability.js (also refreshed core model counts)
- discriminability.json regenerated with 83 total runs

Closes #720