### PR TITLE
data: reliability refresh batch 2 — 6 models via GitHub Models (#753)

### DIFF
--- a/data/discriminability.json
+++ b/data/discriminability.json
@@ -1,151 +1,151 @@
 {
-  "generatedAt": "2026-07-13T03:01:46.109Z",
+  "generatedAt": "2026-07-13T03:41:15.044Z",
   "threshold": 0.6,
-  "totalRuns": 285,
+  "totalRuns": 291,
   "questions": [
     {
       "question": 1,
-      "aCount": 131,
-      "bCount": 154,
-      "aPercent": 46,
-      "bPercent": 54,
-      "discriminability": 0.813,
-      "ratioDiscriminability": 0.919
+      "aCount": 135,
+      "bCount": 156,
+      "aPercent": 46.4,
+      "bPercent": 53.6,
+      "discriminability": 0.789,
+      "ratioDiscriminability": 0.928
     },
     {
       "question": 2,
-      "aCount": 88,
+      "aCount": 94,
       "bCount": 197,
-      "aPercent": 30.9,
-      "bPercent": 69.1,
-      "discriminability": 0.773,
-      "ratioDiscriminability": 0.618
+      "aPercent": 32.3,
+      "bPercent": 67.7,
+      "discriminability": 0.78,
+      "ratioDiscriminability": 0.646
     },
     {
       "question": 3,
-      "aCount": 203,
-      "bCount": 82,
-      "aPercent": 71.2,
-      "bPercent": 28.8,
-      "discriminability": 0.774,
-      "ratioDiscriminability": 0.575
+      "aCount": 207,
+      "bCount": 84,
+      "aPercent": 71.1,
+      "bPercent": 28.9,
+      "discriminability": 0.765,
+      "ratioDiscriminability": 0.577
     },
     {
       "question": 4,
-      "aCount": 103,
-      "bCount": 182,
+      "aCount": 105,
+      "bCount": 186,
       "aPercent": 36.1,
       "bPercent": 63.9,
       "discriminability": 0.826,
-      "ratioDiscriminability": 0.723
+      "ratioDiscriminability": 0.722
     },
     {
       "question": 5,
-      "aCount": 176,
-      "bCount": 109,
-      "aPercent": 61.8,
-      "bPercent": 38.2,
-      "discriminability": 0.711,
-      "ratioDiscriminability": 0.765
+      "aCount": 178,
+      "bCount": 113,
+      "aPercent": 61.2,
+      "bPercent": 38.8,
+      "discriminability": 0.681,
+      "ratioDiscriminability": 0.777
     },
     {
       "question": 6,
-      "aCount": 151,
-      "bCount": 134,
-      "aPercent": 53,
-      "bPercent": 47,
-      "discriminability": 0.789,
-      "ratioDiscriminability": 0.94
+      "aCount": 155,
+      "bCount": 136,
+      "aPercent": 53.3,
+      "bPercent": 46.7,
+      "discriminability": 0.758,
+      "ratioDiscriminability": 0.935
     },
     {
       "question": 7,
-      "aCount": 194,
-      "bCount": 91,
-      "aPercent": 68.1,
-      "bPercent": 31.9,
-      "discriminability": 0.634,
-      "ratioDiscriminability": 0.639
+      "aCount": 199,
+      "bCount": 92,
+      "aPercent": 68.4,
+      "bPercent": 31.6,
+      "discriminability": 0.623,
+      "ratioDiscriminability": 0.632
     },
     {
       "question": 8,
-      "aCount": 95,
-      "bCount": 190,
-      "aPercent": 33.3,
-      "bPercent": 66.7,
-      "discriminability": 0.718,
-      "ratioDiscriminability": 0.667
+      "aCount": 96,
+      "bCount": 195,
+      "aPercent": 33,
+      "bPercent": 67,
+      "discriminability": 0.715,
+      "ratioDiscriminability": 0.66
     },
     {
       "question": 9,
-      "aCount": 179,
+      "aCount": 185,
       "bCount": 106,
-      "aPercent": 62.8,
-      "bPercent": 37.2,
-      "discriminability": 0.744,
-      "ratioDiscriminability": 0.744
+      "aPercent": 63.6,
+      "bPercent": 36.4,
+      "discriminability": 0.724,
+      "ratioDiscriminability": 0.729
     },
     {
       "question": 10,
-      "aCount": 128,
-      "bCount": 157,
-      "aPercent": 44.9,
-      "bPercent": 55.1,
-      "discriminability": 0.882,
-      "ratioDiscriminability": 0.898
+      "aCount": 129,
+      "bCount": 162,
+      "aPercent": 44.3,
+      "bPercent": 55.7,
+      "discriminability": 0.872,
+      "ratioDiscriminability": 0.887
     },
     {
       "question": 11,
       "aCount": 91,
-      "bCount": 194,
-      "aPercent": 31.9,
-      "bPercent": 68.1,
+      "bCount": 200,
+      "aPercent": 31.3,
+      "bPercent": 68.7,
       "discriminability": 0.712,
-      "ratioDiscriminability": 0.639
+      "ratioDiscriminability": 0.625
     },
     {
       "question": 12,
-      "aCount": 180,
-      "bCount": 105,
-      "aPercent": 63.2,
-      "bPercent": 36.8,
-      "discriminability": 0.722,
-      "ratioDiscriminability": 0.737
+      "aCount": 183,
+      "bCount": 108,
+      "aPercent": 62.9,
+      "bPercent": 37.1,
+      "discriminability": 0.685,
+      "ratioDiscriminability": 0.742
     },
     {
       "question": 13,
-      "aCount": 199,
+      "aCount": 205,
       "bCount": 86,
-      "aPercent": 69.8,
-      "bPercent": 30.2,
-      "discriminability": 0.71,
-      "ratioDiscriminability": 0.604
+      "aPercent": 70.4,
+      "bPercent": 29.6,
+      "discriminability": 0.709,
+      "ratioDiscriminability": 0.591
     },
     {
       "question": 14,
-      "aCount": 141,
-      "bCount": 144,
-      "aPercent": 49.5,
-      "bPercent": 50.5,
-      "discriminability": 0.832,
-      "ratioDiscriminability": 0.989
+      "aCount": 143,
+      "bCount": 148,
+      "aPercent": 49.1,
+      "bPercent": 50.9,
+      "discriminability": 0.824,
+      "ratioDiscriminability": 0.983
     },
     {
       "question": 15,
-      "aCount": 184,
-      "bCount": 101,
-      "aPercent": 64.6,
-      "bPercent": 35.4,
-      "discriminability": 0.759,
-      "ratioDiscriminability": 0.709
+      "aCount": 189,
+      "bCount": 102,
+      "aPercent": 64.9,
+      "bPercent": 35.1,
+      "discriminability": 0.758,
+      "ratioDiscriminability": 0.701
     },
     {
       "question": 16,
-      "aCount": 179,
-      "bCount": 106,
-      "aPercent": 62.8,
-      "bPercent": 37.2,
-      "discriminability": 0.747,
-      "ratioDiscriminability": 0.744
+      "aCount": 182,
+      "bCount": 109,
+      "aPercent": 62.5,
+      "bPercent": 37.5,
+      "discriminability": 0.734,
+      "ratioDiscriminability": 0.749
     }
   ],
   "dimensions": [
@@ -158,42 +158,42 @@
       "questions": [
         {
           "question": 1,
-          "aCount": 131,
-          "bCount": 154,
-          "aPercent": 46,
-          "bPercent": 54,
-          "discriminability": 0.813,
-          "ratioDiscriminability": 0.919
+          "aCount": 135,
+          "bCount": 156,
+          "aPercent": 46.4,
+          "bPercent": 53.6,
+          "discriminability": 0.789,
+          "ratioDiscriminability": 0.928
         },
         {
           "question": 2,
-          "aCount": 88,
+          "aCount": 94,
           "bCount": 197,
-          "aPercent": 30.9,
-          "bPercent": 69.1,
-          "discriminability": 0.773,
-          "ratioDiscriminability": 0.618
+          "aPercent": 32.3,
+          "bPercent": 67.7,
+          "discriminability": 0.78,
+          "ratioDiscriminability": 0.646
         },
         {
           "question": 3,
-          "aCount": 203,
-          "bCount": 82,
-          "aPercent": 71.2,
-          "bPercent": 28.8,
-          "discriminability": 0.774,
-          "ratioDiscriminability": 0.575
+          "aCount": 207,
+          "bCount": 84,
+          "aPercent": 71.1,
+          "bPercent": 28.9,
+          "discriminability": 0.765,
+          "ratioDiscriminability": 0.577
         },
         {
           "question": 4,
-          "aCount": 103,
-          "bCount": 182,
+          "aCount": 105,
+          "bCount": 186,
           "aPercent": 36.1,
           "bPercent": 63.9,
           "discriminability": 0.826,
-          "ratioDiscriminability": 0.723
+          "ratioDiscriminability": 0.722
         }
       ],
-      "averageDiscriminability": 0.796
+      "averageDiscriminability": 0.79
     },
     {
       "name": "Precision",
@@ -204,42 +204,42 @@
       "questions": [
         {
           "question": 5,
-          "aCount": 176,
-          "bCount": 109,
-          "aPercent": 61.8,
-          "bPercent": 38.2,
-          "discriminability": 0.711,
-          "ratioDiscriminability": 0.765
+          "aCount": 178,
+          "bCount": 113,
+          "aPercent": 61.2,
+          "bPercent": 38.8,
+          "discriminability": 0.681,
+          "ratioDiscriminability": 0.777
         },
         {
           "question": 6,
-          "aCount": 151,
-          "bCount": 134,
-          "aPercent": 53,
-          "bPercent": 47,
-          "discriminability": 0.789,
-          "ratioDiscriminability": 0.94
+          "aCount": 155,
+          "bCount": 136,
+          "aPercent": 53.3,
+          "bPercent": 46.7,
+          "discriminability": 0.758,
+          "ratioDiscriminability": 0.935
         },
         {
           "question": 7,
-          "aCount": 194,
-          "bCount": 91,
-          "aPercent": 68.1,
-          "bPercent": 31.9,
-          "discriminability": 0.634,
-          "ratioDiscriminability": 0.639
+          "aCount": 199,
+          "bCount": 92,
+          "aPercent": 68.4,
+          "bPercent": 31.6,
+          "discriminability": 0.623,
+          "ratioDiscriminability": 0.632
         },
         {
           "question": 8,
-          "aCount": 95,
-          "bCount": 190,
-          "aPercent": 33.3,
-          "bPercent": 66.7,
-          "discriminability": 0.718,
-          "ratioDiscriminability": 0.667
+          "aCount": 96,
+          "bCount": 195,
+          "aPercent": 33,
+          "bPercent": 67,
+          "discriminability": 0.715,
+          "ratioDiscriminability": 0.66
         }
       ],
-      "averageDiscriminability": 0.713
+      "averageDiscriminability": 0.694
     },
     {
       "name": "Transparency",
@@ -250,42 +250,42 @@
       "questions": [
         {
           "question": 9,
-          "aCount": 179,
+          "aCount": 185,
           "bCount": 106,
-          "aPercent": 62.8,
-          "bPercent": 37.2,
-          "discriminability": 0.744,
-          "ratioDiscriminability": 0.744
+          "aPercent": 63.6,
+          "bPercent": 36.4,
+          "discriminability": 0.724,
+          "ratioDiscriminability": 0.729
         },
         {
           "question": 10,
-          "aCount": 128,
-          "bCount": 157,
-          "aPercent": 44.9,
-          "bPercent": 55.1,
-          "discriminability": 0.882,
-          "ratioDiscriminability": 0.898
+          "aCount": 129,
+          "bCount": 162,
+          "aPercent": 44.3,
+          "bPercent": 55.7,
+          "discriminability": 0.872,
+          "ratioDiscriminability": 0.887
         },
         {
           "question": 11,
           "aCount": 91,
-          "bCount": 194,
-          "aPercent": 31.9,
-          "bPercent": 68.1,
+          "bCount": 200,
+          "aPercent": 31.3,
+          "bPercent": 68.7,
           "discriminability": 0.712,
-          "ratioDiscriminability": 0.639
+          "ratioDiscriminability": 0.625
         },
         {
           "question": 12,
-          "aCount": 180,
-          "bCount": 105,
-          "aPercent": 63.2,
-          "bPercent": 36.8,
-          "discriminability": 0.722,
-          "ratioDiscriminability": 0.737
+          "aCount": 183,
+          "bCount": 108,
+          "aPercent": 62.9,
+          "bPercent": 37.1,
+          "discriminability": 0.685,
+          "ratioDiscriminability": 0.742
         }
       ],
-      "averageDiscriminability": 0.765
+      "averageDiscriminability": 0.748
     },
     {
       "name": "Adaptability",
@@ -296,191 +296,191 @@
       "questions": [
         {
           "question": 13,
-          "aCount": 199,
+          "aCount": 205,
           "bCount": 86,
-          "aPercent": 69.8,
-          "bPercent": 30.2,
-          "discriminability": 0.71,
-          "ratioDiscriminability": 0.604
+          "aPercent": 70.4,
+          "bPercent": 29.6,
+          "discriminability": 0.709,
+          "ratioDiscriminability": 0.591
         },
         {
           "question": 14,
-          "aCount": 141,
-          "bCount": 144,
-          "aPercent": 49.5,
-          "bPercent": 50.5,
-          "discriminability": 0.832,
-          "ratioDiscriminability": 0.989
+          "aCount": 143,
+          "bCount": 148,
+          "aPercent": 49.1,
+          "bPercent": 50.9,
+          "discriminability": 0.824,
+          "ratioDiscriminability": 0.983
         },
         {
           "question": 15,
-          "aCount": 184,
-          "bCount": 101,
-          "aPercent": 64.6,
-          "bPercent": 35.4,
-          "discriminability": 0.759,
-          "ratioDiscriminability": 0.709
+          "aCount": 189,
+          "bCount": 102,
+          "aPercent": 64.9,
+          "bPercent": 35.1,
+          "discriminability": 0.758,
+          "ratioDiscriminability": 0.701
         },
         {
           "question": 16,
-          "aCount": 179,
-          "bCount": 106,
-          "aPercent": 62.8,
-          "bPercent": 37.2,
-          "discriminability": 0.747,
-          "ratioDiscriminability": 0.744
+          "aCount": 182,
+          "bCount": 109,
+          "aPercent": 62.5,
+          "bPercent": 37.5,
+          "discriminability": 0.734,
+          "ratioDiscriminability": 0.749
         }
       ],
-      "averageDiscriminability": 0.762
+      "averageDiscriminability": 0.756
     }
   ],
   "cohorts": {
     "all": {
-      "totalRuns": 285,
+      "totalRuns": 291,
       "questions": [
         {
           "question": 1,
-          "aCount": 131,
-          "bCount": 154,
-          "aPercent": 46,
-          "bPercent": 54,
-          "discriminability": 0.813,
-          "ratioDiscriminability": 0.919
+          "aCount": 135,
+          "bCount": 156,
+          "aPercent": 46.4,
+          "bPercent": 53.6,
+          "discriminability": 0.789,
+          "ratioDiscriminability": 0.928
         },
         {
           "question": 2,
-          "aCount": 88,
+          "aCount": 94,
           "bCount": 197,
-          "aPercent": 30.9,
-          "bPercent": 69.1,
-          "discriminability": 0.773,
-          "ratioDiscriminability": 0.618
+          "aPercent": 32.3,
+          "bPercent": 67.7,
+          "discriminability": 0.78,
+          "ratioDiscriminability": 0.646
         },
         {
           "question": 3,
-          "aCount": 203,
-          "bCount": 82,
-          "aPercent": 71.2,
-          "bPercent": 28.8,
-          "discriminability": 0.774,
-          "ratioDiscriminability": 0.575
+          "aCount": 207,
+          "bCount": 84,
+          "aPercent": 71.1,
+          "bPercent": 28.9,
+          "discriminability": 0.765,
+          "ratioDiscriminability": 0.577
         },
         {
           "question": 4,
-          "aCount": 103,
-          "bCount": 182,
+          "aCount": 105,
+          "bCount": 186,
           "aPercent": 36.1,
           "bPercent": 63.9,
           "discriminability": 0.826,
-          "ratioDiscriminability": 0.723
+          "ratioDiscriminability": 0.722
         },
         {
           "question": 5,
-          "aCount": 176,
-          "bCount": 109,
-          "aPercent": 61.8,
-          "bPercent": 38.2,
-          "discriminability": 0.711,
-          "ratioDiscriminability": 0.765
+          "aCount": 178,
+          "bCount": 113,
+          "aPercent": 61.2,
+          "bPercent": 38.8,
+          "discriminability": 0.681,
+          "ratioDiscriminability": 0.777
         },
         {
           "question": 6,
-          "aCount": 151,
-          "bCount": 134,
-          "aPercent": 53,
-          "bPercent": 47,
-          "discriminability": 0.789,
-          "ratioDiscriminability": 0.94
+          "aCount": 155,
+          "bCount": 136,
+          "aPercent": 53.3,
+          "bPercent": 46.7,
+          "discriminability": 0.758,
+          "ratioDiscriminability": 0.935
         },
         {
           "question": 7,
-          "aCount": 194,
-          "bCount": 91,
-          "aPercent": 68.1,
-          "bPercent": 31.9,
-          "discriminability": 0.634,
-          "ratioDiscriminability": 0.639
+          "aCount": 199,
+          "bCount": 92,
+          "aPercent": 68.4,
+          "bPercent": 31.6,
+          "discriminability": 0.623,
+          "ratioDiscriminability": 0.632
         },
         {
           "question": 8,
-          "aCount": 95,
-          "bCount": 190,
-          "aPercent": 33.3,
-          "bPercent": 66.7,
-          "discriminability": 0.718,
-          "ratioDiscriminability": 0.667
+          "aCount": 96,
+          "bCount": 195,
+          "aPercent": 33,
+          "bPercent": 67,
+          "discriminability": 0.715,
+          "ratioDiscriminability": 0.66
         },
         {
           "question": 9,
-          "aCount": 179,
+          "aCount": 185,
           "bCount": 106,
-          "aPercent": 62.8,
-          "bPercent": 37.2,
-          "discriminability": 0.744,
-          "ratioDiscriminability": 0.744
+          "aPercent": 63.6,
+          "bPercent": 36.4,
+          "discriminability": 0.724,
+          "ratioDiscriminability": 0.729
         },
         {
           "question": 10,
-          "aCount": 128,
-          "bCount": 157,
-          "aPercent": 44.9,
-          "bPercent": 55.1,
-          "discriminability": 0.882,
-          "ratioDiscriminability": 0.898
+          "aCount": 129,
+          "bCount": 162,
+          "aPercent": 44.3,
+          "bPercent": 55.7,
+          "discriminability": 0.872,
+          "ratioDiscriminability": 0.887
         },
         {
           "question": 11,
           "aCount": 91,
-          "bCount": 194,
-          "aPercent": 31.9,
-          "bPercent": 68.1,
+          "bCount": 200,
+          "aPercent": 31.3,
+          "bPercent": 68.7,
           "discriminability": 0.712,
-          "ratioDiscriminability": 0.639
+          "ratioDiscriminability": 0.625
         },
         {
           "question": 12,
-          "aCount": 180,
-          "bCount": 105,
-          "aPercent": 63.2,
-          "bPercent": 36.8,
-          "discriminability": 0.722,
-          "ratioDiscriminability": 0.737
+          "aCount": 183,
+          "bCount": 108,
+          "aPercent": 62.9,
+          "bPercent": 37.1,
+          "discriminability": 0.685,
+          "ratioDiscriminability": 0.742
         },
         {
           "question": 13,
-          "aCount": 199,
+          "aCount": 205,
           "bCount": 86,
-          "aPercent": 69.8,
-          "bPercent": 30.2,
-          "discriminability": 0.71,
-          "ratioDiscriminability": 0.604
+          "aPercent": 70.4,
+          "bPercent": 29.6,
+          "discriminability": 0.709,
+          "ratioDiscriminability": 0.591
         },
         {
           "question": 14,
-          "aCount": 141,
-          "bCount": 144,
-          "aPercent": 49.5,
-          "bPercent": 50.5,
-          "discriminability": 0.832,
-          "ratioDiscriminability": 0.989
+          "aCount": 143,
+          "bCount": 148,
+          "aPercent": 49.1,
+          "bPercent": 50.9,
+          "discriminability": 0.824,
+          "ratioDiscriminability": 0.983
         },
         {
           "question": 15,
-          "aCount": 184,
-          "bCount": 101,
-          "aPercent": 64.6,
-          "bPercent": 35.4,
-          "discriminability": 0.759,
-          "ratioDiscriminability": 0.709
+          "aCount": 189,
+          "bCount": 102,
+          "aPercent": 64.9,
+          "bPercent": 35.1,
+          "discriminability": 0.758,
+          "ratioDiscriminability": 0.701
         },
         {
           "question": 16,
-          "aCount": 179,
-          "bCount": 106,
-          "aPercent": 62.8,
-          "bPercent": 37.2,
-          "discriminability": 0.747,
-          "ratioDiscriminability": 0.744
+          "aCount": 182,
+          "bCount": 109,
+          "aPercent": 62.5,
+          "bPercent": 37.5,
+          "discriminability": 0.734,
+          "ratioDiscriminability": 0.749
         }
       ],
       "dimensions": [
@@ -493,42 +493,42 @@
           "questions": [
             {
               "question": 1,
-              "aCount": 131,
-              "bCount": 154,
-              "aPercent": 46,
-              "bPercent": 54,
-              "discriminability": 0.813,
-              "ratioDiscriminability": 0.919
+              "aCount": 135,
+              "bCount": 156,
+              "aPercent": 46.4,
+              "bPercent": 53.6,
+              "discriminability": 0.789,
+              "ratioDiscriminability": 0.928
             },
             {
               "question": 2,
-              "aCount": 88,
+              "aCount": 94,
               "bCount": 197,
-              "aPercent": 30.9,
-              "bPercent": 69.1,
-              "discriminability": 0.773,
-              "ratioDiscriminability": 0.618
+              "aPercent": 32.3,
+              "bPercent": 67.7,
+              "discriminability": 0.78,
+              "ratioDiscriminability": 0.646
             },
             {
               "question": 3,
-              "aCount": 203,
-              "bCount": 82,
-              "aPercent": 71.2,
-              "bPercent": 28.8,
-              "discriminability": 0.774,
-              "ratioDiscriminability": 0.575
+              "aCount": 207,
+              "bCount": 84,
+              "aPercent": 71.1,
+              "bPercent": 28.9,
+              "discriminability": 0.765,
+              "ratioDiscriminability": 0.577
             },
             {
               "question": 4,
-              "aCount": 103,
-              "bCount": 182,
+              "aCount": 105,
+              "bCount": 186,
               "aPercent": 36.1,
               "bPercent": 63.9,
               "discriminability": 0.826,
-              "ratioDiscriminability": 0.723
+              "ratioDiscriminability": 0.722
             }
           ],
-          "averageDiscriminability": 0.796
+          "averageDiscriminability": 0.79
         },
         {
           "name": "Precision",
@@ -539,42 +539,42 @@
           "questions": [
             {
               "question": 5,
-              "aCount": 176,
-              "bCount": 109,
-              "aPercent": 61.8,
-              "bPercent": 38.2,
-              "discriminability": 0.711,
-              "ratioDiscriminability": 0.765
+              "aCount": 178,
+              "bCount": 113,
+              "aPercent": 61.2,
+              "bPercent": 38.8,
+              "discriminability": 0.681,
+              "ratioDiscriminability": 0.777
             },
             {
               "question": 6,
-              "aCount": 151,
-              "bCount": 134,
-              "aPercent": 53,
-              "bPercent": 47,
-              "discriminability": 0.789,
-              "ratioDiscriminability": 0.94
+              "aCount": 155,
+              "bCount": 136,
+              "aPercent": 53.3,
+              "bPercent": 46.7,
+              "discriminability": 0.758,
+              "ratioDiscriminability": 0.935
             },
             {
               "question": 7,
-              "aCount": 194,
-              "bCount": 91,
-              "aPercent": 68.1,
-              "bPercent": 31.9,
-              "discriminability": 0.634,
-              "ratioDiscriminability": 0.639
+              "aCount": 199,
+              "bCount": 92,
+              "aPercent": 68.4,
+              "bPercent": 31.6,
+              "discriminability": 0.623,
+              "ratioDiscriminability": 0.632
             },
             {
               "question": 8,
-              "aCount": 95,
-              "bCount": 190,
-              "aPercent": 33.3,
-              "bPercent": 66.7,
-              "discriminability": 0.718,
-              "ratioDiscriminability": 0.667
+              "aCount": 96,
+              "bCount": 195,
+              "aPercent": 33,
+              "bPercent": 67,
+              "discriminability": 0.715,
+              "ratioDiscriminability": 0.66
             }
           ],
-          "averageDiscriminability": 0.713
+          "averageDiscriminability": 0.694
         },
         {
           "name": "Transparency",
@@ -585,42 +585,42 @@
           "questions": [
             {
               "question": 9,
-              "aCount": 179,
+              "aCount": 185,
               "bCount": 106,
-              "aPercent": 62.8,
-              "bPercent": 37.2,
-              "discriminability": 0.744,
-              "ratioDiscriminability": 0.744
+              "aPercent": 63.6,
+              "bPercent": 36.4,
+              "discriminability": 0.724,
+              "ratioDiscriminability": 0.729
             },
             {
               "question": 10,
-              "aCount": 128,
-              "bCount": 157,
-              "aPercent": 44.9,
-              "bPercent": 55.1,
-              "discriminability": 0.882,
-              "ratioDiscriminability": 0.898
+              "aCount": 129,
+              "bCount": 162,
+              "aPercent": 44.3,
+              "bPercent": 55.7,
+              "discriminability": 0.872,
+              "ratioDiscriminability": 0.887
             },
             {
               "question": 11,
               "aCount": 91,
-              "bCount": 194,
-              "aPercent": 31.9,
-              "bPercent": 68.1,
+              "bCount": 200,
+              "aPercent": 31.3,
+              "bPercent": 68.7,
               "discriminability": 0.712,
-              "ratioDiscriminability": 0.639
+              "ratioDiscriminability": 0.625
             },
             {
               "question": 12,
-              "aCount": 180,
-              "bCount": 105,
-              "aPercent": 63.2,
-              "bPercent": 36.8,
-              "discriminability": 0.722,
-              "ratioDiscriminability": 0.737
+              "aCount": 183,
+              "bCount": 108,
+              "aPercent": 62.9,
+              "bPercent": 37.1,
+              "discriminability": 0.685,
+              "ratioDiscriminability": 0.742
             }
           ],
-          "averageDiscriminability": 0.765
+          "averageDiscriminability": 0.748
         },
         {
           "name": "Adaptability",
@@ -631,42 +631,42 @@
           "questions": [
             {
               "question": 13,
-              "aCount": 199,
+              "aCount": 205,
               "bCount": 86,
-              "aPercent": 69.8,
-              "bPercent": 30.2,
-              "discriminability": 0.71,
-              "ratioDiscriminability": 0.604
+              "aPercent": 70.4,
+              "bPercent": 29.6,
+              "discriminability": 0.709,
+              "ratioDiscriminability": 0.591
             },
             {
               "question": 14,
-              "aCount": 141,
-              "bCount": 144,
-              "aPercent": 49.5,
-              "bPercent": 50.5,
-              "discriminability": 0.832,
-              "ratioDiscriminability": 0.989
+              "aCount": 143,
+              "bCount": 148,
+              "aPercent": 49.1,
+              "bPercent": 50.9,
+              "discriminability": 0.824,
+              "ratioDiscriminability": 0.983
             },
             {
               "question": 15,
-              "aCount": 184,
-              "bCount": 101,
-              "aPercent": 64.6,
-              "bPercent": 35.4,
-              "discriminability": 0.759,
-              "ratioDiscriminability": 0.709
+              "aCount": 189,
+              "bCount": 102,
+              "aPercent": 64.9,
+              "bPercent": 35.1,
+              "discriminability": 0.758,
+              "ratioDiscriminability": 0.701
             },
             {
               "question": 16,
-              "aCount": 179,
-              "bCount": 106,
-              "aPercent": 62.8,
-              "bPercent": 37.2,
-              "discriminability": 0.747,
-              "ratioDiscriminability": 0.744
+              "aCount": 182,
+              "bCount": 109,
+              "aPercent": 62.5,
+              "bPercent": 37.5,
+              "discriminability": 0.734,
+              "ratioDiscriminability": 0.749
             }
           ],
-          "averageDiscriminability": 0.762
+          "averageDiscriminability": 0.756
         }
       ]
     }

--- a/data/reliability/gpt-4-1-mini-run-4.json
+++ b/data/reliability/gpt-4-1-mini-run-4.json
@@ -1,0 +1,31 @@
+{
+  "model": "gpt-4.1-mini",
+  "provider": "github",
+  "run": 4,
+  "answers": [
+    "A",
+    "A",
+    "B",
+    "B",
+    "B",
+    "A",
+    "A",
+    "B",
+    "A",
+    "B",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B"
+  ],
+  "dimensions": [
+    2,
+    2,
+    2,
+    3
+  ],
+  "type": "PTCF",
+  "questionVersion": "5.18-beta"
+}

--- a/data/reliability/gpt-4-1-nano-run-4.json
+++ b/data/reliability/gpt-4-1-nano-run-4.json
@@ -1,0 +1,31 @@
+{
+  "model": "gpt-4.1-nano",
+  "provider": "github",
+  "run": 4,
+  "answers": [
+    "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "B",
+    "A",
+    "A",
+    "B",
+    "B",
+    "A"
+  ],
+  "dimensions": [
+    4,
+    3,
+    2,
+    2
+  ],
+  "type": "PTCF",
+  "questionVersion": "5.18-beta"
+}

--- a/data/reliability/llama-4-maverick-17b-run-4.json
+++ b/data/reliability/llama-4-maverick-17b-run-4.json
@@ -1,0 +1,31 @@
+{
+  "model": "Llama-4-Maverick-17B-128E-Instruct-FP8",
+  "provider": "github",
+  "run": 4,
+  "answers": [
+    "A",
+    "A",
+    "B",
+    "B",
+    "B",
+    "A",
+    "A",
+    "B",
+    "A",
+    "B",
+    "B",
+    "A",
+    "A",
+    "B",
+    "A",
+    "B"
+  ],
+  "dimensions": [
+    2,
+    2,
+    2,
+    2
+  ],
+  "type": "PTCF",
+  "questionVersion": "5.18-beta"
+}

--- a/data/reliability/llama-4-scout-17b-run-4.json
+++ b/data/reliability/llama-4-scout-17b-run-4.json
@@ -1,0 +1,31 @@
+{
+  "model": "Llama-4-Scout-17B-16E-Instruct",
+  "provider": "github",
+  "run": 4,
+  "answers": [
+    "B",
+    "A",
+    "A",
+    "B",
+    "B",
+    "B",
+    "A",
+    "B",
+    "A",
+    "A",
+    "B",
+    "B",
+    "A",
+    "B",
+    "A",
+    "A"
+  ],
+  "dimensions": [
+    2,
+    1,
+    2,
+    3
+  ],
+  "type": "PECF",
+  "questionVersion": "5.18-beta"
+}

--- a/data/reliability/mistral-medium-3-run-4.json
+++ b/data/reliability/mistral-medium-3-run-4.json
@@ -1,0 +1,31 @@
+{
+  "model": "mistral-ai/mistral-medium-2505",
+  "provider": "github",
+  "run": 4,
+  "answers": [
+    "A",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "B",
+    "A",
+    "B",
+    "B",
+    "B",
+    "A",
+    "B",
+    "A",
+    "B"
+  ],
+  "dimensions": [
+    3,
+    3,
+    1,
+    2
+  ],
+  "type": "PTDF",
+  "questionVersion": "5.18-beta"
+}

--- a/data/reliability/mistral-small-3-1-run-4.json
+++ b/data/reliability/mistral-small-3-1-run-4.json
@@ -1,0 +1,31 @@
+{
+  "model": "mistral-small-2503",
+  "provider": "github",
+  "run": 4,
+  "answers": [
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "B",
+    "B",
+    "A",
+    "B",
+    "B",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A"
+  ],
+  "dimensions": [
+    3,
+    1,
+    1,
+    4
+  ],
+  "type": "PEDF",
+  "questionVersion": "5.18-beta"
+}

--- a/data/results.json
+++ b/data/results.json
@@ -3799,7 +3799,7 @@
       ],
       "model": "Llama-4-Maverick-17B-128E-Instruct-FP8",
       "provider": "github",
-      "reliability": 0.8958,
+      "reliability": 0.875,
       "reliabilityRuns": [
         {
           "type": "PTCF",
@@ -3827,10 +3827,19 @@
             2,
             2
           ]
+        },
+        {
+          "type": "PTCF",
+          "scores": [
+            2,
+            2,
+            2,
+            2
+          ]
         }
       ],
-      "runs": 3,
-      "consistency": 90
+      "runs": 4,
+      "consistency": 88
     },
     {
       "name": "Llama 4 Scout 17B",
@@ -3881,7 +3890,7 @@
       ],
       "model": "Llama-4-Scout-17B-16E-Instruct",
       "provider": "github",
-      "reliability": 0.9375,
+      "reliability": 0.8594,
       "reliabilityRuns": [
         {
           "type": "PEDF",
@@ -3909,10 +3918,19 @@
             2,
             2
           ]
+        },
+        {
+          "type": "PECF",
+          "scores": [
+            2,
+            1,
+            2,
+            3
+          ]
         }
       ],
-      "runs": 3,
-      "consistency": 94
+      "runs": 4,
+      "consistency": 86
     },
     {
       "name": "Llama 3.1 8B",
@@ -4507,7 +4525,7 @@
       ],
       "model": "mistral-medium-2505",
       "provider": "github",
-      "reliability": 0.75,
+      "reliability": 0.6719,
       "badge": "https://abti.kagura-agent.com/badge/RECF",
       "reliabilityRuns": [
         {
@@ -4536,10 +4554,19 @@
             0,
             3
           ]
+        },
+        {
+          "type": "PTDF",
+          "scores": [
+            3,
+            3,
+            1,
+            2
+          ]
         }
       ],
-      "consistency": 75,
-      "runs": 3
+      "consistency": 67,
+      "runs": 4
     },
     {
       "name": "Mistral Small 3.1",
@@ -4590,7 +4617,7 @@
       ],
       "model": "mistral-small-2503",
       "provider": "github",
-      "reliability": 0.7708,
+      "reliability": 0.6875,
       "badge": "https://abti.kagura-agent.com/badge/PTCF",
       "reliabilityRuns": [
         {
@@ -4619,10 +4646,19 @@
             2,
             3
           ]
+        },
+        {
+          "type": "PEDF",
+          "scores": [
+            3,
+            1,
+            1,
+            4
+          ]
         }
       ],
-      "consistency": 77,
-      "runs": 3
+      "consistency": 69,
+      "runs": 4
     },
     {
       "name": "Mistral 7B",
@@ -4782,7 +4818,7 @@
       "model": "gpt-4.1-mini",
       "provider": "github",
       "desc": "Proactive, efficient, candid, flexible. Fast-moving generalist who says what they think and adapts on the fly.",
-      "reliability": 0.8958,
+      "reliability": 0.875,
       "reliabilityRuns": [
         {
           "type": "PTDF",
@@ -4810,10 +4846,19 @@
             1,
             4
           ]
+        },
+        {
+          "type": "PTCF",
+          "scores": [
+            2,
+            2,
+            2,
+            3
+          ]
         }
       ],
-      "consistency": 90,
-      "runs": 3
+      "consistency": 88,
+      "runs": 4
     },
     {
       "name": "GPT-4.1 nano",
@@ -4865,7 +4910,7 @@
       "model": "gpt-4.1-nano",
       "provider": "github",
       "desc": "Proactive, efficient, candid, principled. All gas, no brakes, no filter, no exceptions.",
-      "reliability": 0.9583,
+      "reliability": 0.9219,
       "reliabilityRuns": [
         {
           "type": "PTDF",
@@ -4893,10 +4938,19 @@
             1,
             2
           ]
+        },
+        {
+          "type": "PTCF",
+          "scores": [
+            4,
+            3,
+            2,
+            2
+          ]
         }
       ],
-      "consistency": 96,
-      "runs": 3
+      "consistency": 92,
+      "runs": 4
     },
     {
       "name": "Phi 4",


### PR DESCRIPTION
## Summary

6 new reliability runs (run-4) for remaining core models using current question set (5.18-beta, including redesigned Q11 and Q13).

### New runs
| Model | Run | Type |
|-------|-----|------|
| GPT-4.1-mini | #4 | PTCF |
| GPT-4.1-nano | #4 | PTCF |
| Llama 4 Scout | #4 | PECF |
| Llama 4 Maverick | #4 | PTCF |
| Mistral Small 3.1 | #4 | PEDF |
| Mistral Medium 2505 | #4 | PTDF |

### Discriminability
Regenerated from 291 runs. All 16 questions above 0.6 threshold.

| Question | Disc | Status |
|----------|------|--------|
| Q11 (Transparency — UUID vs PK) | 0.685 | ⚠️ Below 0.7 target |
| Q13 (Adaptability — code ownership) | 0.824 | ✅ Above 0.7 |

Q11 dipped below 0.7 with the full data set — pre-redesign runs (old Q11 text) mixed with post-redesign runs reduce the signal. This is expected; pure post-redesign cohort should show higher discrimination.

### Previous batch
PR #754 covered 15 models (Claude family, GPT-4o/5.x, Gemini). This batch covers the remaining 6 core models.

Closes #753