### PR TITLE
data: reliability refresh after Q11+Q13 redesign (#753)

### DIFF
--- a/data/discriminability.json
+++ b/data/discriminability.json
@@ -1,151 +1,151 @@
 {
-  "generatedAt": "2026-07-12T05:34:19.795Z",
+  "generatedAt": "2026-07-13T03:01:46.109Z",
   "threshold": 0.6,
-  "totalRuns": 238,
+  "totalRuns": 285,
   "questions": [
     {
       "question": 1,
-      "aCount": 108,
-      "bCount": 130,
-      "aPercent": 45.4,
-      "bPercent": 54.6,
-      "discriminability": 0.807,
-      "ratioDiscriminability": 0.908
+      "aCount": 131,
+      "bCount": 154,
+      "aPercent": 46,
+      "bPercent": 54,
+      "discriminability": 0.813,
+      "ratioDiscriminability": 0.919
     },
     {
       "question": 2,
-      "aCount": 78,
-      "bCount": 160,
-      "aPercent": 32.8,
-      "bPercent": 67.2,
-      "discriminability": 0.769,
-      "ratioDiscriminability": 0.655
+      "aCount": 88,
+      "bCount": 197,
+      "aPercent": 30.9,
+      "bPercent": 69.1,
+      "discriminability": 0.773,
+      "ratioDiscriminability": 0.618
     },
     {
       "question": 3,
-      "aCount": 166,
-      "bCount": 72,
-      "aPercent": 69.7,
-      "bPercent": 30.3,
-      "discriminability": 0.801,
-      "ratioDiscriminability": 0.605
+      "aCount": 203,
+      "bCount": 82,
+      "aPercent": 71.2,
+      "bPercent": 28.8,
+      "discriminability": 0.774,
+      "ratioDiscriminability": 0.575
     },
     {
       "question": 4,
-      "aCount": 88,
-      "bCount": 150,
-      "aPercent": 37,
-      "bPercent": 63,
-      "discriminability": 0.818,
-      "ratioDiscriminability": 0.739
-    },
-    {
-      "question": 5,
-      "aCount": 146,
-      "bCount": 92,
-      "aPercent": 61.3,
-      "bPercent": 38.7,
-      "discriminability": 0.649,
-      "ratioDiscriminability": 0.773
-    },
-    {
-      "question": 6,
-      "aCount": 131,
-      "bCount": 107,
-      "aPercent": 55,
-      "bPercent": 45,
-      "discriminability": 0.785,
-      "ratioDiscriminability": 0.899
-    },
-    {
-      "question": 7,
-      "aCount": 155,
-      "bCount": 83,
-      "aPercent": 65.1,
-      "bPercent": 34.9,
-      "discriminability": 0.663,
-      "ratioDiscriminability": 0.697
-    },
-    {
-      "question": 8,
-      "aCount": 77,
-      "bCount": 161,
-      "aPercent": 32.4,
-      "bPercent": 67.6,
-      "discriminability": 0.672,
-      "ratioDiscriminability": 0.647
-    },
-    {
-      "question": 9,
-      "aCount": 144,
-      "bCount": 94,
-      "aPercent": 60.5,
-      "bPercent": 39.5,
-      "discriminability": 0.739,
-      "ratioDiscriminability": 0.79
-    },
-    {
-      "question": 10,
-      "aCount": 101,
-      "bCount": 137,
-      "aPercent": 42.4,
-      "bPercent": 57.6,
-      "discriminability": 0.85,
-      "ratioDiscriminability": 0.849
-    },
-    {
-      "question": 11,
-      "aCount": 70,
-      "bCount": 168,
-      "aPercent": 29.4,
-      "bPercent": 70.6,
-      "discriminability": 0.639,
-      "ratioDiscriminability": 0.588
-    },
-    {
-      "question": 12,
-      "aCount": 144,
-      "bCount": 94,
-      "aPercent": 60.5,
-      "bPercent": 39.5,
-      "discriminability": 0.751,
-      "ratioDiscriminability": 0.79
-    },
-    {
-      "question": 13,
-      "aCount": 166,
-      "bCount": 72,
-      "aPercent": 69.7,
-      "bPercent": 30.3,
-      "discriminability": 0.68,
-      "ratioDiscriminability": 0.605
-    },
-    {
-      "question": 14,
-      "aCount": 114,
-      "bCount": 124,
-      "aPercent": 47.9,
-      "bPercent": 52.1,
-      "discriminability": 0.824,
-      "ratioDiscriminability": 0.958
-    },
-    {
-      "question": 15,
-      "aCount": 152,
-      "bCount": 86,
-      "aPercent": 63.9,
-      "bPercent": 36.1,
-      "discriminability": 0.737,
+      "aCount": 103,
+      "bCount": 182,
+      "aPercent": 36.1,
+      "bPercent": 63.9,
+      "discriminability": 0.826,
       "ratioDiscriminability": 0.723
     },
     {
+      "question": 5,
+      "aCount": 176,
+      "bCount": 109,
+      "aPercent": 61.8,
+      "bPercent": 38.2,
+      "discriminability": 0.711,
+      "ratioDiscriminability": 0.765
+    },
+    {
+      "question": 6,
+      "aCount": 151,
+      "bCount": 134,
+      "aPercent": 53,
+      "bPercent": 47,
+      "discriminability": 0.789,
+      "ratioDiscriminability": 0.94
+    },
+    {
+      "question": 7,
+      "aCount": 194,
+      "bCount": 91,
+      "aPercent": 68.1,
+      "bPercent": 31.9,
+      "discriminability": 0.634,
+      "ratioDiscriminability": 0.639
+    },
+    {
+      "question": 8,
+      "aCount": 95,
+      "bCount": 190,
+      "aPercent": 33.3,
+      "bPercent": 66.7,
+      "discriminability": 0.718,
+      "ratioDiscriminability": 0.667
+    },
+    {
+      "question": 9,
+      "aCount": 179,
+      "bCount": 106,
+      "aPercent": 62.8,
+      "bPercent": 37.2,
+      "discriminability": 0.744,
+      "ratioDiscriminability": 0.744
+    },
+    {
+      "question": 10,
+      "aCount": 128,
+      "bCount": 157,
+      "aPercent": 44.9,
+      "bPercent": 55.1,
+      "discriminability": 0.882,
+      "ratioDiscriminability": 0.898
+    },
+    {
+      "question": 11,
+      "aCount": 91,
+      "bCount": 194,
+      "aPercent": 31.9,
+      "bPercent": 68.1,
+      "discriminability": 0.712,
+      "ratioDiscriminability": 0.639
+    },
+    {
+      "question": 12,
+      "aCount": 180,
+      "bCount": 105,
+      "aPercent": 63.2,
+      "bPercent": 36.8,
+      "discriminability": 0.722,
+      "ratioDiscriminability": 0.737
+    },
+    {
+      "question": 13,
+      "aCount": 199,
+      "bCount": 86,
+      "aPercent": 69.8,
+      "bPercent": 30.2,
+      "discriminability": 0.71,
+      "ratioDiscriminability": 0.604
+    },
+    {
+      "question": 14,
+      "aCount": 141,
+      "bCount": 144,
+      "aPercent": 49.5,
+      "bPercent": 50.5,
+      "discriminability": 0.832,
+      "ratioDiscriminability": 0.989
+    },
+    {
+      "question": 15,
+      "aCount": 184,
+      "bCount": 101,
+      "aPercent": 64.6,
+      "bPercent": 35.4,
+      "discriminability": 0.759,
+      "ratioDiscriminability": 0.709
+    },
+    {
       "question": 16,
-      "aCount": 153,
-      "bCount": 85,
-      "aPercent": 64.3,
-      "bPercent": 35.7,
-      "discriminability": 0.72,
-      "ratioDiscriminability": 0.714
+      "aCount": 179,
+      "bCount": 106,
+      "aPercent": 62.8,
+      "bPercent": 37.2,
+      "discriminability": 0.747,
+      "ratioDiscriminability": 0.744
     }
   ],
   "dimensions": [
@@ -158,42 +158,42 @@
       "questions": [
         {
           "question": 1,
-          "aCount": 108,
-          "bCount": 130,
-          "aPercent": 45.4,
-          "bPercent": 54.6,
-          "discriminability": 0.807,
-          "ratioDiscriminability": 0.908
+          "aCount": 131,
+          "bCount": 154,
+          "aPercent": 46,
+          "bPercent": 54,
+          "discriminability": 0.813,
+          "ratioDiscriminability": 0.919
         },
         {
           "question": 2,
-          "aCount": 78,
-          "bCount": 160,
-          "aPercent": 32.8,
-          "bPercent": 67.2,
-          "discriminability": 0.769,
-          "ratioDiscriminability": 0.655
+          "aCount": 88,
+          "bCount": 197,
+          "aPercent": 30.9,
+          "bPercent": 69.1,
+          "discriminability": 0.773,
+          "ratioDiscriminability": 0.618
         },
         {
           "question": 3,
-          "aCount": 166,
-          "bCount": 72,
-          "aPercent": 69.7,
-          "bPercent": 30.3,
-          "discriminability": 0.801,
-          "ratioDiscriminability": 0.605
+          "aCount": 203,
+          "bCount": 82,
+          "aPercent": 71.2,
+          "bPercent": 28.8,
+          "discriminability": 0.774,
+          "ratioDiscriminability": 0.575
         },
         {
           "question": 4,
-          "aCount": 88,
-          "bCount": 150,
-          "aPercent": 37,
-          "bPercent": 63,
-          "discriminability": 0.818,
-          "ratioDiscriminability": 0.739
+          "aCount": 103,
+          "bCount": 182,
+          "aPercent": 36.1,
+          "bPercent": 63.9,
+          "discriminability": 0.826,
+          "ratioDiscriminability": 0.723
         }
       ],
-      "averageDiscriminability": 0.799
+      "averageDiscriminability": 0.796
     },
     {
       "name": "Precision",
@@ -204,42 +204,42 @@
       "questions": [
         {
           "question": 5,
-          "aCount": 146,
-          "bCount": 92,
-          "aPercent": 61.3,
-          "bPercent": 38.7,
-          "discriminability": 0.649,
-          "ratioDiscriminability": 0.773
+          "aCount": 176,
+          "bCount": 109,
+          "aPercent": 61.8,
+          "bPercent": 38.2,
+          "discriminability": 0.711,
+          "ratioDiscriminability": 0.765
         },
         {
           "question": 6,
-          "aCount": 131,
-          "bCount": 107,
-          "aPercent": 55,
-          "bPercent": 45,
-          "discriminability": 0.785,
-          "ratioDiscriminability": 0.899
+          "aCount": 151,
+          "bCount": 134,
+          "aPercent": 53,
+          "bPercent": 47,
+          "discriminability": 0.789,
+          "ratioDiscriminability": 0.94
         },
         {
           "question": 7,
-          "aCount": 155,
-          "bCount": 83,
-          "aPercent": 65.1,
-          "bPercent": 34.9,
-          "discriminability": 0.663,
-          "ratioDiscriminability": 0.697
+          "aCount": 194,
+          "bCount": 91,
+          "aPercent": 68.1,
+          "bPercent": 31.9,
+          "discriminability": 0.634,
+          "ratioDiscriminability": 0.639
         },
         {
           "question": 8,
-          "aCount": 77,
-          "bCount": 161,
-          "aPercent": 32.4,
-          "bPercent": 67.6,
-          "discriminability": 0.672,
-          "ratioDiscriminability": 0.647
+          "aCount": 95,
+          "bCount": 190,
+          "aPercent": 33.3,
+          "bPercent": 66.7,
+          "discriminability": 0.718,
+          "ratioDiscriminability": 0.667
         }
       ],
-      "averageDiscriminability": 0.692
+      "averageDiscriminability": 0.713
     },
     {
       "name": "Transparency",
@@ -250,42 +250,42 @@
       "questions": [
         {
           "question": 9,
-          "aCount": 144,
-          "bCount": 94,
-          "aPercent": 60.5,
-          "bPercent": 39.5,
-          "discriminability": 0.739,
-          "ratioDiscriminability": 0.79
+          "aCount": 179,
+          "bCount": 106,
+          "aPercent": 62.8,
+          "bPercent": 37.2,
+          "discriminability": 0.744,
+          "ratioDiscriminability": 0.744
         },
         {
           "question": 10,
-          "aCount": 101,
-          "bCount": 137,
-          "aPercent": 42.4,
-          "bPercent": 57.6,
-          "discriminability": 0.85,
-          "ratioDiscriminability": 0.849
+          "aCount": 128,
+          "bCount": 157,
+          "aPercent": 44.9,
+          "bPercent": 55.1,
+          "discriminability": 0.882,
+          "ratioDiscriminability": 0.898
         },
         {
           "question": 11,
-          "aCount": 70,
-          "bCount": 168,
-          "aPercent": 29.4,
-          "bPercent": 70.6,
-          "discriminability": 0.639,
-          "ratioDiscriminability": 0.588
+          "aCount": 91,
+          "bCount": 194,
+          "aPercent": 31.9,
+          "bPercent": 68.1,
+          "discriminability": 0.712,
+          "ratioDiscriminability": 0.639
         },
         {
           "question": 12,
-          "aCount": 144,
-          "bCount": 94,
-          "aPercent": 60.5,
-          "bPercent": 39.5,
-          "discriminability": 0.751,
-          "ratioDiscriminability": 0.79
+          "aCount": 180,
+          "bCount": 105,
+          "aPercent": 63.2,
+          "bPercent": 36.8,
+          "discriminability": 0.722,
+          "ratioDiscriminability": 0.737
         }
       ],
-      "averageDiscriminability": 0.745
+      "averageDiscriminability": 0.765
     },
     {
       "name": "Adaptability",
@@ -296,191 +296,191 @@
       "questions": [
         {
           "question": 13,
-          "aCount": 166,
-          "bCount": 72,
-          "aPercent": 69.7,
-          "bPercent": 30.3,
-          "discriminability": 0.68,
-          "ratioDiscriminability": 0.605
+          "aCount": 199,
+          "bCount": 86,
+          "aPercent": 69.8,
+          "bPercent": 30.2,
+          "discriminability": 0.71,
+          "ratioDiscriminability": 0.604
         },
         {
           "question": 14,
-          "aCount": 114,
-          "bCount": 124,
-          "aPercent": 47.9,
-          "bPercent": 52.1,
-          "discriminability": 0.824,
-          "ratioDiscriminability": 0.958
+          "aCount": 141,
+          "bCount": 144,
+          "aPercent": 49.5,
+          "bPercent": 50.5,
+          "discriminability": 0.832,
+          "ratioDiscriminability": 0.989
         },
         {
           "question": 15,
-          "aCount": 152,
-          "bCount": 86,
-          "aPercent": 63.9,
-          "bPercent": 36.1,
-          "discriminability": 0.737,
-          "ratioDiscriminability": 0.723
+          "aCount": 184,
+          "bCount": 101,
+          "aPercent": 64.6,
+          "bPercent": 35.4,
+          "discriminability": 0.759,
+          "ratioDiscriminability": 0.709
         },
         {
           "question": 16,
-          "aCount": 153,
-          "bCount": 85,
-          "aPercent": 64.3,
-          "bPercent": 35.7,
-          "discriminability": 0.72,
-          "ratioDiscriminability": 0.714
+          "aCount": 179,
+          "bCount": 106,
+          "aPercent": 62.8,
+          "bPercent": 37.2,
+          "discriminability": 0.747,
+          "ratioDiscriminability": 0.744
         }
       ],
-      "averageDiscriminability": 0.74
+      "averageDiscriminability": 0.762
     }
   ],
   "cohorts": {
     "all": {
-      "totalRuns": 238,
+      "totalRuns": 285,
       "questions": [
         {
           "question": 1,
-          "aCount": 108,
-          "bCount": 130,
-          "aPercent": 45.4,
-          "bPercent": 54.6,
-          "discriminability": 0.807,
-          "ratioDiscriminability": 0.908
+          "aCount": 131,
+          "bCount": 154,
+          "aPercent": 46,
+          "bPercent": 54,
+          "discriminability": 0.813,
+          "ratioDiscriminability": 0.919
         },
         {
           "question": 2,
-          "aCount": 78,
-          "bCount": 160,
-          "aPercent": 32.8,
-          "bPercent": 67.2,
-          "discriminability": 0.769,
-          "ratioDiscriminability": 0.655
+          "aCount": 88,
+          "bCount": 197,
+          "aPercent": 30.9,
+          "bPercent": 69.1,
+          "discriminability": 0.773,
+          "ratioDiscriminability": 0.618
         },
         {
           "question": 3,
-          "aCount": 166,
-          "bCount": 72,
-          "aPercent": 69.7,
-          "bPercent": 30.3,
-          "discriminability": 0.801,
-          "ratioDiscriminability": 0.605
+          "aCount": 203,
+          "bCount": 82,
+          "aPercent": 71.2,
+          "bPercent": 28.8,
+          "discriminability": 0.774,
+          "ratioDiscriminability": 0.575
         },
         {
           "question": 4,
-          "aCount": 88,
-          "bCount": 150,
-          "aPercent": 37,
-          "bPercent": 63,
-          "discriminability": 0.818,
-          "ratioDiscriminability": 0.739
-        },
-        {
-          "question": 5,
-          "aCount": 146,
-          "bCount": 92,
-          "aPercent": 61.3,
-          "bPercent": 38.7,
-          "discriminability": 0.649,
-          "ratioDiscriminability": 0.773
-        },
-        {
-          "question": 6,
-          "aCount": 131,
-          "bCount": 107,
-          "aPercent": 55,
-          "bPercent": 45,
-          "discriminability": 0.785,
-          "ratioDiscriminability": 0.899
-        },
-        {
-          "question": 7,
-          "aCount": 155,
-          "bCount": 83,
-          "aPercent": 65.1,
-          "bPercent": 34.9,
-          "discriminability": 0.663,
-          "ratioDiscriminability": 0.697
-        },
-        {
-          "question": 8,
-          "aCount": 77,
-          "bCount": 161,
-          "aPercent": 32.4,
-          "bPercent": 67.6,
-          "discriminability": 0.672,
-          "ratioDiscriminability": 0.647
-        },
-        {
-          "question": 9,
-          "aCount": 144,
-          "bCount": 94,
-          "aPercent": 60.5,
-          "bPercent": 39.5,
-          "discriminability": 0.739,
-          "ratioDiscriminability": 0.79
-        },
-        {
-          "question": 10,
-          "aCount": 101,
-          "bCount": 137,
-          "aPercent": 42.4,
-          "bPercent": 57.6,
-          "discriminability": 0.85,
-          "ratioDiscriminability": 0.849
-        },
-        {
-          "question": 11,
-          "aCount": 70,
-          "bCount": 168,
-          "aPercent": 29.4,
-          "bPercent": 70.6,
-          "discriminability": 0.639,
-          "ratioDiscriminability": 0.588
-        },
-        {
-          "question": 12,
-          "aCount": 144,
-          "bCount": 94,
-          "aPercent": 60.5,
-          "bPercent": 39.5,
-          "discriminability": 0.751,
-          "ratioDiscriminability": 0.79
-        },
-        {
-          "question": 13,
-          "aCount": 166,
-          "bCount": 72,
-          "aPercent": 69.7,
-          "bPercent": 30.3,
-          "discriminability": 0.68,
-          "ratioDiscriminability": 0.605
-        },
-        {
-          "question": 14,
-          "aCount": 114,
-          "bCount": 124,
-          "aPercent": 47.9,
-          "bPercent": 52.1,
-          "discriminability": 0.824,
-          "ratioDiscriminability": 0.958
-        },
-        {
-          "question": 15,
-          "aCount": 152,
-          "bCount": 86,
-          "aPercent": 63.9,
-          "bPercent": 36.1,
-          "discriminability": 0.737,
+          "aCount": 103,
+          "bCount": 182,
+          "aPercent": 36.1,
+          "bPercent": 63.9,
+          "discriminability": 0.826,
           "ratioDiscriminability": 0.723
         },
         {
+          "question": 5,
+          "aCount": 176,
+          "bCount": 109,
+          "aPercent": 61.8,
+          "bPercent": 38.2,
+          "discriminability": 0.711,
+          "ratioDiscriminability": 0.765
+        },
+        {
+          "question": 6,
+          "aCount": 151,
+          "bCount": 134,
+          "aPercent": 53,
+          "bPercent": 47,
+          "discriminability": 0.789,
+          "ratioDiscriminability": 0.94
+        },
+        {
+          "question": 7,
+          "aCount": 194,
+          "bCount": 91,
+          "aPercent": 68.1,
+          "bPercent": 31.9,
+          "discriminability": 0.634,
+          "ratioDiscriminability": 0.639
+        },
+        {
+          "question": 8,
+          "aCount": 95,
+          "bCount": 190,
+          "aPercent": 33.3,
+          "bPercent": 66.7,
+          "discriminability": 0.718,
+          "ratioDiscriminability": 0.667
+        },
+        {
+          "question": 9,
+          "aCount": 179,
+          "bCount": 106,
+          "aPercent": 62.8,
+          "bPercent": 37.2,
+          "discriminability": 0.744,
+          "ratioDiscriminability": 0.744
+        },
+        {
+          "question": 10,
+          "aCount": 128,
+          "bCount": 157,
+          "aPercent": 44.9,
+          "bPercent": 55.1,
+          "discriminability": 0.882,
+          "ratioDiscriminability": 0.898
+        },
+        {
+          "question": 11,
+          "aCount": 91,
+          "bCount": 194,
+          "aPercent": 31.9,
+          "bPercent": 68.1,
+          "discriminability": 0.712,
+          "ratioDiscriminability": 0.639
+        },
+        {
+          "question": 12,
+          "aCount": 180,
+          "bCount": 105,
+          "aPercent": 63.2,
+          "bPercent": 36.8,
+          "discriminability": 0.722,
+          "ratioDiscriminability": 0.737
+        },
+        {
+          "question": 13,
+          "aCount": 199,
+          "bCount": 86,
+          "aPercent": 69.8,
+          "bPercent": 30.2,
+          "discriminability": 0.71,
+          "ratioDiscriminability": 0.604
+        },
+        {
+          "question": 14,
+          "aCount": 141,
+          "bCount": 144,
+          "aPercent": 49.5,
+          "bPercent": 50.5,
+          "discriminability": 0.832,
+          "ratioDiscriminability": 0.989
+        },
+        {
+          "question": 15,
+          "aCount": 184,
+          "bCount": 101,
+          "aPercent": 64.6,
+          "bPercent": 35.4,
+          "discriminability": 0.759,
+          "ratioDiscriminability": 0.709
+        },
+        {
           "question": 16,
-          "aCount": 153,
-          "bCount": 85,
-          "aPercent": 64.3,
-          "bPercent": 35.7,
-          "discriminability": 0.72,
-          "ratioDiscriminability": 0.714
+          "aCount": 179,
+          "bCount": 106,
+          "aPercent": 62.8,
+          "bPercent": 37.2,
+          "discriminability": 0.747,
+          "ratioDiscriminability": 0.744
         }
       ],
       "dimensions": [
@@ -493,42 +493,42 @@
           "questions": [
             {
               "question": 1,
-              "aCount": 108,
-              "bCount": 130,
-              "aPercent": 45.4,
-              "bPercent": 54.6,
-              "discriminability": 0.807,
-              "ratioDiscriminability": 0.908
+              "aCount": 131,
+              "bCount": 154,
+              "aPercent": 46,
+              "bPercent": 54,
+              "discriminability": 0.813,
+              "ratioDiscriminability": 0.919
             },
             {
               "question": 2,
-              "aCount": 78,
-              "bCount": 160,
-              "aPercent": 32.8,
-              "bPercent": 67.2,
-              "discriminability": 0.769,
-              "ratioDiscriminability": 0.655
+              "aCount": 88,
+              "bCount": 197,
+              "aPercent": 30.9,
+              "bPercent": 69.1,
+              "discriminability": 0.773,
+              "ratioDiscriminability": 0.618
             },
             {
               "question": 3,
-              "aCount": 166,
-              "bCount": 72,
-              "aPercent": 69.7,
-              "bPercent": 30.3,
-              "discriminability": 0.801,
-              "ratioDiscriminability": 0.605
+              "aCount": 203,
+              "bCount": 82,
+              "aPercent": 71.2,
+              "bPercent": 28.8,
+              "discriminability": 0.774,
+              "ratioDiscriminability": 0.575
             },
             {
               "question": 4,
-              "aCount": 88,
-              "bCount": 150,
-              "aPercent": 37,
-              "bPercent": 63,
-              "discriminability": 0.818,
-              "ratioDiscriminability": 0.739
+              "aCount": 103,
+              "bCount": 182,
+              "aPercent": 36.1,
+              "bPercent": 63.9,
+              "discriminability": 0.826,
+              "ratioDiscriminability": 0.723
             }
           ],
-          "averageDiscriminability": 0.799
+          "averageDiscriminability": 0.796
         },
         {
           "name": "Precision",
@@ -539,42 +539,42 @@
           "questions": [
             {
               "question": 5,
-              "aCount": 146,
-              "bCount": 92,
-              "aPercent": 61.3,
-              "bPercent": 38.7,
-              "discriminability": 0.649,
-              "ratioDiscriminability": 0.773
+              "aCount": 176,
+              "bCount": 109,
+              "aPercent": 61.8,
+              "bPercent": 38.2,
+              "discriminability": 0.711,
+              "ratioDiscriminability": 0.765
             },
             {
               "question": 6,
-              "aCount": 131,
-              "bCount": 107,
-              "aPercent": 55,
-              "bPercent": 45,
-              "discriminability": 0.785,
-              "ratioDiscriminability": 0.899
+              "aCount": 151,
+              "bCount": 134,
+              "aPercent": 53,
+              "bPercent": 47,
+              "discriminability": 0.789,
+              "ratioDiscriminability": 0.94
             },
             {
               "question": 7,
-              "aCount": 155,
-              "bCount": 83,
-              "aPercent": 65.1,
-              "bPercent": 34.9,
-              "discriminability": 0.663,
-              "ratioDiscriminability": 0.697
+              "aCount": 194,
+              "bCount": 91,
+              "aPercent": 68.1,
+              "bPercent": 31.9,
+              "discriminability": 0.634,
+              "ratioDiscriminability": 0.639
             },
             {
               "question": 8,
-              "aCount": 77,
-              "bCount": 161,
-              "aPercent": 32.4,
-              "bPercent": 67.6,
-              "discriminability": 0.672,
-              "ratioDiscriminability": 0.647
+              "aCount": 95,
+              "bCount": 190,
+              "aPercent": 33.3,
+              "bPercent": 66.7,
+              "discriminability": 0.718,
+              "ratioDiscriminability": 0.667
             }
           ],
-          "averageDiscriminability": 0.692
+          "averageDiscriminability": 0.713
         },
         {
           "name": "Transparency",
@@ -585,42 +585,42 @@
           "questions": [
             {
               "question": 9,
-              "aCount": 144,
-              "bCount": 94,
-              "aPercent": 60.5,
-              "bPercent": 39.5,
-              "discriminability": 0.739,
-              "ratioDiscriminability": 0.79
+              "aCount": 179,
+              "bCount": 106,
+              "aPercent": 62.8,
+              "bPercent": 37.2,
+              "discriminability": 0.744,
+              "ratioDiscriminability": 0.744
             },
             {
               "question": 10,
-              "aCount": 101,
-              "bCount": 137,
-              "aPercent": 42.4,
-              "bPercent": 57.6,
-              "discriminability": 0.85,
-              "ratioDiscriminability": 0.849
+              "aCount": 128,
+              "bCount": 157,
+              "aPercent": 44.9,
+              "bPercent": 55.1,
+              "discriminability": 0.882,
+              "ratioDiscriminability": 0.898
             },
             {
               "question": 11,
-              "aCount": 70,
-              "bCount": 168,
-              "aPercent": 29.4,
-              "bPercent": 70.6,
-              "discriminability": 0.639,
-              "ratioDiscriminability": 0.588
+              "aCount": 91,
+              "bCount": 194,
+              "aPercent": 31.9,
+              "bPercent": 68.1,
+              "discriminability": 0.712,
+              "ratioDiscriminability": 0.639
             },
             {
               "question": 12,
-              "aCount": 144,
-              "bCount": 94,
-              "aPercent": 60.5,
-              "bPercent": 39.5,
-              "discriminability": 0.751,
-              "ratioDiscriminability": 0.79
+              "aCount": 180,
+              "bCount": 105,
+              "aPercent": 63.2,
+              "bPercent": 36.8,
+              "discriminability": 0.722,
+              "ratioDiscriminability": 0.737
             }
           ],
-          "averageDiscriminability": 0.745
+          "averageDiscriminability": 0.765
         },
         {
           "name": "Adaptability",
@@ -631,42 +631,42 @@
           "questions": [
             {
               "question": 13,
-              "aCount": 166,
-              "bCount": 72,
-              "aPercent": 69.7,
-              "bPercent": 30.3,
-              "discriminability": 0.68,
-              "ratioDiscriminability": 0.605
+              "aCount": 199,
+              "bCount": 86,
+              "aPercent": 69.8,
+              "bPercent": 30.2,
+              "discriminability": 0.71,
+              "ratioDiscriminability": 0.604
             },
             {
               "question": 14,
-              "aCount": 114,
-              "bCount": 124,
-              "aPercent": 47.9,
-              "bPercent": 52.1,
-              "discriminability": 0.824,
-              "ratioDiscriminability": 0.958
+              "aCount": 141,
+              "bCount": 144,
+              "aPercent": 49.5,
+              "bPercent": 50.5,
+              "discriminability": 0.832,
+              "ratioDiscriminability": 0.989
             },
             {
               "question": 15,
-              "aCount": 152,
-              "bCount": 86,
-              "aPercent": 63.9,
-              "bPercent": 36.1,
-              "discriminability": 0.737,
-              "ratioDiscriminability": 0.723
+              "aCount": 184,
+              "bCount": 101,
+              "aPercent": 64.6,
+              "bPercent": 35.4,
+              "discriminability": 0.759,
+              "ratioDiscriminability": 0.709
             },
             {
               "question": 16,
-              "aCount": 153,
-              "bCount": 85,
-              "aPercent": 64.3,
-              "bPercent": 35.7,
-              "discriminability": 0.72,
-              "ratioDiscriminability": 0.714
+              "aCount": 179,
+              "bCount": 106,
+              "aPercent": 62.8,
+              "bPercent": 37.2,
+              "discriminability": 0.747,
+              "ratioDiscriminability": 0.744
             }
           ],
-          "averageDiscriminability": 0.74
+          "averageDiscriminability": 0.762
         }
       ]
     }

--- a/data/reliability/claude-haiku-4-5-run-43.json
+++ b/data/reliability/claude-haiku-4-5-run-43.json
@@ -1,0 +1,31 @@
+{
+  "model": "claude-haiku-4-5",
+  "provider": "anthropic",
+  "run": 43,
+  "answers": [
+    "B",
+    "B",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "B",
+    "B",
+    "A",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "A"
+  ],
+  "dimensions": [
+    2,
+    2,
+    3,
+    3
+  ],
+  "type": "PTCF",
+  "questionVersion": "5.18-beta"
+}

--- a/data/reliability/claude-opus-4-6-run-4.json
+++ b/data/reliability/claude-opus-4-6-run-4.json
@@ -1,0 +1,31 @@
+{
+  "model": "claude-opus-4-6",
+  "provider": "anthropic",
+  "run": 4,
+  "answers": [
+    "B",
+    "B",
+    "A",
+    "B",
+    "B",
+    "B",
+    "A",
+    "B",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "B",
+    "B",
+    "A"
+  ],
+  "dimensions": [
+    1,
+    1,
+    3,
+    2
+  ],
+  "type": "RECF",
+  "questionVersion": "5.18-beta"
+}

--- a/data/reliability/claude-opus-4-7-run-4.json
+++ b/data/reliability/claude-opus-4-7-run-4.json
@@ -1,0 +1,31 @@
+{
+  "model": "claude-opus-4-7",
+  "provider": "anthropic",
+  "run": 4,
+  "answers": [
+    "B",
+    "B",
+    "B",
+    "B",
+    "A",
+    "B",
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "A"
+  ],
+  "dimensions": [
+    0,
+    2,
+    4,
+    3
+  ],
+  "type": "RTCF",
+  "questionVersion": "5.18-beta"
+}

--- a/data/reliability/claude-opus-4-8-run-2.json
+++ b/data/reliability/claude-opus-4-8-run-2.json
@@ -1,0 +1,31 @@
+{
+  "model": "claude-opus-4-8",
+  "provider": "anthropic",
+  "run": 2,
+  "answers": [
+    "B",
+    "B",
+    "A",
+    "B",
+    "A",
+    "B",
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A"
+  ],
+  "dimensions": [
+    1,
+    2,
+    4,
+    4
+  ],
+  "type": "RTCF",
+  "questionVersion": "5.18-beta"
+}

--- a/data/reliability/claude-sonnet-4-5-run-4.json
+++ b/data/reliability/claude-sonnet-4-5-run-4.json
@@ -1,0 +1,31 @@
+{
+  "model": "claude-sonnet-4-5",
+  "provider": "anthropic",
+  "run": 4,
+  "answers": [
+    "A",
+    "B",
+    "A",
+    "A",
+    "B",
+    "A",
+    "B",
+    "B",
+    "A",
+    "A",
+    "A",
+    "B",
+    "B",
+    "A",
+    "A",
+    "B"
+  ],
+  "dimensions": [
+    3,
+    1,
+    3,
+    2
+  ],
+  "type": "PECF",
+  "questionVersion": "5.18-beta"
+}

--- a/data/reliability/claude-sonnet-4-6-run-2.json
+++ b/data/reliability/claude-sonnet-4-6-run-2.json
@@ -1,0 +1,31 @@
+{
+  "model": "claude-sonnet-4-6",
+  "provider": "anthropic",
+  "run": 2,
+  "answers": [
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "A",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "B"
+  ],
+  "dimensions": [
+    0,
+    2,
+    3,
+    2
+  ],
+  "type": "RTCF",
+  "questionVersion": "5.18-beta"
+}

--- a/data/reliability/claude-sonnet-5-run-4.json
+++ b/data/reliability/claude-sonnet-5-run-4.json
@@ -1,0 +1,31 @@
+{
+  "model": "claude-sonnet-5",
+  "provider": "anthropic",
+  "run": 4,
+  "answers": [
+    "B",
+    "B",
+    "A",
+    "B",
+    "A",
+    "B",
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B"
+  ],
+  "dimensions": [
+    1,
+    2,
+    4,
+    3
+  ],
+  "type": "RTCF",
+  "questionVersion": "5.18-beta"
+}

--- a/data/reliability/gemini-2-5-pro-run-41.json
+++ b/data/reliability/gemini-2-5-pro-run-41.json
@@ -1,0 +1,31 @@
+{
+  "model": "gemini-2.5-pro",
+  "provider": "anthropic",
+  "run": 41,
+  "answers": [
+    "A",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "B",
+    "B",
+    "B"
+  ],
+  "dimensions": [
+    3,
+    4,
+    3,
+    1
+  ],
+  "type": "PTCN",
+  "questionVersion": "5.18-beta"
+}

--- a/data/reliability/gemini-3-5-flash-run-4.json
+++ b/data/reliability/gemini-3-5-flash-run-4.json
@@ -1,0 +1,31 @@
+{
+  "model": "gemini-3.5-flash",
+  "provider": "anthropic",
+  "run": 4,
+  "answers": [
+    "B",
+    "B",
+    "A",
+    "B",
+    "A",
+    "B",
+    "A",
+    "B",
+    "B",
+    "A",
+    "B",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A"
+  ],
+  "dimensions": [
+    1,
+    2,
+    1,
+    4
+  ],
+  "type": "RTDF",
+  "questionVersion": "5.18-beta"
+}

--- a/data/reliability/gpt-4-1-run-4.json
+++ b/data/reliability/gpt-4-1-run-4.json
@@ -1,0 +1,31 @@
+{
+  "model": "gpt-4.1",
+  "provider": "anthropic",
+  "run": 4,
+  "answers": [
+    "B",
+    "B",
+    "A",
+    "B",
+    "B",
+    "B",
+    "A",
+    "B",
+    "A",
+    "B",
+    "B",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A"
+  ],
+  "dimensions": [
+    1,
+    1,
+    1,
+    4
+  ],
+  "type": "REDF",
+  "questionVersion": "5.18-beta"
+}

--- a/data/reliability/gpt-4o-mini-run-34.json
+++ b/data/reliability/gpt-4o-mini-run-34.json
@@ -1,0 +1,31 @@
+{
+  "model": "gpt-4o-mini",
+  "provider": "anthropic",
+  "run": 34,
+  "answers": [
+    "A",
+    "B",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A"
+  ],
+  "dimensions": [
+    3,
+    3,
+    3,
+    4
+  ],
+  "type": "PTCF",
+  "questionVersion": "5.18-beta"
+}

--- a/data/reliability/gpt-4o-run-4.json
+++ b/data/reliability/gpt-4o-run-4.json
@@ -1,0 +1,31 @@
+{
+  "model": "gpt-4o",
+  "provider": "anthropic",
+  "run": 4,
+  "answers": [
+    "B",
+    "B",
+    "A",
+    "B",
+    "A",
+    "B",
+    "A",
+    "B",
+    "A",
+    "B",
+    "B",
+    "B",
+    "A",
+    "A",
+    "B",
+    "B"
+  ],
+  "dimensions": [
+    1,
+    2,
+    1,
+    2
+  ],
+  "type": "RTDF",
+  "questionVersion": "5.18-beta"
+}

--- a/data/reliability/gpt-5-4-mini-run-2.json
+++ b/data/reliability/gpt-5-4-mini-run-2.json
@@ -1,0 +1,31 @@
+{
+  "model": "gpt-5.4-mini",
+  "provider": "anthropic",
+  "run": 2,
+  "answers": [
+    "A",
+    "A",
+    "A",
+    "B",
+    "B",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A"
+  ],
+  "dimensions": [
+    3,
+    2,
+    3,
+    3
+  ],
+  "type": "PTCF",
+  "questionVersion": "5.18-beta"
+}

--- a/data/reliability/gpt-5-4-run-4.json
+++ b/data/reliability/gpt-5-4-run-4.json
@@ -1,0 +1,31 @@
+{
+  "model": "gpt-5.4",
+  "provider": "anthropic",
+  "run": 4,
+  "answers": [
+    "B",
+    "B",
+    "A",
+    "B",
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "B",
+    "B",
+    "A"
+  ],
+  "dimensions": [
+    1,
+    3,
+    3,
+    2
+  ],
+  "type": "RTCF",
+  "questionVersion": "5.18-beta"
+}

--- a/data/reliability/gpt-5-5-run-4.json
+++ b/data/reliability/gpt-5-5-run-4.json
@@ -1,0 +1,31 @@
+{
+  "model": "gpt-5.5",
+  "provider": "anthropic",
+  "run": 4,
+  "answers": [
+    "A",
+    "B",
+    "A",
+    "B",
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A"
+  ],
+  "dimensions": [
+    2,
+    3,
+    3,
+    4
+  ],
+  "type": "PTCF",
+  "questionVersion": "5.18-beta"
+}

--- a/data/results.json
+++ b/data/results.json
@@ -104,8 +104,8 @@
       "model": "claude-haiku-4.5",
       "provider": "anthropic",
       "consistency": 73,
-      "runs": 25,
-      "reliability": 0.725,
+      "runs": 26,
+      "reliability": 0.726,
       "reliabilityRuns": [
         {
           "type": "RTCN",
@@ -331,6 +331,15 @@
             4,
             3
           ]
+        },
+        {
+          "type": "PTCF",
+          "scores": [
+            2,
+            2,
+            3,
+            3
+          ]
         }
       ]
     },
@@ -431,10 +440,20 @@
           "provider": "anthropic"
         }
       ],
-      "reliability": 0.8542,
-      "consistency": 85,
+      "reliability": 1,
+      "consistency": 100,
       "runs": 1,
-      "reliabilityRuns": 0
+      "reliabilityRuns": [
+        {
+          "type": "RTCF",
+          "scores": [
+            1,
+            2,
+            4,
+            4
+          ]
+        }
+      ]
     },
     {
       "name": "Claude Opus 4.6",
@@ -486,8 +505,8 @@
       "model": "claude-opus-4.6",
       "provider": "anthropic",
       "consistency": 77,
-      "runs": 23,
-      "reliability": 0.7663,
+      "runs": 24,
+      "reliability": 0.7656,
       "reliabilityRuns": [
         {
           "type": "PTCN",
@@ -513,6 +532,15 @@
             1,
             3,
             1,
+            2
+          ]
+        },
+        {
+          "type": "RECF",
+          "scores": [
+            1,
+            1,
+            3,
             2
           ]
         },
@@ -747,9 +775,9 @@
       ],
       "model": "claude-opus-4.7",
       "provider": "anthropic",
-      "consistency": 98,
-      "runs": 3,
-      "reliability": 0.9792,
+      "consistency": 95,
+      "runs": 4,
+      "reliability": 0.9531,
       "reliabilityRuns": [
         {
           "type": "RECF",
@@ -776,6 +804,15 @@
             1,
             4,
             2
+          ]
+        },
+        {
+          "type": "RTCF",
+          "scores": [
+            0,
+            2,
+            4,
+            3
           ]
         }
       ]
@@ -830,8 +867,8 @@
       "model": "claude-sonnet-4.5",
       "provider": "anthropic",
       "consistency": 57,
-      "runs": 26,
-      "reliability": 0.5673,
+      "runs": 27,
+      "reliability": 0.5741,
       "reliabilityRuns": [
         {
           "type": "RECN",
@@ -858,6 +895,15 @@
             1,
             2,
             1
+          ]
+        },
+        {
+          "type": "PECF",
+          "scores": [
+            3,
+            1,
+            3,
+            2
           ]
         },
         {
@@ -1118,10 +1164,20 @@
       ],
       "model": "claude-sonnet-4.6",
       "provider": "anthropic",
-      "consistency": 88,
+      "consistency": 100,
       "runs": 1,
-      "reliability": 0.875,
-      "reliabilityRuns": 0
+      "reliability": 1,
+      "reliabilityRuns": [
+        {
+          "type": "RTCF",
+          "scores": [
+            0,
+            2,
+            3,
+            2
+          ]
+        }
+      ]
     },
     {
       "name": "Codestral (Mistral)",
@@ -2143,10 +2199,19 @@
             3,
             2
           ]
+        },
+        {
+          "type": "PTCN",
+          "scores": [
+            3,
+            4,
+            3,
+            1
+          ]
         }
       ],
-      "runs": 23,
-      "reliability": 0.9293,
+      "runs": 24,
+      "reliability": 0.9297,
       "consistency": 93
     },
     {
@@ -2464,7 +2529,7 @@
           "runs": 3
         }
       ],
-      "reliability": 0.763,
+      "reliability": 0.765,
       "reliabilityRuns": [
         {
           "type": "RTCF",
@@ -2491,6 +2556,15 @@
             4,
             2,
             3
+          ]
+        },
+        {
+          "type": "REDF",
+          "scores": [
+            1,
+            1,
+            1,
+            4
           ]
         },
         {
@@ -2683,8 +2757,8 @@
           ]
         }
       ],
-      "consistency": 76,
-      "runs": 24
+      "consistency": 77,
+      "runs": 25
     },
     {
       "name": "GPT-4o",
@@ -2783,7 +2857,7 @@
           "provider": "openai"
         }
       ],
-      "reliability": 0.7813,
+      "reliability": 0.7778,
       "reliabilityRuns": [
         {
           "type": "RTCF",
@@ -2810,6 +2884,15 @@
             3,
             1,
             3
+          ]
+        },
+        {
+          "type": "RTDF",
+          "scores": [
+            1,
+            2,
+            1,
+            2
           ]
         },
         {
@@ -3021,7 +3104,7 @@
         }
       ],
       "consistency": 78,
-      "runs": 26
+      "runs": 27
     },
     {
       "name": "GPT-4o mini",
@@ -3072,7 +3155,7 @@
       ],
       "model": "gpt-4o-mini",
       "provider": "openai",
-      "reliability": 0.7321,
+      "reliability": 0.7109,
       "reliabilityRuns": [
         {
           "type": "PECF",
@@ -3136,10 +3219,19 @@
             2,
             3
           ]
+        },
+        {
+          "type": "PTCF",
+          "scores": [
+            3,
+            3,
+            3,
+            4
+          ]
         }
       ],
-      "consistency": 73,
-      "runs": 7
+      "consistency": 71,
+      "runs": 8
     },
     {
       "name": "GPT-5 mini",
@@ -3343,11 +3435,20 @@
             2,
             4
           ]
+        },
+        {
+          "type": "PTCF",
+          "scores": [
+            2,
+            3,
+            3,
+            4
+          ]
         }
       ],
-      "runs": 3,
-      "reliability": 0.8333,
-      "consistency": 83
+      "runs": 4,
+      "reliability": 0.8438,
+      "consistency": 84
     },
     {
       "name": "Granite 3.3 8B",
@@ -5699,7 +5800,7 @@
       ],
       "model": "gemini-3.5-flash",
       "provider": "openai",
-      "runs": 3,
+      "runs": 4,
       "reliabilityRuns": [
         {
           "type": "PECN",
@@ -5727,10 +5828,19 @@
             1,
             4
           ]
+        },
+        {
+          "type": "RTDF",
+          "scores": [
+            1,
+            2,
+            1,
+            4
+          ]
         }
       ],
-      "reliability": 0.7917,
-      "consistency": 79
+      "reliability": 0.7813,
+      "consistency": 78
     },
     {
       "name": "Gemini 3.1 Pro Preview",
@@ -5917,7 +6027,7 @@
       ],
       "model": "gpt-5.4",
       "provider": "openai",
-      "runs": 3,
+      "runs": 4,
       "reliabilityRuns": [
         {
           "type": "PTDF",
@@ -5945,10 +6055,19 @@
             2,
             3
           ]
+        },
+        {
+          "type": "RTCF",
+          "scores": [
+            1,
+            3,
+            3,
+            2
+          ]
         }
       ],
-      "reliability": 0.9167,
-      "consistency": 92
+      "reliability": 0.8438,
+      "consistency": 84
     },
     {
       "name": "GPT-5.4 Mini",
@@ -6000,9 +6119,19 @@
       "model": "gpt-5.4-mini",
       "provider": "openai",
       "runs": 1,
-      "reliabilityRuns": 0,
-      "reliability": 0.9375,
-      "consistency": 94
+      "reliabilityRuns": [
+        {
+          "type": "PTCF",
+          "scores": [
+            3,
+            2,
+            3,
+            3
+          ]
+        }
+      ],
+      "reliability": 1,
+      "consistency": 100
     },
     {
       "name": "Gemini 3 Flash Preview",
@@ -6136,11 +6265,20 @@
             3,
             3
           ]
+        },
+        {
+          "type": "RTCF",
+          "scores": [
+            1,
+            2,
+            4,
+            3
+          ]
         }
       ],
-      "runs": 3,
-      "reliability": 0.9167,
-      "consistency": 92
+      "runs": 4,
+      "reliability": 0.8594,
+      "consistency": 86
     }
   ]
 }


### PR DESCRIPTION
## Summary

15 new reliability runs via floway for core models, incorporating the latest question set (including redesigned Q7, Q11, Q13, Q16).

### New runs
| Model | Run | Type |
|-------|-----|------|
| Claude Haiku 4.5 | #43 | PTCF |
| Claude Sonnet 4.5 | #4 | PECF |
| Claude Sonnet 4.6 | #2 | RTCF |
| Claude Sonnet 5 | #4 | RTCF |
| Claude Opus 4.6 | #4 | RECF |
| Claude Opus 4.7 | #4 | RTCF |
| Claude Opus 4.8 | #2 | RTCF |
| GPT-4o | #4 | RTDF |
| GPT-4o-mini | #34 | PTCF |
| GPT-4.1 | #4 | REDF |
| GPT-5.4 | #4 | RTCF |
| GPT-5.4 Mini | #2 | PTCF |
| GPT-5.5 | #4 | PTCF |
| Gemini 2.5 Pro | #41 | PTCN |
| Gemini 3.5 Flash | #4 | RTDF |

### Discriminability
Regenerated from 285 runs. All 16 questions above 0.6 threshold.

### In progress
- DeepSeek R1 run 2: 8/16 saved (GitHub Models rate limited, will resume next loop)

Partial progress on #753