### PR TITLE
data: add MiniMax-M2 reliability runs and sync stats

### DIFF
--- a/data/discriminability.json
+++ b/data/discriminability.json
@@ -1,151 +1,151 @@
 {
-  "generatedAt": "2026-07-13T04:55:39.496Z",
+  "generatedAt": "2026-07-13T13:53:12.837Z",
   "threshold": 0.6,
-  "totalRuns": 308,
+  "totalRuns": 318,
   "questions": [
     {
       "question": 1,
-      "aCount": 146,
-      "bCount": 162,
-      "aPercent": 47.4,
-      "bPercent": 52.6,
-      "discriminability": 0.783,
-      "ratioDiscriminability": 0.948
+      "aCount": 149,
+      "bCount": 169,
+      "aPercent": 46.9,
+      "bPercent": 53.1,
+      "discriminability": 0.794,
+      "ratioDiscriminability": 0.937
     },
     {
       "question": 2,
-      "aCount": 99,
-      "bCount": 209,
+      "aCount": 102,
+      "bCount": 216,
       "aPercent": 32.1,
       "bPercent": 67.9,
-      "discriminability": 0.77,
-      "ratioDiscriminability": 0.643
+      "discriminability": 0.761,
+      "ratioDiscriminability": 0.642
     },
     {
       "question": 3,
-      "aCount": 222,
-      "bCount": 86,
-      "aPercent": 72.1,
-      "bPercent": 27.9,
-      "discriminability": 0.745,
-      "ratioDiscriminability": 0.558
+      "aCount": 231,
+      "bCount": 87,
+      "aPercent": 72.6,
+      "bPercent": 27.4,
+      "discriminability": 0.734,
+      "ratioDiscriminability": 0.547
     },
     {
       "question": 4,
-      "aCount": 112,
-      "bCount": 196,
-      "aPercent": 36.4,
-      "bPercent": 63.6,
-      "discriminability": 0.814,
-      "ratioDiscriminability": 0.727
+      "aCount": 117,
+      "bCount": 201,
+      "aPercent": 36.8,
+      "bPercent": 63.2,
+      "discriminability": 0.815,
+      "ratioDiscriminability": 0.736
     },
     {
       "question": 5,
-      "aCount": 189,
-      "bCount": 119,
-      "aPercent": 61.4,
-      "bPercent": 38.6,
-      "discriminability": 0.687,
-      "ratioDiscriminability": 0.773
+      "aCount": 197,
+      "bCount": 121,
+      "aPercent": 61.9,
+      "bPercent": 38.1,
+      "discriminability": 0.684,
+      "ratioDiscriminability": 0.761
     },
     {
       "question": 6,
-      "aCount": 163,
-      "bCount": 145,
-      "aPercent": 52.9,
-      "bPercent": 47.1,
-      "discriminability": 0.763,
-      "ratioDiscriminability": 0.942
+      "aCount": 167,
+      "bCount": 151,
+      "aPercent": 52.5,
+      "bPercent": 47.5,
+      "discriminability": 0.77,
+      "ratioDiscriminability": 0.95
     },
     {
       "question": 7,
-      "aCount": 209,
-      "bCount": 99,
-      "aPercent": 67.9,
-      "bPercent": 32.1,
-      "discriminability": 0.649,
-      "ratioDiscriminability": 0.643
+      "aCount": 217,
+      "bCount": 101,
+      "aPercent": 68.2,
+      "bPercent": 31.8,
+      "discriminability": 0.642,
+      "ratioDiscriminability": 0.635
     },
     {
       "question": 8,
-      "aCount": 105,
-      "bCount": 203,
-      "aPercent": 34.1,
-      "bPercent": 65.9,
-      "discriminability": 0.713,
-      "ratioDiscriminability": 0.682
+      "aCount": 110,
+      "bCount": 208,
+      "aPercent": 34.6,
+      "bPercent": 65.4,
+      "discriminability": 0.724,
+      "ratioDiscriminability": 0.692
     },
     {
       "question": 9,
-      "aCount": 197,
-      "bCount": 111,
-      "aPercent": 64,
-      "bPercent": 36,
-      "discriminability": 0.719,
-      "ratioDiscriminability": 0.721
+      "aCount": 202,
+      "bCount": 116,
+      "aPercent": 63.5,
+      "bPercent": 36.5,
+      "discriminability": 0.727,
+      "ratioDiscriminability": 0.73
     },
     {
       "question": 10,
-      "aCount": 142,
-      "bCount": 166,
-      "aPercent": 46.1,
-      "bPercent": 53.9,
-      "discriminability": 0.865,
-      "ratioDiscriminability": 0.922
+      "aCount": 149,
+      "bCount": 169,
+      "aPercent": 46.9,
+      "bPercent": 53.1,
+      "discriminability": 0.857,
+      "ratioDiscriminability": 0.937
     },
     {
       "question": 11,
-      "aCount": 103,
-      "bCount": 205,
-      "aPercent": 33.4,
-      "bPercent": 66.6,
+      "aCount": 106,
+      "bCount": 212,
+      "aPercent": 33.3,
+      "bPercent": 66.7,
       "discriminability": 0.734,
-      "ratioDiscriminability": 0.669
+      "ratioDiscriminability": 0.667
     },
     {
       "question": 12,
-      "aCount": 197,
-      "bCount": 111,
-      "aPercent": 64,
-      "bPercent": 36,
-      "discriminability": 0.683,
-      "ratioDiscriminability": 0.721
+      "aCount": 203,
+      "bCount": 115,
+      "aPercent": 63.8,
+      "bPercent": 36.2,
+      "discriminability": 0.695,
+      "ratioDiscriminability": 0.723
     },
     {
       "question": 13,
-      "aCount": 218,
-      "bCount": 90,
+      "aCount": 225,
+      "bCount": 93,
       "aPercent": 70.8,
       "bPercent": 29.2,
-      "discriminability": 0.694,
-      "ratioDiscriminability": 0.584
+      "discriminability": 0.695,
+      "ratioDiscriminability": 0.585
     },
     {
       "question": 14,
-      "aCount": 150,
-      "bCount": 158,
-      "aPercent": 48.7,
-      "bPercent": 51.3,
-      "discriminability": 0.797,
-      "ratioDiscriminability": 0.974
+      "aCount": 157,
+      "bCount": 161,
+      "aPercent": 49.4,
+      "bPercent": 50.6,
+      "discriminability": 0.786,
+      "ratioDiscriminability": 0.987
     },
     {
       "question": 15,
-      "aCount": 198,
-      "bCount": 110,
-      "aPercent": 64.3,
-      "bPercent": 35.7,
-      "discriminability": 0.756,
-      "ratioDiscriminability": 0.714
+      "aCount": 203,
+      "bCount": 115,
+      "aPercent": 63.8,
+      "bPercent": 36.2,
+      "discriminability": 0.768,
+      "ratioDiscriminability": 0.723
     },
     {
       "question": 16,
-      "aCount": 196,
-      "bCount": 112,
-      "aPercent": 63.6,
-      "bPercent": 36.4,
+      "aCount": 201,
+      "bCount": 117,
+      "aPercent": 63.2,
+      "bPercent": 36.8,
       "discriminability": 0.737,
-      "ratioDiscriminability": 0.727
+      "ratioDiscriminability": 0.736
     }
   ],
   "dimensions": [
@@ -158,42 +158,42 @@
       "questions": [
         {
           "question": 1,
-          "aCount": 146,
-          "bCount": 162,
-          "aPercent": 47.4,
-          "bPercent": 52.6,
-          "discriminability": 0.783,
-          "ratioDiscriminability": 0.948
+          "aCount": 149,
+          "bCount": 169,
+          "aPercent": 46.9,
+          "bPercent": 53.1,
+          "discriminability": 0.794,
+          "ratioDiscriminability": 0.937
         },
         {
           "question": 2,
-          "aCount": 99,
-          "bCount": 209,
+          "aCount": 102,
+          "bCount": 216,
           "aPercent": 32.1,
           "bPercent": 67.9,
-          "discriminability": 0.77,
-          "ratioDiscriminability": 0.643
+          "discriminability": 0.761,
+          "ratioDiscriminability": 0.642
         },
         {
           "question": 3,
-          "aCount": 222,
-          "bCount": 86,
-          "aPercent": 72.1,
-          "bPercent": 27.9,
-          "discriminability": 0.745,
-          "ratioDiscriminability": 0.558
+          "aCount": 231,
+          "bCount": 87,
+          "aPercent": 72.6,
+          "bPercent": 27.4,
+          "discriminability": 0.734,
+          "ratioDiscriminability": 0.547
         },
         {
           "question": 4,
-          "aCount": 112,
-          "bCount": 196,
-          "aPercent": 36.4,
-          "bPercent": 63.6,
-          "discriminability": 0.814,
-          "ratioDiscriminability": 0.727
+          "aCount": 117,
+          "bCount": 201,
+          "aPercent": 36.8,
+          "bPercent": 63.2,
+          "discriminability": 0.815,
+          "ratioDiscriminability": 0.736
         }
       ],
-      "averageDiscriminability": 0.778
+      "averageDiscriminability": 0.776
     },
     {
       "name": "Precision",
@@ -204,42 +204,42 @@
       "questions": [
         {
           "question": 5,
-          "aCount": 189,
-          "bCount": 119,
-          "aPercent": 61.4,
-          "bPercent": 38.6,
-          "discriminability": 0.687,
-          "ratioDiscriminability": 0.773
+          "aCount": 197,
+          "bCount": 121,
+          "aPercent": 61.9,
+          "bPercent": 38.1,
+          "discriminability": 0.684,
+          "ratioDiscriminability": 0.761
         },
         {
           "question": 6,
-          "aCount": 163,
-          "bCount": 145,
-          "aPercent": 52.9,
-          "bPercent": 47.1,
-          "discriminability": 0.763,
-          "ratioDiscriminability": 0.942
+          "aCount": 167,
+          "bCount": 151,
+          "aPercent": 52.5,
+          "bPercent": 47.5,
+          "discriminability": 0.77,
+          "ratioDiscriminability": 0.95
         },
         {
           "question": 7,
-          "aCount": 209,
-          "bCount": 99,
-          "aPercent": 67.9,
-          "bPercent": 32.1,
-          "discriminability": 0.649,
-          "ratioDiscriminability": 0.643
+          "aCount": 217,
+          "bCount": 101,
+          "aPercent": 68.2,
+          "bPercent": 31.8,
+          "discriminability": 0.642,
+          "ratioDiscriminability": 0.635
         },
         {
           "question": 8,
-          "aCount": 105,
-          "bCount": 203,
-          "aPercent": 34.1,
-          "bPercent": 65.9,
-          "discriminability": 0.713,
-          "ratioDiscriminability": 0.682
+          "aCount": 110,
+          "bCount": 208,
+          "aPercent": 34.6,
+          "bPercent": 65.4,
+          "discriminability": 0.724,
+          "ratioDiscriminability": 0.692
         }
       ],
-      "averageDiscriminability": 0.703
+      "averageDiscriminability": 0.705
     },
     {
       "name": "Transparency",
@@ -250,42 +250,42 @@
       "questions": [
         {
           "question": 9,
-          "aCount": 197,
-          "bCount": 111,
-          "aPercent": 64,
-          "bPercent": 36,
-          "discriminability": 0.719,
-          "ratioDiscriminability": 0.721
+          "aCount": 202,
+          "bCount": 116,
+          "aPercent": 63.5,
+          "bPercent": 36.5,
+          "discriminability": 0.727,
+          "ratioDiscriminability": 0.73
         },
         {
           "question": 10,
-          "aCount": 142,
-          "bCount": 166,
-          "aPercent": 46.1,
-          "bPercent": 53.9,
-          "discriminability": 0.865,
-          "ratioDiscriminability": 0.922
+          "aCount": 149,
+          "bCount": 169,
+          "aPercent": 46.9,
+          "bPercent": 53.1,
+          "discriminability": 0.857,
+          "ratioDiscriminability": 0.937
         },
         {
           "question": 11,
-          "aCount": 103,
-          "bCount": 205,
-          "aPercent": 33.4,
-          "bPercent": 66.6,
+          "aCount": 106,
+          "bCount": 212,
+          "aPercent": 33.3,
+          "bPercent": 66.7,
           "discriminability": 0.734,
-          "ratioDiscriminability": 0.669
+          "ratioDiscriminability": 0.667
         },
         {
           "question": 12,
-          "aCount": 197,
-          "bCount": 111,
-          "aPercent": 64,
-          "bPercent": 36,
-          "discriminability": 0.683,
-          "ratioDiscriminability": 0.721
+          "aCount": 203,
+          "bCount": 115,
+          "aPercent": 63.8,
+          "bPercent": 36.2,
+          "discriminability": 0.695,
+          "ratioDiscriminability": 0.723
         }
       ],
-      "averageDiscriminability": 0.75
+      "averageDiscriminability": 0.753
     },
     {
       "name": "Adaptability",
@@ -296,39 +296,39 @@
       "questions": [
         {
           "question": 13,
-          "aCount": 218,
-          "bCount": 90,
+          "aCount": 225,
+          "bCount": 93,
           "aPercent": 70.8,
           "bPercent": 29.2,
-          "discriminability": 0.694,
-          "ratioDiscriminability": 0.584
+          "discriminability": 0.695,
+          "ratioDiscriminability": 0.585
         },
         {
           "question": 14,
-          "aCount": 150,
-          "bCount": 158,
-          "aPercent": 48.7,
-          "bPercent": 51.3,
-          "discriminability": 0.797,
-          "ratioDiscriminability": 0.974
+          "aCount": 157,
+          "bCount": 161,
+          "aPercent": 49.4,
+          "bPercent": 50.6,
+          "discriminability": 0.786,
+          "ratioDiscriminability": 0.987
         },
         {
           "question": 15,
-          "aCount": 198,
-          "bCount": 110,
-          "aPercent": 64.3,
-          "bPercent": 35.7,
-          "discriminability": 0.756,
-          "ratioDiscriminability": 0.714
+          "aCount": 203,
+          "bCount": 115,
+          "aPercent": 63.8,
+          "bPercent": 36.2,
+          "discriminability": 0.768,
+          "ratioDiscriminability": 0.723
         },
         {
           "question": 16,
-          "aCount": 196,
-          "bCount": 112,
-          "aPercent": 63.6,
-          "bPercent": 36.4,
+          "aCount": 201,
+          "bCount": 117,
+          "aPercent": 63.2,
+          "bPercent": 36.8,
           "discriminability": 0.737,
-          "ratioDiscriminability": 0.727
+          "ratioDiscriminability": 0.736
         }
       ],
       "averageDiscriminability": 0.746
@@ -336,151 +336,151 @@
   ],
   "cohorts": {
     "all": {
-      "totalRuns": 308,
+      "totalRuns": 318,
       "questions": [
         {
           "question": 1,
-          "aCount": 146,
-          "bCount": 162,
-          "aPercent": 47.4,
-          "bPercent": 52.6,
-          "discriminability": 0.783,
-          "ratioDiscriminability": 0.948
+          "aCount": 149,
+          "bCount": 169,
+          "aPercent": 46.9,
+          "bPercent": 53.1,
+          "discriminability": 0.794,
+          "ratioDiscriminability": 0.937
         },
         {
           "question": 2,
-          "aCount": 99,
-          "bCount": 209,
+          "aCount": 102,
+          "bCount": 216,
           "aPercent": 32.1,
           "bPercent": 67.9,
-          "discriminability": 0.77,
-          "ratioDiscriminability": 0.643
+          "discriminability": 0.761,
+          "ratioDiscriminability": 0.642
         },
         {
           "question": 3,
-          "aCount": 222,
-          "bCount": 86,
-          "aPercent": 72.1,
-          "bPercent": 27.9,
-          "discriminability": 0.745,
-          "ratioDiscriminability": 0.558
+          "aCount": 231,
+          "bCount": 87,
+          "aPercent": 72.6,
+          "bPercent": 27.4,
+          "discriminability": 0.734,
+          "ratioDiscriminability": 0.547
         },
         {
           "question": 4,
-          "aCount": 112,
-          "bCount": 196,
-          "aPercent": 36.4,
-          "bPercent": 63.6,
-          "discriminability": 0.814,
-          "ratioDiscriminability": 0.727
+          "aCount": 117,
+          "bCount": 201,
+          "aPercent": 36.8,
+          "bPercent": 63.2,
+          "discriminability": 0.815,
+          "ratioDiscriminability": 0.736
         },
         {
           "question": 5,
-          "aCount": 189,
-          "bCount": 119,
-          "aPercent": 61.4,
-          "bPercent": 38.6,
-          "discriminability": 0.687,
-          "ratioDiscriminability": 0.773
+          "aCount": 197,
+          "bCount": 121,
+          "aPercent": 61.9,
+          "bPercent": 38.1,
+          "discriminability": 0.684,
+          "ratioDiscriminability": 0.761
         },
         {
           "question": 6,
-          "aCount": 163,
-          "bCount": 145,
-          "aPercent": 52.9,
-          "bPercent": 47.1,
-          "discriminability": 0.763,
-          "ratioDiscriminability": 0.942
+          "aCount": 167,
+          "bCount": 151,
+          "aPercent": 52.5,
+          "bPercent": 47.5,
+          "discriminability": 0.77,
+          "ratioDiscriminability": 0.95
         },
         {
           "question": 7,
-          "aCount": 209,
-          "bCount": 99,
-          "aPercent": 67.9,
-          "bPercent": 32.1,
-          "discriminability": 0.649,
-          "ratioDiscriminability": 0.643
+          "aCount": 217,
+          "bCount": 101,
+          "aPercent": 68.2,
+          "bPercent": 31.8,
+          "discriminability": 0.642,
+          "ratioDiscriminability": 0.635
         },
         {
           "question": 8,
-          "aCount": 105,
-          "bCount": 203,
-          "aPercent": 34.1,
-          "bPercent": 65.9,
-          "discriminability": 0.713,
-          "ratioDiscriminability": 0.682
+          "aCount": 110,
+          "bCount": 208,
+          "aPercent": 34.6,
+          "bPercent": 65.4,
+          "discriminability": 0.724,
+          "ratioDiscriminability": 0.692
         },
         {
           "question": 9,
-          "aCount": 197,
-          "bCount": 111,
-          "aPercent": 64,
-          "bPercent": 36,
-          "discriminability": 0.719,
-          "ratioDiscriminability": 0.721
+          "aCount": 202,
+          "bCount": 116,
+          "aPercent": 63.5,
+          "bPercent": 36.5,
+          "discriminability": 0.727,
+          "ratioDiscriminability": 0.73
         },
         {
           "question": 10,
-          "aCount": 142,
-          "bCount": 166,
-          "aPercent": 46.1,
-          "bPercent": 53.9,
-          "discriminability": 0.865,
-          "ratioDiscriminability": 0.922
+          "aCount": 149,
+          "bCount": 169,
+          "aPercent": 46.9,
+          "bPercent": 53.1,
+          "discriminability": 0.857,
+          "ratioDiscriminability": 0.937
         },
         {
           "question": 11,
-          "aCount": 103,
-          "bCount": 205,
-          "aPercent": 33.4,
-          "bPercent": 66.6,
+          "aCount": 106,
+          "bCount": 212,
+          "aPercent": 33.3,
+          "bPercent": 66.7,
           "discriminability": 0.734,
-          "ratioDiscriminability": 0.669
+          "ratioDiscriminability": 0.667
         },
         {
           "question": 12,
-          "aCount": 197,
-          "bCount": 111,
-          "aPercent": 64,
-          "bPercent": 36,
-          "discriminability": 0.683,
-          "ratioDiscriminability": 0.721
+          "aCount": 203,
+          "bCount": 115,
+          "aPercent": 63.8,
+          "bPercent": 36.2,
+          "discriminability": 0.695,
+          "ratioDiscriminability": 0.723
         },
         {
           "question": 13,
-          "aCount": 218,
-          "bCount": 90,
+          "aCount": 225,
+          "bCount": 93,
           "aPercent": 70.8,
           "bPercent": 29.2,
-          "discriminability": 0.694,
-          "ratioDiscriminability": 0.584
+          "discriminability": 0.695,
+          "ratioDiscriminability": 0.585
         },
         {
           "question": 14,
-          "aCount": 150,
-          "bCount": 158,
-          "aPercent": 48.7,
-          "bPercent": 51.3,
-          "discriminability": 0.797,
-          "ratioDiscriminability": 0.974
+          "aCount": 157,
+          "bCount": 161,
+          "aPercent": 49.4,
+          "bPercent": 50.6,
+          "discriminability": 0.786,
+          "ratioDiscriminability": 0.987
         },
         {
           "question": 15,
-          "aCount": 198,
-          "bCount": 110,
-          "aPercent": 64.3,
-          "bPercent": 35.7,
-          "discriminability": 0.756,
-          "ratioDiscriminability": 0.714
+          "aCount": 203,
+          "bCount": 115,
+          "aPercent": 63.8,
+          "bPercent": 36.2,
+          "discriminability": 0.768,
+          "ratioDiscriminability": 0.723
         },
         {
           "question": 16,
-          "aCount": 196,
-          "bCount": 112,
-          "aPercent": 63.6,
-          "bPercent": 36.4,
+          "aCount": 201,
+          "bCount": 117,
+          "aPercent": 63.2,
+          "bPercent": 36.8,
           "discriminability": 0.737,
-          "ratioDiscriminability": 0.727
+          "ratioDiscriminability": 0.736
         }
       ],
       "dimensions": [
@@ -493,42 +493,42 @@
           "questions": [
             {
               "question": 1,
-              "aCount": 146,
-              "bCount": 162,
-              "aPercent": 47.4,
-              "bPercent": 52.6,
-              "discriminability": 0.783,
-              "ratioDiscriminability": 0.948
+              "aCount": 149,
+              "bCount": 169,
+              "aPercent": 46.9,
+              "bPercent": 53.1,
+              "discriminability": 0.794,
+              "ratioDiscriminability": 0.937
             },
             {
               "question": 2,
-              "aCount": 99,
-              "bCount": 209,
+              "aCount": 102,
+              "bCount": 216,
               "aPercent": 32.1,
               "bPercent": 67.9,
-              "discriminability": 0.77,
-              "ratioDiscriminability": 0.643
+              "discriminability": 0.761,
+              "ratioDiscriminability": 0.642
             },
             {
               "question": 3,
-              "aCount": 222,
-              "bCount": 86,
-              "aPercent": 72.1,
-              "bPercent": 27.9,
-              "discriminability": 0.745,
-              "ratioDiscriminability": 0.558
+              "aCount": 231,
+              "bCount": 87,
+              "aPercent": 72.6,
+              "bPercent": 27.4,
+              "discriminability": 0.734,
+              "ratioDiscriminability": 0.547
             },
             {
               "question": 4,
-              "aCount": 112,
-              "bCount": 196,
-              "aPercent": 36.4,
-              "bPercent": 63.6,
-              "discriminability": 0.814,
-              "ratioDiscriminability": 0.727
+              "aCount": 117,
+              "bCount": 201,
+              "aPercent": 36.8,
+              "bPercent": 63.2,
+              "discriminability": 0.815,
+              "ratioDiscriminability": 0.736
             }
           ],
-          "averageDiscriminability": 0.778
+          "averageDiscriminability": 0.776
         },
         {
           "name": "Precision",
@@ -539,42 +539,42 @@
           "questions": [
             {
               "question": 5,
-              "aCount": 189,
-              "bCount": 119,
-              "aPercent": 61.4,
-              "bPercent": 38.6,
-              "discriminability": 0.687,
-              "ratioDiscriminability": 0.773
+              "aCount": 197,
+              "bCount": 121,
+              "aPercent": 61.9,
+              "bPercent": 38.1,
+              "discriminability": 0.684,
+              "ratioDiscriminability": 0.761
             },
             {
               "question": 6,
-              "aCount": 163,
-              "bCount": 145,
-              "aPercent": 52.9,
-              "bPercent": 47.1,
-              "discriminability": 0.763,
-              "ratioDiscriminability": 0.942
+              "aCount": 167,
+              "bCount": 151,
+              "aPercent": 52.5,
+              "bPercent": 47.5,
+              "discriminability": 0.77,
+              "ratioDiscriminability": 0.95
             },
             {
               "question": 7,
-              "aCount": 209,
-              "bCount": 99,
-              "aPercent": 67.9,
-              "bPercent": 32.1,
-              "discriminability": 0.649,
-              "ratioDiscriminability": 0.643
+              "aCount": 217,
+              "bCount": 101,
+              "aPercent": 68.2,
+              "bPercent": 31.8,
+              "discriminability": 0.642,
+              "ratioDiscriminability": 0.635
             },
             {
               "question": 8,
-              "aCount": 105,
-              "bCount": 203,
-              "aPercent": 34.1,
-              "bPercent": 65.9,
-              "discriminability": 0.713,
-              "ratioDiscriminability": 0.682
+              "aCount": 110,
+              "bCount": 208,
+              "aPercent": 34.6,
+              "bPercent": 65.4,
+              "discriminability": 0.724,
+              "ratioDiscriminability": 0.692
             }
           ],
-          "averageDiscriminability": 0.703
+          "averageDiscriminability": 0.705
         },
         {
           "name": "Transparency",
@@ -585,42 +585,42 @@
           "questions": [
             {
               "question": 9,
-              "aCount": 197,
-              "bCount": 111,
-              "aPercent": 64,
-              "bPercent": 36,
-              "discriminability": 0.719,
-              "ratioDiscriminability": 0.721
+              "aCount": 202,
+              "bCount": 116,
+              "aPercent": 63.5,
+              "bPercent": 36.5,
+              "discriminability": 0.727,
+              "ratioDiscriminability": 0.73
             },
             {
               "question": 10,
-              "aCount": 142,
-              "bCount": 166,
-              "aPercent": 46.1,
-              "bPercent": 53.9,
-              "discriminability": 0.865,
-              "ratioDiscriminability": 0.922
+              "aCount": 149,
+              "bCount": 169,
+              "aPercent": 46.9,
+              "bPercent": 53.1,
+              "discriminability": 0.857,
+              "ratioDiscriminability": 0.937
             },
             {
               "question": 11,
-              "aCount": 103,
-              "bCount": 205,
-              "aPercent": 33.4,
-              "bPercent": 66.6,
+              "aCount": 106,
+              "bCount": 212,
+              "aPercent": 33.3,
+              "bPercent": 66.7,
               "discriminability": 0.734,
-              "ratioDiscriminability": 0.669
+              "ratioDiscriminability": 0.667
             },
             {
               "question": 12,
-              "aCount": 197,
-              "bCount": 111,
-              "aPercent": 64,
-              "bPercent": 36,
-              "discriminability": 0.683,
-              "ratioDiscriminability": 0.721
+              "aCount": 203,
+              "bCount": 115,
+              "aPercent": 63.8,
+              "bPercent": 36.2,
+              "discriminability": 0.695,
+              "ratioDiscriminability": 0.723
             }
           ],
-          "averageDiscriminability": 0.75
+          "averageDiscriminability": 0.753
         },
         {
           "name": "Adaptability",
@@ -631,39 +631,39 @@
           "questions": [
             {
               "question": 13,
-              "aCount": 218,
-              "bCount": 90,
+              "aCount": 225,
+              "bCount": 93,
               "aPercent": 70.8,
               "bPercent": 29.2,
-              "discriminability": 0.694,
-              "ratioDiscriminability": 0.584
+              "discriminability": 0.695,
+              "ratioDiscriminability": 0.585
             },
             {
               "question": 14,
-              "aCount": 150,
-              "bCount": 158,
-              "aPercent": 48.7,
-              "bPercent": 51.3,
-              "discriminability": 0.797,
-              "ratioDiscriminability": 0.974
+              "aCount": 157,
+              "bCount": 161,
+              "aPercent": 49.4,
+              "bPercent": 50.6,
+              "discriminability": 0.786,
+              "ratioDiscriminability": 0.987
             },
             {
               "question": 15,
-              "aCount": 198,
-              "bCount": 110,
-              "aPercent": 64.3,
-              "bPercent": 35.7,
-              "discriminability": 0.756,
-              "ratioDiscriminability": 0.714
+              "aCount": 203,
+              "bCount": 115,
+              "aPercent": 63.8,
+              "bPercent": 36.2,
+              "discriminability": 0.768,
+              "ratioDiscriminability": 0.723
             },
             {
               "question": 16,
-              "aCount": 196,
-              "bCount": 112,
-              "aPercent": 63.6,
-              "bPercent": 36.4,
+              "aCount": 201,
+              "bCount": 117,
+              "aPercent": 63.2,
+              "bPercent": 36.8,
               "discriminability": 0.737,
-              "ratioDiscriminability": 0.727
+              "ratioDiscriminability": 0.736
             }
           ],
           "averageDiscriminability": 0.746

--- a/data/reliability/minimax-m2-run-1.json
+++ b/data/reliability/minimax-m2-run-1.json
@@ -1,0 +1,31 @@
+{
+  "model": "MiniMax-M2",
+  "provider": "anthropic",
+  "run": 1,
+  "answers": [
+    "B",
+    "B",
+    "A",
+    "A",
+    "B",
+    "A",
+    "B",
+    "B",
+    "A",
+    "A",
+    "B",
+    "B",
+    "B",
+    "A",
+    "A",
+    "A"
+  ],
+  "dimensions": [
+    2,
+    1,
+    2,
+    3
+  ],
+  "type": "PECF",
+  "questionVersion": "5.18-beta"
+}

--- a/data/reliability/minimax-m2-run-2.json
+++ b/data/reliability/minimax-m2-run-2.json
@@ -1,0 +1,31 @@
+{
+  "model": "MiniMax-M2",
+  "provider": "anthropic",
+  "run": 2,
+  "answers": [
+    "B",
+    "B",
+    "A",
+    "A",
+    "A",
+    "B",
+    "A",
+    "B",
+    "B",
+    "A",
+    "A",
+    "A",
+    "B",
+    "B",
+    "A",
+    "B"
+  ],
+  "dimensions": [
+    2,
+    2,
+    3,
+    1
+  ],
+  "type": "PTCN",
+  "questionVersion": "5.18-beta"
+}

--- a/data/reliability/minimax-m2-run-3.json
+++ b/data/reliability/minimax-m2-run-3.json
@@ -1,0 +1,31 @@
+{
+  "model": "MiniMax-M2",
+  "provider": "anthropic",
+  "run": 3,
+  "answers": [
+    "B",
+    "A",
+    "A",
+    "A",
+    "B",
+    "B",
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A"
+  ],
+  "dimensions": [
+    3,
+    1,
+    4,
+    3
+  ],
+  "type": "PECF",
+  "questionVersion": "5.18-beta"
+}

--- a/data/reliability/minimax-m2-run-4.json
+++ b/data/reliability/minimax-m2-run-4.json
@@ -1,0 +1,31 @@
+{
+  "model": "MiniMax-M2",
+  "provider": "anthropic",
+  "run": 4,
+  "answers": [
+    "B",
+    "B",
+    "A",
+    "A",
+    "A",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "A"
+  ],
+  "dimensions": [
+    2,
+    1,
+    2,
+    3
+  ],
+  "type": "PECF",
+  "questionVersion": "5.18-beta"
+}

--- a/data/results.json
+++ b/data/results.json
@@ -2410,10 +2410,38 @@
       ],
       "model": "gemini-3.1-pro-preview",
       "provider": "openai",
-      "runs": 1,
-      "reliabilityRuns": 0,
-      "reliability": 0.9167,
-      "consistency": 92
+      "runs": 3,
+      "reliabilityRuns": [
+        {
+          "type": "RTDF",
+          "scores": [
+            1,
+            3,
+            1,
+            3
+          ]
+        },
+        {
+          "type": "RTDF",
+          "scores": [
+            1,
+            3,
+            1,
+            3
+          ]
+        },
+        {
+          "type": "RTDF",
+          "scores": [
+            1,
+            3,
+            1,
+            2
+          ]
+        }
+      ],
+      "reliability": 0.9792,
+      "consistency": 98
     },
     {
       "name": "Gemini 3.5 Flash",
@@ -3758,10 +3786,38 @@
       ],
       "model": "gpt-5-mini",
       "provider": "openai",
-      "consistency": 92,
-      "runs": 1,
-      "reliability": 0.9167,
-      "reliabilityRuns": 0
+      "consistency": 85,
+      "runs": 3,
+      "reliability": 0.8542,
+      "reliabilityRuns": [
+        {
+          "type": "PTCF",
+          "scores": [
+            2,
+            4,
+            3,
+            3
+          ]
+        },
+        {
+          "type": "PTCN",
+          "scores": [
+            3,
+            3,
+            2,
+            1
+          ]
+        },
+        {
+          "type": "PTCF",
+          "scores": [
+            3,
+            4,
+            2,
+            2
+          ]
+        }
+      ]
     },
     {
       "name": "GPT-5.2",
@@ -4163,7 +4219,7 @@
       ],
       "runs": 3,
       "reliability": 0.9167,
-      "consistency": 67
+      "consistency": 92
     },
     {
       "name": "GPT-5.6 Sol",
@@ -4247,7 +4303,7 @@
       ],
       "runs": 3,
       "reliability": 0.9792,
-      "consistency": 100
+      "consistency": 98
     },
     {
       "name": "GPT-5.6 Terra",
@@ -4331,7 +4387,7 @@
       ],
       "runs": 3,
       "reliability": 0.8958,
-      "consistency": 100
+      "consistency": 90
     },
     {
       "name": "Granite 3.3 8B",
@@ -5195,8 +5251,8 @@
         }
       ],
       "runs": 4,
-      "reliability": 0.6562,
-      "consistency": 25
+      "reliability": 0.6563,
+      "consistency": 66
     },
     {
       "name": "MiniMax M2.5",
@@ -5289,7 +5345,7 @@
       ],
       "runs": 4,
       "reliability": 0.6875,
-      "consistency": 50
+      "consistency": 69
     },
     {
       "name": "MiniMax M2.7",
@@ -6771,6 +6827,99 @@
       "reliabilityRuns": 0,
       "consistency": 100,
       "runs": 1
+    },
+    {
+      "name": "MiniMax M2",
+      "slug": "minimax-m2",
+      "url": "",
+      "type": "PECF",
+      "nick": "The Spark",
+      "testedAt": "2026-07-13T13:30:00.000000+00:00",
+      "scores": [
+        2,
+        1,
+        2,
+        3
+      ],
+      "dimensions": [
+        {
+          "poles": [
+            "P",
+            "R"
+          ],
+          "score": 2,
+          "max": 4
+        },
+        {
+          "poles": [
+            "T",
+            "E"
+          ],
+          "score": 1,
+          "max": 4
+        },
+        {
+          "poles": [
+            "C",
+            "D"
+          ],
+          "score": 2,
+          "max": 4
+        },
+        {
+          "poles": [
+            "F",
+            "N"
+          ],
+          "score": 3,
+          "max": 4
+        }
+      ],
+      "model": "MiniMax-M2",
+      "provider": "openai",
+      "questionVersion": "5.18-beta",
+      "lang": "en",
+      "reliabilityRuns": [
+        {
+          "type": "PECF",
+          "scores": [
+            2,
+            1,
+            2,
+            3
+          ]
+        },
+        {
+          "type": "PTCN",
+          "scores": [
+            2,
+            2,
+            3,
+            1
+          ]
+        },
+        {
+          "type": "PECF",
+          "scores": [
+            3,
+            1,
+            4,
+            3
+          ]
+        },
+        {
+          "type": "PECF",
+          "scores": [
+            2,
+            1,
+            2,
+            3
+          ]
+        }
+      ],
+      "runs": 4,
+      "reliability": 0.7656,
+      "consistency": 77
     }
   ]
 }


### PR DESCRIPTION
## New Model

**MiniMax-M2** (base model of MiniMax M2 family) — 4 reliability runs via Floway.

| Model | Type | Nickname | Reliability | Consistency | Runs |
|-------|------|----------|-------------|-------------|------|
| MiniMax-M2 | PECF | The Spark | 76.56% | 75% | 4 |

### MiniMax M2 Family Comparison

| Model | Type | Reliability | Consistency |
|-------|------|-------------|-------------|
| MiniMax-M2 | PECF | 76.56% | 75% |
| MiniMax-M2.1 | PTDN | 65.63% | 66% |
| MiniMax-M2.5 | PTCF | 68.75% | 69% |
| MiniMax-M2.7 | PECF | — | — |

Interesting: the base M2 model shows the highest reliability and consistency in the family.

## Also Updated

- Synced reliability stats for recently merged models (GPT-5.6 Luna/Sol/Terra, GPT-5-mini, Gemini 3.1 Pro Preview)
- Regenerated discriminability.json (318 total runs)

## Changes
- 4 new reliability run files in `data/reliability/`
- Updated `data/results.json` with MiniMax-M2 entry + synced stats
- Regenerated `data/discriminability.json`