### PR TITLE
data: expand reliability to Llama-4, Mistral, Ministral, Phi-4 (v5.15-beta)

### DIFF
--- a/data/discriminability.json
+++ b/data/discriminability.json
@@ -1,151 +1,151 @@
 {
-  "generatedAt": "2026-07-09T01:49:07.729Z",
+  "generatedAt": "2026-07-09T06:32:55.950Z",
   "threshold": 0.6,
-  "totalRuns": 83,
+  "totalRuns": 96,
   "questions": [
     {
       "question": 1,
-      "aCount": 48,
-      "bCount": 35,
-      "aPercent": 57.8,
-      "bPercent": 42.2,
-      "discriminability": 0.687,
-      "ratioDiscriminability": 0.843
+      "aCount": 58,
+      "bCount": 38,
+      "aPercent": 60.4,
+      "bPercent": 39.6,
+      "discriminability": 0.67,
+      "ratioDiscriminability": 0.792
     },
     {
       "question": 2,
-      "aCount": 29,
-      "bCount": 54,
-      "aPercent": 34.9,
-      "bPercent": 65.1,
-      "discriminability": 0.792,
-      "ratioDiscriminability": 0.699
+      "aCount": 38,
+      "bCount": 58,
+      "aPercent": 39.6,
+      "bPercent": 60.4,
+      "discriminability": 0.737,
+      "ratioDiscriminability": 0.792
     },
     {
       "question": 3,
-      "aCount": 60,
-      "bCount": 23,
-      "aPercent": 72.3,
-      "bPercent": 27.7,
-      "discriminability": 0.699,
-      "ratioDiscriminability": 0.554
+      "aCount": 63,
+      "bCount": 33,
+      "aPercent": 65.6,
+      "bPercent": 34.4,
+      "discriminability": 0.8,
+      "ratioDiscriminability": 0.688
     },
     {
       "question": 4,
-      "aCount": 26,
-      "bCount": 57,
-      "aPercent": 31.3,
-      "bPercent": 68.7,
-      "discriminability": 0.761,
-      "ratioDiscriminability": 0.627
+      "aCount": 31,
+      "bCount": 65,
+      "aPercent": 32.3,
+      "bPercent": 67.7,
+      "discriminability": 0.794,
+      "ratioDiscriminability": 0.646
     },
     {
       "question": 5,
-      "aCount": 50,
-      "bCount": 33,
-      "aPercent": 60.2,
-      "bPercent": 39.8,
-      "discriminability": 0.488,
-      "ratioDiscriminability": 0.795
+      "aCount": 60,
+      "bCount": 36,
+      "aPercent": 62.5,
+      "bPercent": 37.5,
+      "discriminability": 0.586,
+      "ratioDiscriminability": 0.75
     },
     {
       "question": 6,
-      "aCount": 47,
-      "bCount": 36,
-      "aPercent": 56.6,
-      "bPercent": 43.4,
-      "discriminability": 0.545,
-      "ratioDiscriminability": 0.867
+      "aCount": 57,
+      "bCount": 39,
+      "aPercent": 59.4,
+      "bPercent": 40.6,
+      "discriminability": 0.728,
+      "ratioDiscriminability": 0.813
     },
     {
       "question": 7,
-      "aCount": 62,
-      "bCount": 21,
-      "aPercent": 74.7,
-      "bPercent": 25.3,
-      "discriminability": 0.482,
-      "ratioDiscriminability": 0.506
+      "aCount": 68,
+      "bCount": 28,
+      "aPercent": 70.8,
+      "bPercent": 29.2,
+      "discriminability": 0.602,
+      "ratioDiscriminability": 0.583
     },
     {
       "question": 8,
-      "aCount": 29,
-      "bCount": 54,
-      "aPercent": 34.9,
-      "bPercent": 65.1,
-      "discriminability": 0.732,
-      "ratioDiscriminability": 0.699
+      "aCount": 33,
+      "bCount": 63,
+      "aPercent": 34.4,
+      "bPercent": 65.6,
+      "discriminability": 0.673,
+      "ratioDiscriminability": 0.688
     },
     {
       "question": 9,
-      "aCount": 56,
-      "bCount": 27,
-      "aPercent": 67.5,
-      "bPercent": 32.5,
-      "discriminability": 0.502,
-      "ratioDiscriminability": 0.651
+      "aCount": 66,
+      "bCount": 30,
+      "aPercent": 68.8,
+      "bPercent": 31.3,
+      "discriminability": 0.647,
+      "ratioDiscriminability": 0.625
     },
     {
       "question": 10,
-      "aCount": 34,
-      "bCount": 49,
-      "aPercent": 41,
-      "bPercent": 59,
-      "discriminability": 0.811,
-      "ratioDiscriminability": 0.819
+      "aCount": 43,
+      "bCount": 53,
+      "aPercent": 44.8,
+      "bPercent": 55.2,
+      "discriminability": 0.838,
+      "ratioDiscriminability": 0.896
     },
     {
       "question": 11,
-      "aCount": 28,
-      "bCount": 55,
-      "aPercent": 33.7,
-      "bPercent": 66.3,
-      "discriminability": 0.664,
-      "ratioDiscriminability": 0.675
+      "aCount": 32,
+      "bCount": 64,
+      "aPercent": 33.3,
+      "bPercent": 66.7,
+      "discriminability": 0.707,
+      "ratioDiscriminability": 0.667
     },
     {
       "question": 12,
-      "aCount": 49,
-      "bCount": 34,
-      "aPercent": 59,
-      "bPercent": 41,
-      "discriminability": 0.568,
-      "ratioDiscriminability": 0.819
+      "aCount": 53,
+      "bCount": 43,
+      "aPercent": 55.2,
+      "bPercent": 44.8,
+      "discriminability": 0.757,
+      "ratioDiscriminability": 0.896
     },
     {
       "question": 13,
-      "aCount": 55,
-      "bCount": 28,
-      "aPercent": 66.3,
-      "bPercent": 33.7,
-      "discriminability": 0.659,
-      "ratioDiscriminability": 0.675
+      "aCount": 66,
+      "bCount": 30,
+      "aPercent": 68.8,
+      "bPercent": 31.3,
+      "discriminability": 0.704,
+      "ratioDiscriminability": 0.625
     },
     {
       "question": 14,
       "aCount": 34,
-      "bCount": 49,
-      "aPercent": 41,
-      "bPercent": 59,
-      "discriminability": 0.607,
-      "ratioDiscriminability": 0.819
+      "bCount": 62,
+      "aPercent": 35.4,
+      "bPercent": 64.6,
+      "discriminability": 0.633,
+      "ratioDiscriminability": 0.708
     },
     {
       "question": 15,
-      "aCount": 48,
-      "bCount": 35,
-      "aPercent": 57.8,
-      "bPercent": 42.2,
-      "discriminability": 0.681,
-      "ratioDiscriminability": 0.843
+      "aCount": 59,
+      "bCount": 37,
+      "aPercent": 61.5,
+      "bPercent": 38.5,
+      "discriminability": 0.674,
+      "ratioDiscriminability": 0.771
     },
     {
       "question": 16,
-      "aCount": 59,
-      "bCount": 24,
-      "aPercent": 71.1,
-      "bPercent": 28.9,
-      "discriminability": 0.528,
-      "ratioDiscriminability": 0.578
+      "aCount": 66,
+      "bCount": 30,
+      "aPercent": 68.8,
+      "bPercent": 31.3,
+      "discriminability": 0.641,
+      "ratioDiscriminability": 0.625
     }
   ],
   "dimensions": [
@@ -158,42 +158,42 @@
       "questions": [
         {
           "question": 1,
-          "aCount": 48,
-          "bCount": 35,
-          "aPercent": 57.8,
-          "bPercent": 42.2,
-          "discriminability": 0.687,
-          "ratioDiscriminability": 0.843
+          "aCount": 58,
+          "bCount": 38,
+          "aPercent": 60.4,
+          "bPercent": 39.6,
+          "discriminability": 0.67,
+          "ratioDiscriminability": 0.792
         },
         {
           "question": 2,
-          "aCount": 29,
-          "bCount": 54,
-          "aPercent": 34.9,
-          "bPercent": 65.1,
-          "discriminability": 0.792,
-          "ratioDiscriminability": 0.699
+          "aCount": 38,
+          "bCount": 58,
+          "aPercent": 39.6,
+          "bPercent": 60.4,
+          "discriminability": 0.737,
+          "ratioDiscriminability": 0.792
         },
         {
           "question": 3,
-          "aCount": 60,
-          "bCount": 23,
-          "aPercent": 72.3,
-          "bPercent": 27.7,
-          "discriminability": 0.699,
-          "ratioDiscriminability": 0.554
+          "aCount": 63,
+          "bCount": 33,
+          "aPercent": 65.6,
+          "bPercent": 34.4,
+          "discriminability": 0.8,
+          "ratioDiscriminability": 0.688
         },
         {
           "question": 4,
-          "aCount": 26,
-          "bCount": 57,
-          "aPercent": 31.3,
-          "bPercent": 68.7,
-          "discriminability": 0.761,
-          "ratioDiscriminability": 0.627
+          "aCount": 31,
+          "bCount": 65,
+          "aPercent": 32.3,
+          "bPercent": 67.7,
+          "discriminability": 0.794,
+          "ratioDiscriminability": 0.646
         }
       ],
-      "averageDiscriminability": 0.735
+      "averageDiscriminability": 0.75
     },
     {
       "name": "Precision",
@@ -204,42 +204,42 @@
       "questions": [
         {
           "question": 5,
-          "aCount": 50,
-          "bCount": 33,
-          "aPercent": 60.2,
-          "bPercent": 39.8,
-          "discriminability": 0.488,
-          "ratioDiscriminability": 0.795
+          "aCount": 60,
+          "bCount": 36,
+          "aPercent": 62.5,
+          "bPercent": 37.5,
+          "discriminability": 0.586,
+          "ratioDiscriminability": 0.75
         },
         {
           "question": 6,
-          "aCount": 47,
-          "bCount": 36,
-          "aPercent": 56.6,
-          "bPercent": 43.4,
-          "discriminability": 0.545,
-          "ratioDiscriminability": 0.867
+          "aCount": 57,
+          "bCount": 39,
+          "aPercent": 59.4,
+          "bPercent": 40.6,
+          "discriminability": 0.728,
+          "ratioDiscriminability": 0.813
         },
         {
           "question": 7,
-          "aCount": 62,
-          "bCount": 21,
-          "aPercent": 74.7,
-          "bPercent": 25.3,
-          "discriminability": 0.482,
-          "ratioDiscriminability": 0.506
+          "aCount": 68,
+          "bCount": 28,
+          "aPercent": 70.8,
+          "bPercent": 29.2,
+          "discriminability": 0.602,
+          "ratioDiscriminability": 0.583
         },
         {
           "question": 8,
-          "aCount": 29,
-          "bCount": 54,
-          "aPercent": 34.9,
-          "bPercent": 65.1,
-          "discriminability": 0.732,
-          "ratioDiscriminability": 0.699
+          "aCount": 33,
+          "bCount": 63,
+          "aPercent": 34.4,
+          "bPercent": 65.6,
+          "discriminability": 0.673,
+          "ratioDiscriminability": 0.688
         }
       ],
-      "averageDiscriminability": 0.562
+      "averageDiscriminability": 0.647
     },
     {
       "name": "Transparency",
@@ -250,42 +250,42 @@
       "questions": [
         {
           "question": 9,
-          "aCount": 56,
-          "bCount": 27,
-          "aPercent": 67.5,
-          "bPercent": 32.5,
-          "discriminability": 0.502,
-          "ratioDiscriminability": 0.651
+          "aCount": 66,
+          "bCount": 30,
+          "aPercent": 68.8,
+          "bPercent": 31.3,
+          "discriminability": 0.647,
+          "ratioDiscriminability": 0.625
         },
         {
           "question": 10,
-          "aCount": 34,
-          "bCount": 49,
-          "aPercent": 41,
-          "bPercent": 59,
-          "discriminability": 0.811,
-          "ratioDiscriminability": 0.819
+          "aCount": 43,
+          "bCount": 53,
+          "aPercent": 44.8,
+          "bPercent": 55.2,
+          "discriminability": 0.838,
+          "ratioDiscriminability": 0.896
         },
         {
           "question": 11,
-          "aCount": 28,
-          "bCount": 55,
-          "aPercent": 33.7,
-          "bPercent": 66.3,
-          "discriminability": 0.664,
-          "ratioDiscriminability": 0.675
+          "aCount": 32,
+          "bCount": 64,
+          "aPercent": 33.3,
+          "bPercent": 66.7,
+          "discriminability": 0.707,
+          "ratioDiscriminability": 0.667
         },
         {
           "question": 12,
-          "aCount": 49,
-          "bCount": 34,
-          "aPercent": 59,
-          "bPercent": 41,
-          "discriminability": 0.568,
-          "ratioDiscriminability": 0.819
+          "aCount": 53,
+          "bCount": 43,
+          "aPercent": 55.2,
+          "bPercent": 44.8,
+          "discriminability": 0.757,
+          "ratioDiscriminability": 0.896
         }
       ],
-      "averageDiscriminability": 0.636
+      "averageDiscriminability": 0.737
     },
     {
       "name": "Adaptability",
@@ -296,191 +296,191 @@
       "questions": [
         {
           "question": 13,
-          "aCount": 55,
-          "bCount": 28,
-          "aPercent": 66.3,
-          "bPercent": 33.7,
-          "discriminability": 0.659,
-          "ratioDiscriminability": 0.675
+          "aCount": 66,
+          "bCount": 30,
+          "aPercent": 68.8,
+          "bPercent": 31.3,
+          "discriminability": 0.704,
+          "ratioDiscriminability": 0.625
         },
         {
           "question": 14,
           "aCount": 34,
-          "bCount": 49,
-          "aPercent": 41,
-          "bPercent": 59,
-          "discriminability": 0.607,
-          "ratioDiscriminability": 0.819
+          "bCount": 62,
+          "aPercent": 35.4,
+          "bPercent": 64.6,
+          "discriminability": 0.633,
+          "ratioDiscriminability": 0.708
         },
         {
           "question": 15,
-          "aCount": 48,
-          "bCount": 35,
-          "aPercent": 57.8,
-          "bPercent": 42.2,
-          "discriminability": 0.681,
-          "ratioDiscriminability": 0.843
+          "aCount": 59,
+          "bCount": 37,
+          "aPercent": 61.5,
+          "bPercent": 38.5,
+          "discriminability": 0.674,
+          "ratioDiscriminability": 0.771
         },
         {
           "question": 16,
-          "aCount": 59,
-          "bCount": 24,
-          "aPercent": 71.1,
-          "bPercent": 28.9,
-          "discriminability": 0.528,
-          "ratioDiscriminability": 0.578
+          "aCount": 66,
+          "bCount": 30,
+          "aPercent": 68.8,
+          "bPercent": 31.3,
+          "discriminability": 0.641,
+          "ratioDiscriminability": 0.625
         }
       ],
-      "averageDiscriminability": 0.619
+      "averageDiscriminability": 0.663
     }
   ],
   "cohorts": {
     "all": {
-      "totalRuns": 83,
+      "totalRuns": 96,
       "questions": [
         {
           "question": 1,
-          "aCount": 48,
-          "bCount": 35,
-          "aPercent": 57.8,
-          "bPercent": 42.2,
-          "discriminability": 0.687,
-          "ratioDiscriminability": 0.843
+          "aCount": 58,
+          "bCount": 38,
+          "aPercent": 60.4,
+          "bPercent": 39.6,
+          "discriminability": 0.67,
+          "ratioDiscriminability": 0.792
         },
         {
           "question": 2,
-          "aCount": 29,
-          "bCount": 54,
-          "aPercent": 34.9,
-          "bPercent": 65.1,
-          "discriminability": 0.792,
-          "ratioDiscriminability": 0.699
+          "aCount": 38,
+          "bCount": 58,
+          "aPercent": 39.6,
+          "bPercent": 60.4,
+          "discriminability": 0.737,
+          "ratioDiscriminability": 0.792
         },
         {
           "question": 3,
-          "aCount": 60,
-          "bCount": 23,
-          "aPercent": 72.3,
-          "bPercent": 27.7,
-          "discriminability": 0.699,
-          "ratioDiscriminability": 0.554
+          "aCount": 63,
+          "bCount": 33,
+          "aPercent": 65.6,
+          "bPercent": 34.4,
+          "discriminability": 0.8,
+          "ratioDiscriminability": 0.688
         },
         {
           "question": 4,
-          "aCount": 26,
-          "bCount": 57,
-          "aPercent": 31.3,
-          "bPercent": 68.7,
-          "discriminability": 0.761,
-          "ratioDiscriminability": 0.627
+          "aCount": 31,
+          "bCount": 65,
+          "aPercent": 32.3,
+          "bPercent": 67.7,
+          "discriminability": 0.794,
+          "ratioDiscriminability": 0.646
         },
         {
           "question": 5,
-          "aCount": 50,
-          "bCount": 33,
-          "aPercent": 60.2,
-          "bPercent": 39.8,
-          "discriminability": 0.488,
-          "ratioDiscriminability": 0.795
+          "aCount": 60,
+          "bCount": 36,
+          "aPercent": 62.5,
+          "bPercent": 37.5,
+          "discriminability": 0.586,
+          "ratioDiscriminability": 0.75
         },
         {
           "question": 6,
-          "aCount": 47,
-          "bCount": 36,
-          "aPercent": 56.6,
-          "bPercent": 43.4,
-          "discriminability": 0.545,
-          "ratioDiscriminability": 0.867
+          "aCount": 57,
+          "bCount": 39,
+          "aPercent": 59.4,
+          "bPercent": 40.6,
+          "discriminability": 0.728,
+          "ratioDiscriminability": 0.813
         },
         {
           "question": 7,
-          "aCount": 62,
-          "bCount": 21,
-          "aPercent": 74.7,
-          "bPercent": 25.3,
-          "discriminability": 0.482,
-          "ratioDiscriminability": 0.506
+          "aCount": 68,
+          "bCount": 28,
+          "aPercent": 70.8,
+          "bPercent": 29.2,
+          "discriminability": 0.602,
+          "ratioDiscriminability": 0.583
         },
         {
           "question": 8,
-          "aCount": 29,
-          "bCount": 54,
-          "aPercent": 34.9,
-          "bPercent": 65.1,
-          "discriminability": 0.732,
-          "ratioDiscriminability": 0.699
+          "aCount": 33,
+          "bCount": 63,
+          "aPercent": 34.4,
+          "bPercent": 65.6,
+          "discriminability": 0.673,
+          "ratioDiscriminability": 0.688
         },
         {
           "question": 9,
-          "aCount": 56,
-          "bCount": 27,
-          "aPercent": 67.5,
-          "bPercent": 32.5,
-          "discriminability": 0.502,
-          "ratioDiscriminability": 0.651
+          "aCount": 66,
+          "bCount": 30,
+          "aPercent": 68.8,
+          "bPercent": 31.3,
+          "discriminability": 0.647,
+          "ratioDiscriminability": 0.625
         },
         {
           "question": 10,
-          "aCount": 34,
-          "bCount": 49,
-          "aPercent": 41,
-          "bPercent": 59,
-          "discriminability": 0.811,
-          "ratioDiscriminability": 0.819
+          "aCount": 43,
+          "bCount": 53,
+          "aPercent": 44.8,
+          "bPercent": 55.2,
+          "discriminability": 0.838,
+          "ratioDiscriminability": 0.896
         },
         {
           "question": 11,
-          "aCount": 28,
-          "bCount": 55,
-          "aPercent": 33.7,
-          "bPercent": 66.3,
-          "discriminability": 0.664,
-          "ratioDiscriminability": 0.675
+          "aCount": 32,
+          "bCount": 64,
+          "aPercent": 33.3,
+          "bPercent": 66.7,
+          "discriminability": 0.707,
+          "ratioDiscriminability": 0.667
         },
         {
           "question": 12,
-          "aCount": 49,
-          "bCount": 34,
-          "aPercent": 59,
-          "bPercent": 41,
-          "discriminability": 0.568,
-          "ratioDiscriminability": 0.819
+          "aCount": 53,
+          "bCount": 43,
+          "aPercent": 55.2,
+          "bPercent": 44.8,
+          "discriminability": 0.757,
+          "ratioDiscriminability": 0.896
         },
         {
           "question": 13,
-          "aCount": 55,
-          "bCount": 28,
-          "aPercent": 66.3,
-          "bPercent": 33.7,
-          "discriminability": 0.659,
-          "ratioDiscriminability": 0.675
+          "aCount": 66,
+          "bCount": 30,
+          "aPercent": 68.8,
+          "bPercent": 31.3,
+          "discriminability": 0.704,
+          "ratioDiscriminability": 0.625
         },
         {
           "question": 14,
           "aCount": 34,
-          "bCount": 49,
-          "aPercent": 41,
-          "bPercent": 59,
-          "discriminability": 0.607,
-          "ratioDiscriminability": 0.819
+          "bCount": 62,
+          "aPercent": 35.4,
+          "bPercent": 64.6,
+          "discriminability": 0.633,
+          "ratioDiscriminability": 0.708
         },
         {
           "question": 15,
-          "aCount": 48,
-          "bCount": 35,
-          "aPercent": 57.8,
-          "bPercent": 42.2,
-          "discriminability": 0.681,
-          "ratioDiscriminability": 0.843
+          "aCount": 59,
+          "bCount": 37,
+          "aPercent": 61.5,
+          "bPercent": 38.5,
+          "discriminability": 0.674,
+          "ratioDiscriminability": 0.771
         },
         {
           "question": 16,
-          "aCount": 59,
-          "bCount": 24,
-          "aPercent": 71.1,
-          "bPercent": 28.9,
-          "discriminability": 0.528,
-          "ratioDiscriminability": 0.578
+          "aCount": 66,
+          "bCount": 30,
+          "aPercent": 68.8,
+          "bPercent": 31.3,
+          "discriminability": 0.641,
+          "ratioDiscriminability": 0.625
         }
       ],
       "dimensions": [
@@ -493,42 +493,42 @@
           "questions": [
             {
               "question": 1,
-              "aCount": 48,
-              "bCount": 35,
-              "aPercent": 57.8,
-              "bPercent": 42.2,
-              "discriminability": 0.687,
-              "ratioDiscriminability": 0.843
+              "aCount": 58,
+              "bCount": 38,
+              "aPercent": 60.4,
+              "bPercent": 39.6,
+              "discriminability": 0.67,
+              "ratioDiscriminability": 0.792
             },
             {
               "question": 2,
-              "aCount": 29,
-              "bCount": 54,
-              "aPercent": 34.9,
-              "bPercent": 65.1,
-              "discriminability": 0.792,
-              "ratioDiscriminability": 0.699
+              "aCount": 38,
+              "bCount": 58,
+              "aPercent": 39.6,
+              "bPercent": 60.4,
+              "discriminability": 0.737,
+              "ratioDiscriminability": 0.792
             },
             {
               "question": 3,
-              "aCount": 60,
-              "bCount": 23,
-              "aPercent": 72.3,
-              "bPercent": 27.7,
-              "discriminability": 0.699,
-              "ratioDiscriminability": 0.554
+              "aCount": 63,
+              "bCount": 33,
+              "aPercent": 65.6,
+              "bPercent": 34.4,
+              "discriminability": 0.8,
+              "ratioDiscriminability": 0.688
             },
             {
               "question": 4,
-              "aCount": 26,
-              "bCount": 57,
-              "aPercent": 31.3,
-              "bPercent": 68.7,
-              "discriminability": 0.761,
-              "ratioDiscriminability": 0.627
+              "aCount": 31,
+              "bCount": 65,
+              "aPercent": 32.3,
+              "bPercent": 67.7,
+              "discriminability": 0.794,
+              "ratioDiscriminability": 0.646
             }
           ],
-          "averageDiscriminability": 0.735
+          "averageDiscriminability": 0.75
         },
         {
           "name": "Precision",
@@ -539,42 +539,42 @@
           "questions": [
             {
               "question": 5,
-              "aCount": 50,
-              "bCount": 33,
-              "aPercent": 60.2,
-              "bPercent": 39.8,
-              "discriminability": 0.488,
-              "ratioDiscriminability": 0.795
+              "aCount": 60,
+              "bCount": 36,
+              "aPercent": 62.5,
+              "bPercent": 37.5,
+              "discriminability": 0.586,
+              "ratioDiscriminability": 0.75
             },
             {
               "question": 6,
-              "aCount": 47,
-              "bCount": 36,
-              "aPercent": 56.6,
-              "bPercent": 43.4,
-              "discriminability": 0.545,
-              "ratioDiscriminability": 0.867
+              "aCount": 57,
+              "bCount": 39,
+              "aPercent": 59.4,
+              "bPercent": 40.6,
+              "discriminability": 0.728,
+              "ratioDiscriminability": 0.813
             },
             {
               "question": 7,
-              "aCount": 62,
-              "bCount": 21,
-              "aPercent": 74.7,
-              "bPercent": 25.3,
-              "discriminability": 0.482,
-              "ratioDiscriminability": 0.506
+              "aCount": 68,
+              "bCount": 28,
+              "aPercent": 70.8,
+              "bPercent": 29.2,
+              "discriminability": 0.602,
+              "ratioDiscriminability": 0.583
             },
             {
               "question": 8,
-              "aCount": 29,
-              "bCount": 54,
-              "aPercent": 34.9,
-              "bPercent": 65.1,
-              "discriminability": 0.732,
-              "ratioDiscriminability": 0.699
+              "aCount": 33,
+              "bCount": 63,
+              "aPercent": 34.4,
+              "bPercent": 65.6,
+              "discriminability": 0.673,
+              "ratioDiscriminability": 0.688
             }
           ],
-          "averageDiscriminability": 0.562
+          "averageDiscriminability": 0.647
         },
         {
           "name": "Transparency",
@@ -585,42 +585,42 @@
           "questions": [
             {
               "question": 9,
-              "aCount": 56,
-              "bCount": 27,
-              "aPercent": 67.5,
-              "bPercent": 32.5,
-              "discriminability": 0.502,
-              "ratioDiscriminability": 0.651
+              "aCount": 66,
+              "bCount": 30,
+              "aPercent": 68.8,
+              "bPercent": 31.3,
+              "discriminability": 0.647,
+              "ratioDiscriminability": 0.625
             },
             {
               "question": 10,
-              "aCount": 34,
-              "bCount": 49,
-              "aPercent": 41,
-              "bPercent": 59,
-              "discriminability": 0.811,
-              "ratioDiscriminability": 0.819
+              "aCount": 43,
+              "bCount": 53,
+              "aPercent": 44.8,
+              "bPercent": 55.2,
+              "discriminability": 0.838,
+              "ratioDiscriminability": 0.896
             },
             {
               "question": 11,
-              "aCount": 28,
-              "bCount": 55,
-              "aPercent": 33.7,
-              "bPercent": 66.3,
-              "discriminability": 0.664,
-              "ratioDiscriminability": 0.675
+              "aCount": 32,
+              "bCount": 64,
+              "aPercent": 33.3,
+              "bPercent": 66.7,
+              "discriminability": 0.707,
+              "ratioDiscriminability": 0.667
             },
             {
               "question": 12,
-              "aCount": 49,
-              "bCount": 34,
-              "aPercent": 59,
-              "bPercent": 41,
-              "discriminability": 0.568,
-              "ratioDiscriminability": 0.819
+              "aCount": 53,
+              "bCount": 43,
+              "aPercent": 55.2,
+              "bPercent": 44.8,
+              "discriminability": 0.757,
+              "ratioDiscriminability": 0.896
             }
           ],
-          "averageDiscriminability": 0.636
+          "averageDiscriminability": 0.737
         },
         {
           "name": "Adaptability",
@@ -631,191 +631,191 @@
           "questions": [
             {
               "question": 13,
-              "aCount": 55,
-              "bCount": 28,
-              "aPercent": 66.3,
-              "bPercent": 33.7,
-              "discriminability": 0.659,
-              "ratioDiscriminability": 0.675
+              "aCount": 66,
+              "bCount": 30,
+              "aPercent": 68.8,
+              "bPercent": 31.3,
+              "discriminability": 0.704,
+              "ratioDiscriminability": 0.625
             },
             {
               "question": 14,
               "aCount": 34,
-              "bCount": 49,
-              "aPercent": 41,
-              "bPercent": 59,
-              "discriminability": 0.607,
-              "ratioDiscriminability": 0.819
+              "bCount": 62,
+              "aPercent": 35.4,
+              "bPercent": 64.6,
+              "discriminability": 0.633,
+              "ratioDiscriminability": 0.708
             },
             {
               "question": 15,
-              "aCount": 48,
-              "bCount": 35,
-              "aPercent": 57.8,
-              "bPercent": 42.2,
-              "discriminability": 0.681,
-              "ratioDiscriminability": 0.843
+              "aCount": 59,
+              "bCount": 37,
+              "aPercent": 61.5,
+              "bPercent": 38.5,
+              "discriminability": 0.674,
+              "ratioDiscriminability": 0.771
             },
             {
               "question": 16,
-              "aCount": 59,
-              "bCount": 24,
-              "aPercent": 71.1,
-              "bPercent": 28.9,
-              "discriminability": 0.528,
-              "ratioDiscriminability": 0.578
+              "aCount": 66,
+              "bCount": 30,
+              "aPercent": 68.8,
+              "bPercent": 31.3,
+              "discriminability": 0.641,
+              "ratioDiscriminability": 0.625
             }
           ],
-          "averageDiscriminability": 0.619
+          "averageDiscriminability": 0.663
         }
       ]
     },
     "v4": {
-      "totalRuns": 24,
+      "totalRuns": 31,
       "questions": [
         {
           "question": 1,
-          "aCount": 9,
-          "bCount": 15,
-          "aPercent": 37.5,
-          "bPercent": 62.5,
-          "discriminability": 0.702,
-          "ratioDiscriminability": 0.75
+          "aCount": 14,
+          "bCount": 17,
+          "aPercent": 45.2,
+          "bPercent": 54.8,
+          "discriminability": 0.771,
+          "ratioDiscriminability": 0.903
         },
         {
           "question": 2,
-          "aCount": 10,
-          "bCount": 14,
-          "aPercent": 41.7,
-          "bPercent": 58.3,
-          "discriminability": 0.866,
-          "ratioDiscriminability": 0.833
+          "aCount": 14,
+          "bCount": 17,
+          "aPercent": 45.2,
+          "bPercent": 54.8,
+          "discriminability": 0.822,
+          "ratioDiscriminability": 0.903
         },
         {
           "question": 3,
-          "aCount": 16,
-          "bCount": 8,
-          "aPercent": 66.7,
-          "bPercent": 33.3,
-          "discriminability": 0.882,
-          "ratioDiscriminability": 0.667
+          "aCount": 18,
+          "bCount": 13,
+          "aPercent": 58.1,
+          "bPercent": 41.9,
+          "discriminability": 0.891,
+          "ratioDiscriminability": 0.839
         },
         {
           "question": 4,
-          "aCount": 10,
-          "bCount": 14,
-          "aPercent": 41.7,
-          "bPercent": 58.3,
-          "discriminability": 0.726,
-          "ratioDiscriminability": 0.833
+          "aCount": 15,
+          "bCount": 16,
+          "aPercent": 48.4,
+          "bPercent": 51.6,
+          "discriminability": 0.767,
+          "ratioDiscriminability": 0.968
         },
         {
           "question": 5,
-          "aCount": 18,
-          "bCount": 6,
-          "aPercent": 75,
-          "bPercent": 25,
-          "discriminability": 0.645,
-          "ratioDiscriminability": 0.5
+          "aCount": 22,
+          "bCount": 9,
+          "aPercent": 71,
+          "bPercent": 29,
+          "discriminability": 0.696,
+          "ratioDiscriminability": 0.581
         },
         {
           "question": 6,
-          "aCount": 12,
+          "aCount": 19,
           "bCount": 12,
-          "aPercent": 50,
-          "bPercent": 50,
-          "discriminability": 0.667,
-          "ratioDiscriminability": 1
+          "aPercent": 61.3,
+          "bPercent": 38.7,
+          "discriminability": 0.722,
+          "ratioDiscriminability": 0.774
         },
         {
           "question": 7,
-          "aCount": 20,
-          "bCount": 4,
-          "aPercent": 83.3,
-          "bPercent": 16.7,
-          "discriminability": 0.577,
-          "ratioDiscriminability": 0.333
+          "aCount": 23,
+          "bCount": 8,
+          "aPercent": 74.2,
+          "bPercent": 25.8,
+          "discriminability": 0.702,
+          "ratioDiscriminability": 0.516
         },
         {
           "question": 8,
-          "aCount": 9,
-          "bCount": 15,
-          "aPercent": 37.5,
-          "bPercent": 62.5,
-          "discriminability": 0.846,
-          "ratioDiscriminability": 0.75
+          "aCount": 12,
+          "bCount": 19,
+          "aPercent": 38.7,
+          "bPercent": 61.3,
+          "discriminability": 0.776,
+          "ratioDiscriminability": 0.774
         },
         {
           "question": 9,
-          "aCount": 16,
-          "bCount": 8,
-          "aPercent": 66.7,
-          "bPercent": 33.3,
-          "discriminability": 0.667,
-          "ratioDiscriminability": 0.667
+          "aCount": 22,
+          "bCount": 9,
+          "aPercent": 71,
+          "bPercent": 29,
+          "discriminability": 0.752,
+          "ratioDiscriminability": 0.581
         },
         {
           "question": 10,
-          "aCount": 8,
-          "bCount": 16,
-          "aPercent": 33.3,
-          "bPercent": 66.7,
-          "discriminability": 0.816,
-          "ratioDiscriminability": 0.667
+          "aCount": 11,
+          "bCount": 20,
+          "aPercent": 35.5,
+          "bPercent": 64.5,
+          "discriminability": 0.752,
+          "ratioDiscriminability": 0.71
         },
         {
           "question": 11,
-          "aCount": 8,
-          "bCount": 16,
-          "aPercent": 33.3,
-          "bPercent": 66.7,
-          "discriminability": 0.745,
-          "ratioDiscriminability": 0.667
+          "aCount": 12,
+          "bCount": 19,
+          "aPercent": 38.7,
+          "bPercent": 61.3,
+          "discriminability": 0.776,
+          "ratioDiscriminability": 0.774
         },
         {
           "question": 12,
-          "aCount": 13,
-          "bCount": 11,
-          "aPercent": 54.2,
-          "bPercent": 45.8,
-          "discriminability": 0.661,
-          "ratioDiscriminability": 0.917
+          "aCount": 17,
+          "bCount": 14,
+          "aPercent": 54.8,
+          "bPercent": 45.2,
+          "discriminability": 0.757,
+          "ratioDiscriminability": 0.903
         },
         {
           "question": 13,
-          "aCount": 16,
-          "bCount": 8,
-          "aPercent": 66.7,
-          "bPercent": 33.3,
-          "discriminability": 0.816,
-          "ratioDiscriminability": 0.667
+          "aCount": 21,
+          "bCount": 10,
+          "aPercent": 67.7,
+          "bPercent": 32.3,
+          "discriminability": 0.827,
+          "ratioDiscriminability": 0.645
         },
         {
           "question": 14,
           "aCount": 10,
-          "bCount": 14,
-          "aPercent": 41.7,
-          "bPercent": 58.3,
-          "discriminability": 0.553,
-          "ratioDiscriminability": 0.833
+          "bCount": 21,
+          "aPercent": 32.3,
+          "bPercent": 67.7,
+          "discriminability": 0.6,
+          "ratioDiscriminability": 0.645
         },
         {
           "question": 15,
-          "aCount": 15,
-          "bCount": 9,
-          "aPercent": 62.5,
-          "bPercent": 37.5,
-          "discriminability": 0.618,
-          "ratioDiscriminability": 0.75
+          "aCount": 20,
+          "bCount": 11,
+          "aPercent": 64.5,
+          "bPercent": 35.5,
+          "discriminability": 0.636,
+          "ratioDiscriminability": 0.71
         },
         {
           "question": 16,
-          "aCount": 17,
-          "bCount": 7,
-          "aPercent": 70.8,
-          "bPercent": 29.2,
-          "discriminability": 0.618,
-          "ratioDiscriminability": 0.583
+          "aCount": 23,
+          "bCount": 8,
+          "aPercent": 74.2,
+          "bPercent": 25.8,
+          "discriminability": 0.575,
+          "ratioDiscriminability": 0.516
         }
       ],
       "dimensions": [
@@ -828,42 +828,42 @@
           "questions": [
             {
               "question": 1,
-              "aCount": 9,
-              "bCount": 15,
-              "aPercent": 37.5,
-              "bPercent": 62.5,
-              "discriminability": 0.702,
-              "ratioDiscriminability": 0.75
+              "aCount": 14,
+              "bCount": 17,
+              "aPercent": 45.2,
+              "bPercent": 54.8,
+              "discriminability": 0.771,
+              "ratioDiscriminability": 0.903
             },
             {
               "question": 2,
-              "aCount": 10,
-              "bCount": 14,
-              "aPercent": 41.7,
-              "bPercent": 58.3,
-              "discriminability": 0.866,
-              "ratioDiscriminability": 0.833
+              "aCount": 14,
+              "bCount": 17,
+              "aPercent": 45.2,
+              "bPercent": 54.8,
+              "discriminability": 0.822,
+              "ratioDiscriminability": 0.903
             },
             {
               "question": 3,
-              "aCount": 16,
-              "bCount": 8,
-              "aPercent": 66.7,
-              "bPercent": 33.3,
-              "discriminability": 0.882,
-              "ratioDiscriminability": 0.667
+              "aCount": 18,
+              "bCount": 13,
+              "aPercent": 58.1,
+              "bPercent": 41.9,
+              "discriminability": 0.891,
+              "ratioDiscriminability": 0.839
             },
             {
               "question": 4,
-              "aCount": 10,
-              "bCount": 14,
-              "aPercent": 41.7,
-              "bPercent": 58.3,
-              "discriminability": 0.726,
-              "ratioDiscriminability": 0.833
+              "aCount": 15,
+              "bCount": 16,
+              "aPercent": 48.4,
+              "bPercent": 51.6,
+              "discriminability": 0.767,
+              "ratioDiscriminability": 0.968
             }
           ],
-          "averageDiscriminability": 0.794
+          "averageDiscriminability": 0.813
         },
         {
           "name": "Precision",
@@ -874,42 +874,42 @@
           "questions": [
             {
               "question": 5,
-              "aCount": 18,
-              "bCount": 6,
-              "aPercent": 75,
-              "bPercent": 25,
-              "discriminability": 0.645,
-              "ratioDiscriminability": 0.5
+              "aCount": 22,
+              "bCount": 9,
+              "aPercent": 71,
+              "bPercent": 29,
+              "discriminability": 0.696,
+              "ratioDiscriminability": 0.581
             },
             {
               "question": 6,
-              "aCount": 12,
+              "aCount": 19,
               "bCount": 12,
-              "aPercent": 50,
-              "bPercent": 50,
-              "discriminability": 0.667,
-              "ratioDiscriminability": 1
+              "aPercent": 61.3,
+              "bPercent": 38.7,
+              "discriminability": 0.722,
+              "ratioDiscriminability": 0.774
             },
             {
               "question": 7,
-              "aCount": 20,
-              "bCount": 4,
-              "aPercent": 83.3,
-              "bPercent": 16.7,
-              "discriminability": 0.577,
-              "ratioDiscriminability": 0.333
+              "aCount": 23,
+              "bCount": 8,
+              "aPercent": 74.2,
+              "bPercent": 25.8,
+              "discriminability": 0.702,
+              "ratioDiscriminability": 0.516
             },
             {
               "question": 8,
-              "aCount": 9,
-              "bCount": 15,
-              "aPercent": 37.5,
-              "bPercent": 62.5,
-              "discriminability": 0.846,
-              "ratioDiscriminability": 0.75
+              "aCount": 12,
+              "bCount": 19,
+              "aPercent": 38.7,
+              "bPercent": 61.3,
+              "discriminability": 0.776,
+              "ratioDiscriminability": 0.774
             }
           ],
-          "averageDiscriminability": 0.684
+          "averageDiscriminability": 0.724
         },
         {
           "name": "Transparency",
@@ -920,42 +920,42 @@
           "questions": [
             {
               "question": 9,
-              "aCount": 16,
-              "bCount": 8,
-              "aPercent": 66.7,
-              "bPercent": 33.3,
-              "discriminability": 0.667,
-              "ratioDiscriminability": 0.667
+              "aCount": 22,
+              "bCount": 9,
+              "aPercent": 71,
+              "bPercent": 29,
+              "discriminability": 0.752,
+              "ratioDiscriminability": 0.581
             },
             {
               "question": 10,
-              "aCount": 8,
-              "bCount": 16,
-              "aPercent": 33.3,
-              "bPercent": 66.7,
-              "discriminability": 0.816,
-              "ratioDiscriminability": 0.667
+              "aCount": 11,
+              "bCount": 20,
+              "aPercent": 35.5,
+              "bPercent": 64.5,
+              "discriminability": 0.752,
+              "ratioDiscriminability": 0.71
             },
             {
               "question": 11,
-              "aCount": 8,
-              "bCount": 16,
-              "aPercent": 33.3,
-              "bPercent": 66.7,
-              "discriminability": 0.745,
-              "ratioDiscriminability": 0.667
+              "aCount": 12,
+              "bCount": 19,
+              "aPercent": 38.7,
+              "bPercent": 61.3,
+              "discriminability": 0.776,
+              "ratioDiscriminability": 0.774
             },
             {
               "question": 12,
-              "aCount": 13,
-              "bCount": 11,
-              "aPercent": 54.2,
-              "bPercent": 45.8,
-              "discriminability": 0.661,
-              "ratioDiscriminability": 0.917
+              "aCount": 17,
+              "bCount": 14,
+              "aPercent": 54.8,
+              "bPercent": 45.2,
+              "discriminability": 0.757,
+              "ratioDiscriminability": 0.903
             }
           ],
-          "averageDiscriminability": 0.722
+          "averageDiscriminability": 0.759
         },
         {
           "name": "Adaptability",
@@ -966,191 +966,191 @@
           "questions": [
             {
               "question": 13,
-              "aCount": 16,
-              "bCount": 8,
-              "aPercent": 66.7,
-              "bPercent": 33.3,
-              "discriminability": 0.816,
-              "ratioDiscriminability": 0.667
+              "aCount": 21,
+              "bCount": 10,
+              "aPercent": 67.7,
+              "bPercent": 32.3,
+              "discriminability": 0.827,
+              "ratioDiscriminability": 0.645
             },
             {
               "question": 14,
               "aCount": 10,
-              "bCount": 14,
-              "aPercent": 41.7,
-              "bPercent": 58.3,
-              "discriminability": 0.553,
-              "ratioDiscriminability": 0.833
+              "bCount": 21,
+              "aPercent": 32.3,
+              "bPercent": 67.7,
+              "discriminability": 0.6,
+              "ratioDiscriminability": 0.645
             },
             {
               "question": 15,
-              "aCount": 15,
-              "bCount": 9,
-              "aPercent": 62.5,
-              "bPercent": 37.5,
-              "discriminability": 0.618,
-              "ratioDiscriminability": 0.75
+              "aCount": 20,
+              "bCount": 11,
+              "aPercent": 64.5,
+              "bPercent": 35.5,
+              "discriminability": 0.636,
+              "ratioDiscriminability": 0.71
             },
             {
               "question": 16,
-              "aCount": 17,
-              "bCount": 7,
-              "aPercent": 70.8,
-              "bPercent": 29.2,
-              "discriminability": 0.618,
-              "ratioDiscriminability": 0.583
+              "aCount": 23,
+              "bCount": 8,
+              "aPercent": 74.2,
+              "bPercent": 25.8,
+              "discriminability": 0.575,
+              "ratioDiscriminability": 0.516
             }
           ],
-          "averageDiscriminability": 0.651
+          "averageDiscriminability": 0.659
         }
       ]
     },
     "v5-beta": {
-      "totalRuns": 59,
+      "totalRuns": 65,
       "questions": [
         {
           "question": 1,
-          "aCount": 39,
-          "bCount": 20,
-          "aPercent": 66.1,
-          "bPercent": 33.9,
-          "discriminability": 0.596,
-          "ratioDiscriminability": 0.678
+          "aCount": 44,
+          "bCount": 21,
+          "aPercent": 67.7,
+          "bPercent": 32.3,
+          "discriminability": 0.564,
+          "ratioDiscriminability": 0.646
         },
         {
           "question": 2,
-          "aCount": 19,
-          "bCount": 40,
-          "aPercent": 32.2,
-          "bPercent": 67.8,
-          "discriminability": 0.666,
-          "ratioDiscriminability": 0.644
+          "aCount": 24,
+          "bCount": 41,
+          "aPercent": 36.9,
+          "bPercent": 63.1,
+          "discriminability": 0.747,
+          "ratioDiscriminability": 0.738
         },
         {
           "question": 3,
-          "aCount": 44,
-          "bCount": 15,
-          "aPercent": 74.6,
-          "bPercent": 25.4,
-          "discriminability": 0.551,
-          "ratioDiscriminability": 0.508
+          "aCount": 45,
+          "bCount": 20,
+          "aPercent": 69.2,
+          "bPercent": 30.8,
+          "discriminability": 0.714,
+          "ratioDiscriminability": 0.615
         },
         {
           "question": 4,
           "aCount": 16,
-          "bCount": 43,
-          "aPercent": 27.1,
-          "bPercent": 72.9,
-          "discriminability": 0.742,
-          "ratioDiscriminability": 0.542
+          "bCount": 49,
+          "aPercent": 24.6,
+          "bPercent": 75.4,
+          "discriminability": 0.684,
+          "ratioDiscriminability": 0.492
         },
         {
           "question": 5,
-          "aCount": 32,
+          "aCount": 38,
           "bCount": 27,
-          "aPercent": 54.2,
-          "bPercent": 45.8,
-          "discriminability": 0.436,
-          "ratioDiscriminability": 0.915
+          "aPercent": 58.5,
+          "bPercent": 41.5,
+          "discriminability": 0.558,
+          "ratioDiscriminability": 0.831
         },
         {
           "question": 6,
-          "aCount": 35,
-          "bCount": 24,
-          "aPercent": 59.3,
-          "bPercent": 40.7,
-          "discriminability": 0.226,
-          "ratioDiscriminability": 0.814
+          "aCount": 38,
+          "bCount": 27,
+          "aPercent": 58.5,
+          "bPercent": 41.5,
+          "discriminability": 0.543,
+          "ratioDiscriminability": 0.831
         },
         {
           "question": 7,
-          "aCount": 42,
-          "bCount": 17,
-          "aPercent": 71.2,
-          "bPercent": 28.8,
-          "discriminability": 0.416,
-          "ratioDiscriminability": 0.576
+          "aCount": 45,
+          "bCount": 20,
+          "aPercent": 69.2,
+          "bPercent": 30.8,
+          "discriminability": 0.438,
+          "ratioDiscriminability": 0.615
         },
         {
           "question": 8,
-          "aCount": 20,
-          "bCount": 39,
-          "aPercent": 33.9,
-          "bPercent": 66.1,
-          "discriminability": 0.627,
-          "ratioDiscriminability": 0.678
+          "aCount": 21,
+          "bCount": 44,
+          "aPercent": 32.3,
+          "bPercent": 67.7,
+          "discriminability": 0.584,
+          "ratioDiscriminability": 0.646
         },
         {
           "question": 9,
-          "aCount": 40,
-          "bCount": 19,
-          "aPercent": 67.8,
-          "bPercent": 32.2,
-          "discriminability": 0.408,
-          "ratioDiscriminability": 0.644
+          "aCount": 44,
+          "bCount": 21,
+          "aPercent": 67.7,
+          "bPercent": 32.3,
+          "discriminability": 0.486,
+          "ratioDiscriminability": 0.646
         },
         {
           "question": 10,
-          "aCount": 26,
+          "aCount": 32,
           "bCount": 33,
-          "aPercent": 44.1,
-          "bPercent": 55.9,
-          "discriminability": 0.898,
-          "ratioDiscriminability": 0.881
+          "aPercent": 49.2,
+          "bPercent": 50.8,
+          "discriminability": 0.927,
+          "ratioDiscriminability": 0.985
         },
         {
           "question": 11,
           "aCount": 20,
-          "bCount": 39,
-          "aPercent": 33.9,
-          "bPercent": 66.1,
-          "discriminability": 0.69,
-          "ratioDiscriminability": 0.678
+          "bCount": 45,
+          "aPercent": 30.8,
+          "bPercent": 69.2,
+          "discriminability": 0.663,
+          "ratioDiscriminability": 0.615
         },
         {
           "question": 12,
           "aCount": 36,
-          "bCount": 23,
-          "aPercent": 61,
-          "bPercent": 39,
-          "discriminability": 0.38,
-          "ratioDiscriminability": 0.78
+          "bCount": 29,
+          "aPercent": 55.4,
+          "bPercent": 44.6,
+          "discriminability": 0.615,
+          "ratioDiscriminability": 0.892
         },
         {
           "question": 13,
-          "aCount": 39,
+          "aCount": 45,
           "bCount": 20,
-          "aPercent": 66.1,
-          "bPercent": 33.9,
-          "discriminability": 0.674,
-          "ratioDiscriminability": 0.678
+          "aPercent": 69.2,
+          "bPercent": 30.8,
+          "discriminability": 0.655,
+          "ratioDiscriminability": 0.615
         },
         {
           "question": 14,
           "aCount": 24,
-          "bCount": 35,
-          "aPercent": 40.7,
-          "bPercent": 59.3,
-          "discriminability": 0.736,
-          "ratioDiscriminability": 0.814
+          "bCount": 41,
+          "aPercent": 36.9,
+          "bPercent": 63.1,
+          "discriminability": 0.74,
+          "ratioDiscriminability": 0.738
         },
         {
           "question": 15,
-          "aCount": 33,
+          "aCount": 39,
           "bCount": 26,
-          "aPercent": 55.9,
-          "bPercent": 44.1,
-          "discriminability": 0.68,
-          "ratioDiscriminability": 0.881
+          "aPercent": 60,
+          "bPercent": 40,
+          "discriminability": 0.692,
+          "ratioDiscriminability": 0.8
         },
         {
           "question": 16,
-          "aCount": 42,
-          "bCount": 17,
-          "aPercent": 71.2,
-          "bPercent": 28.8,
-          "discriminability": 0.429,
-          "ratioDiscriminability": 0.576
+          "aCount": 43,
+          "bCount": 22,
+          "aPercent": 66.2,
+          "bPercent": 33.8,
+          "discriminability": 0.618,
+          "ratioDiscriminability": 0.677
         }
       ],
       "dimensions": [
@@ -1163,42 +1163,42 @@
           "questions": [
             {
               "question": 1,
-              "aCount": 39,
-              "bCount": 20,
-              "aPercent": 66.1,
-              "bPercent": 33.9,
-              "discriminability": 0.596,
-              "ratioDiscriminability": 0.678
+              "aCount": 44,
+              "bCount": 21,
+              "aPercent": 67.7,
+              "bPercent": 32.3,
+              "discriminability": 0.564,
+              "ratioDiscriminability": 0.646
             },
             {
               "question": 2,
-              "aCount": 19,
-              "bCount": 40,
-              "aPercent": 32.2,
-              "bPercent": 67.8,
-              "discriminability": 0.666,
-              "ratioDiscriminability": 0.644
+              "aCount": 24,
+              "bCount": 41,
+              "aPercent": 36.9,
+              "bPercent": 63.1,
+              "discriminability": 0.747,
+              "ratioDiscriminability": 0.738
             },
             {
               "question": 3,
-              "aCount": 44,
-              "bCount": 15,
-              "aPercent": 74.6,
-              "bPercent": 25.4,
-              "discriminability": 0.551,
-              "ratioDiscriminability": 0.508
+              "aCount": 45,
+              "bCount": 20,
+              "aPercent": 69.2,
+              "bPercent": 30.8,
+              "discriminability": 0.714,
+              "ratioDiscriminability": 0.615
             },
             {
               "question": 4,
               "aCount": 16,
-              "bCount": 43,
-              "aPercent": 27.1,
-              "bPercent": 72.9,
-              "discriminability": 0.742,
-              "ratioDiscriminability": 0.542
+              "bCount": 49,
+              "aPercent": 24.6,
+              "bPercent": 75.4,
+              "discriminability": 0.684,
+              "ratioDiscriminability": 0.492
             }
           ],
-          "averageDiscriminability": 0.639
+          "averageDiscriminability": 0.677
         },
         {
           "name": "Precision",
@@ -1209,42 +1209,42 @@
           "questions": [
             {
               "question": 5,
-              "aCount": 32,
+              "aCount": 38,
               "bCount": 27,
-              "aPercent": 54.2,
-              "bPercent": 45.8,
-              "discriminability": 0.436,
-              "ratioDiscriminability": 0.915
+              "aPercent": 58.5,
+              "bPercent": 41.5,
+              "discriminability": 0.558,
+              "ratioDiscriminability": 0.831
             },
             {
               "question": 6,
-              "aCount": 35,
-              "bCount": 24,
-              "aPercent": 59.3,
-              "bPercent": 40.7,
-              "discriminability": 0.226,
-              "ratioDiscriminability": 0.814
+              "aCount": 38,
+              "bCount": 27,
+              "aPercent": 58.5,
+              "bPercent": 41.5,
+              "discriminability": 0.543,
+              "ratioDiscriminability": 0.831
             },
             {
               "question": 7,
-              "aCount": 42,
-              "bCount": 17,
-              "aPercent": 71.2,
-              "bPercent": 28.8,
-              "discriminability": 0.416,
-              "ratioDiscriminability": 0.576
+              "aCount": 45,
+              "bCount": 20,
+              "aPercent": 69.2,
+              "bPercent": 30.8,
+              "discriminability": 0.438,
+              "ratioDiscriminability": 0.615
             },
             {
               "question": 8,
-              "aCount": 20,
-              "bCount": 39,
-              "aPercent": 33.9,
-              "bPercent": 66.1,
-              "discriminability": 0.627,
-              "ratioDiscriminability": 0.678
+              "aCount": 21,
+              "bCount": 44,
+              "aPercent": 32.3,
+              "bPercent": 67.7,
+              "discriminability": 0.584,
+              "ratioDiscriminability": 0.646
             }
           ],
-          "averageDiscriminability": 0.426
+          "averageDiscriminability": 0.531
         },
         {
           "name": "Transparency",
@@ -1255,42 +1255,42 @@
           "questions": [
             {
               "question": 9,
-              "aCount": 40,
-              "bCount": 19,
-              "aPercent": 67.8,
-              "bPercent": 32.2,
-              "discriminability": 0.408,
-              "ratioDiscriminability": 0.644
+              "aCount": 44,
+              "bCount": 21,
+              "aPercent": 67.7,
+              "bPercent": 32.3,
+              "discriminability": 0.486,
+              "ratioDiscriminability": 0.646
             },
             {
               "question": 10,
-              "aCount": 26,
+              "aCount": 32,
               "bCount": 33,
-              "aPercent": 44.1,
-              "bPercent": 55.9,
-              "discriminability": 0.898,
-              "ratioDiscriminability": 0.881
+              "aPercent": 49.2,
+              "bPercent": 50.8,
+              "discriminability": 0.927,
+              "ratioDiscriminability": 0.985
             },
             {
               "question": 11,
               "aCount": 20,
-              "bCount": 39,
-              "aPercent": 33.9,
-              "bPercent": 66.1,
-              "discriminability": 0.69,
-              "ratioDiscriminability": 0.678
+              "bCount": 45,
+              "aPercent": 30.8,
+              "bPercent": 69.2,
+              "discriminability": 0.663,
+              "ratioDiscriminability": 0.615
             },
             {
               "question": 12,
               "aCount": 36,
-              "bCount": 23,
-              "aPercent": 61,
-              "bPercent": 39,
-              "discriminability": 0.38,
-              "ratioDiscriminability": 0.78
+              "bCount": 29,
+              "aPercent": 55.4,
+              "bPercent": 44.6,
+              "discriminability": 0.615,
+              "ratioDiscriminability": 0.892
             }
           ],
-          "averageDiscriminability": 0.594
+          "averageDiscriminability": 0.673
         },
         {
           "name": "Adaptability",
@@ -1301,42 +1301,42 @@
           "questions": [
             {
               "question": 13,
-              "aCount": 39,
+              "aCount": 45,
               "bCount": 20,
-              "aPercent": 66.1,
-              "bPercent": 33.9,
-              "discriminability": 0.674,
-              "ratioDiscriminability": 0.678
+              "aPercent": 69.2,
+              "bPercent": 30.8,
+              "discriminability": 0.655,
+              "ratioDiscriminability": 0.615
             },
             {
               "question": 14,
               "aCount": 24,
-              "bCount": 35,
-              "aPercent": 40.7,
-              "bPercent": 59.3,
-              "discriminability": 0.736,
-              "ratioDiscriminability": 0.814
+              "bCount": 41,
+              "aPercent": 36.9,
+              "bPercent": 63.1,
+              "discriminability": 0.74,
+              "ratioDiscriminability": 0.738
             },
             {
               "question": 15,
-              "aCount": 33,
+              "aCount": 39,
               "bCount": 26,
-              "aPercent": 55.9,
-              "bPercent": 44.1,
-              "discriminability": 0.68,
-              "ratioDiscriminability": 0.881
+              "aPercent": 60,
+              "bPercent": 40,
+              "discriminability": 0.692,
+              "ratioDiscriminability": 0.8
             },
             {
               "question": 16,
-              "aCount": 42,
-              "bCount": 17,
-              "aPercent": 71.2,
-              "bPercent": 28.8,
-              "discriminability": 0.429,
-              "ratioDiscriminability": 0.576
+              "aCount": 43,
+              "bCount": 22,
+              "aPercent": 66.2,
+              "bPercent": 33.8,
+              "discriminability": 0.618,
+              "ratioDiscriminability": 0.677
             }
           ],
-          "averageDiscriminability": 0.63
+          "averageDiscriminability": 0.676
         }
       ]
     }

--- a/data/reliability/llama-4-maverick-run-1.json
+++ b/data/reliability/llama-4-maverick-run-1.json
@@ -1,0 +1,30 @@
+{
+    "model": "Llama-4-Maverick-17B-128E-Instruct-FP8",
+    "provider": "github",
+    "run": 1,
+    "answers": [
+        "A",
+        "A",
+        "B",
+        "B",
+        "A",
+        "A",
+        "A",
+        "B",
+        "A",
+        "A",
+        "B",
+        "B",
+        "A",
+        "B",
+        "A",
+        "B"
+    ],
+    "type": "PTCF",
+    "dimensions": [
+        2,
+        3,
+        2,
+        2
+    ]
+}

--- a/data/reliability/llama-4-maverick-run-2.json
+++ b/data/reliability/llama-4-maverick-run-2.json
@@ -1,0 +1,30 @@
+{
+    "model": "Llama-4-Maverick-17B-128E-Instruct-FP8",
+    "provider": "github",
+    "run": 2,
+    "answers": [
+        "B",
+        "B",
+        "B",
+        "B",
+        "A",
+        "A",
+        "A",
+        "B",
+        "A",
+        "A",
+        "B",
+        "B",
+        "A",
+        "B",
+        "A",
+        "A"
+    ],
+    "type": "RTCF",
+    "dimensions": [
+        0,
+        3,
+        2,
+        3
+    ]
+}

--- a/data/reliability/llama-4-maverick-run-3.json
+++ b/data/reliability/llama-4-maverick-run-3.json
@@ -1,0 +1,30 @@
+{
+    "model": "Llama-4-Maverick-17B-128E-Instruct-FP8",
+    "provider": "github",
+    "run": 3,
+    "answers": [
+        "A",
+        "A",
+        "B",
+        "B",
+        "A",
+        "A",
+        "B",
+        "A",
+        "A",
+        "A",
+        "B",
+        "B",
+        "A",
+        "B",
+        "A",
+        "B"
+    ],
+    "type": "PTCF",
+    "dimensions": [
+        2,
+        3,
+        2,
+        2
+    ]
+}

--- a/data/reliability/llama-4-scout-run-1.json
+++ b/data/reliability/llama-4-scout-run-1.json
@@ -1,0 +1,30 @@
+{
+    "model": "Llama-4-Scout-17B-16E-Instruct",
+    "provider": "github",
+    "run": 1,
+    "answers": [
+        "A",
+        "A",
+        "B",
+        "B",
+        "A",
+        "B",
+        "B",
+        "B",
+        "B",
+        "A",
+        "B",
+        "B",
+        "A",
+        "B",
+        "A",
+        "B"
+    ],
+    "type": "PEDF",
+    "dimensions": [
+        2,
+        1,
+        1,
+        2
+    ]
+}

--- a/data/reliability/llama-4-scout-run-2.json
+++ b/data/reliability/llama-4-scout-run-2.json
@@ -1,0 +1,30 @@
+{
+    "model": "Llama-4-Scout-17B-16E-Instruct",
+    "provider": "github",
+    "run": 2,
+    "answers": [
+        "A",
+        "A",
+        "B",
+        "B",
+        "A",
+        "B",
+        "B",
+        "B",
+        "B",
+        "A",
+        "B",
+        "B",
+        "A",
+        "B",
+        "A",
+        "B"
+    ],
+    "type": "PEDF",
+    "dimensions": [
+        2,
+        1,
+        1,
+        2
+    ]
+}

--- a/data/reliability/llama-4-scout-run-3.json
+++ b/data/reliability/llama-4-scout-run-3.json
@@ -1,0 +1,30 @@
+{
+    "model": "Llama-4-Scout-17B-16E-Instruct",
+    "provider": "github",
+    "run": 3,
+    "answers": [
+        "A",
+        "A",
+        "A",
+        "B",
+        "A",
+        "B",
+        "A",
+        "B",
+        "A",
+        "A",
+        "B",
+        "B",
+        "A",
+        "B",
+        "A",
+        "B"
+    ],
+    "type": "PTCF",
+    "dimensions": [
+        3,
+        2,
+        2,
+        2
+    ]
+}

--- a/data/reliability/ministral-3b-run-1.json
+++ b/data/reliability/ministral-3b-run-1.json
@@ -1,0 +1,30 @@
+{
+    "model": "Ministral-3B",
+    "provider": "github",
+    "run": 1,
+    "answers": [
+        "B",
+        "A",
+        "B",
+        "A",
+        "A",
+        "A",
+        "B",
+        "B",
+        "A",
+        "B",
+        "A",
+        "B",
+        "A",
+        "B",
+        "A",
+        "A"
+    ],
+    "type": "PTCF",
+    "dimensions": [
+        2,
+        2,
+        2,
+        3
+    ]
+}

--- a/data/reliability/ministral-3b-run-2.json
+++ b/data/reliability/ministral-3b-run-2.json
@@ -1,0 +1,30 @@
+{
+    "model": "Ministral-3B",
+    "provider": "github",
+    "run": 2,
+    "answers": [
+        "A",
+        "A",
+        "B",
+        "A",
+        "B",
+        "A",
+        "B",
+        "B",
+        "A",
+        "A",
+        "A",
+        "B",
+        "A",
+        "B",
+        "A",
+        "A"
+    ],
+    "type": "PECF",
+    "dimensions": [
+        3,
+        1,
+        3,
+        3
+    ]
+}

--- a/data/reliability/ministral-3b-run-3.json
+++ b/data/reliability/ministral-3b-run-3.json
@@ -1,0 +1,30 @@
+{
+    "model": "Ministral-3B",
+    "provider": "github",
+    "run": 3,
+    "answers": [
+        "B",
+        "B",
+        "B",
+        "A",
+        "A",
+        "A",
+        "B",
+        "A",
+        "A",
+        "A",
+        "A",
+        "B",
+        "A",
+        "B",
+        "A",
+        "A"
+    ],
+    "type": "RTCF",
+    "dimensions": [
+        1,
+        3,
+        3,
+        3
+    ]
+}

--- a/data/reliability/mistral-small-2503-run-1.json
+++ b/data/reliability/mistral-small-2503-run-1.json
@@ -1,0 +1,30 @@
+{
+    "model": "mistral-small-2503",
+    "provider": "github",
+    "run": 1,
+    "answers": [
+        "A",
+        "A",
+        "B",
+        "A",
+        "A",
+        "A",
+        "B",
+        "A",
+        "A",
+        "B",
+        "A",
+        "A",
+        "A",
+        "B",
+        "B",
+        "A"
+    ],
+    "type": "PTCF",
+    "dimensions": [
+        3,
+        3,
+        3,
+        2
+    ]
+}

--- a/data/reliability/mistral-small-2503-run-2.json
+++ b/data/reliability/mistral-small-2503-run-2.json
@@ -1,0 +1,30 @@
+{
+    "model": "mistral-small-2503",
+    "provider": "github",
+    "run": 2,
+    "answers": [
+        "A",
+        "B",
+        "A",
+        "B",
+        "B",
+        "A",
+        "A",
+        "A",
+        "A",
+        "A",
+        "B",
+        "A",
+        "B",
+        "B",
+        "B",
+        "B"
+    ],
+    "type": "PTCN",
+    "dimensions": [
+        2,
+        3,
+        3,
+        0
+    ]
+}

--- a/data/reliability/mistral-small-2503-run-3.json
+++ b/data/reliability/mistral-small-2503-run-3.json
@@ -1,0 +1,30 @@
+{
+    "model": "mistral-small-2503",
+    "provider": "github",
+    "run": 3,
+    "answers": [
+        "A",
+        "B",
+        "B",
+        "A",
+        "A",
+        "A",
+        "A",
+        "B",
+        "A",
+        "B",
+        "B",
+        "A",
+        "A",
+        "B",
+        "A",
+        "A"
+    ],
+    "type": "PTCF",
+    "dimensions": [
+        2,
+        3,
+        2,
+        3
+    ]
+}

--- a/data/reliability/phi-4-run-1.json
+++ b/data/reliability/phi-4-run-1.json
@@ -1,0 +1,31 @@
+{
+  "model": "Phi-4",
+  "provider": "github",
+  "run": 1,
+  "answers": [
+    "A",
+    "A",
+    "A",
+    "B",
+    "B",
+    "A",
+    "A",
+    "B",
+    "B",
+    "B",
+    "B",
+    "A",
+    "B",
+    "B",
+    "A",
+    "A"
+  ],
+  "dimensions": [
+    3,
+    2,
+    1,
+    2
+  ],
+  "type": "PTDF",
+  "questionVersion": "5.15-beta"
+}


### PR DESCRIPTION
## Summary

Adds reliability test data for 5 new models via GitHub Models provider (v5.15-beta questions).

### Results (3 runs each)

| Model | Run 1 | Run 2 | Run 3 | Consistent? |
|-------|-------|-------|-------|-------------|
| Llama-4-Scout-17B-16E-Instruct | PEDF | PEDF | PTCF | 2/3 |
| Llama-4-Maverick-17B-128E-Instruct-FP8 | PTCF | RTCF | PTCF | 2/3 |
| mistral-small-2503 | PTCF | PTCN | PTCF | 2/3 |
| Ministral-3B | PTCF | PECF | RTCF | 0/3 |
| Phi-4 | PTDF | — | — | (rate limited) |

### Notes

- 4 models have 3 complete runs each (exceeds acceptance criteria of ≥3 models with 3 runs)
- Phi-4 has 1 run; GitHub Models rate limit prevented runs 2-3 (can retry later)
- Ministral-3B shows low consistency across runs (3 different types), interesting for discriminability analysis
- Discriminability regeneration pending as separate step

### TODO
- [ ] Complete Phi-4 runs 2-3 when quota resets
- [ ] Regenerate discriminability stats

Refs #722