### PR TITLE
data: add Codestral-2501 and GPT-4.1-mini reliability runs

### DIFF
--- a/data/reliability/codestral-2501-run-301.json
+++ b/data/reliability/codestral-2501-run-301.json
@@ -1,0 +1,30 @@
+{
+    "model": "Codestral-2501",
+    "provider": "github",
+    "run": 301,
+    "answers": [
+        "B",
+        "A",
+        "B",
+        "A",
+        "A",
+        "B",
+        "A",
+        "B",
+        "B",
+        "B",
+        "B",
+        "A",
+        "A",
+        "A",
+        "B",
+        "A"
+    ],
+    "type": "PTDF",
+    "dimensions": [
+        2,
+        2,
+        1,
+        3
+    ]
+}

--- a/data/reliability/codestral-2501-run-302.json
+++ b/data/reliability/codestral-2501-run-302.json
@@ -1,0 +1,30 @@
+{
+    "model": "Codestral-2501",
+    "provider": "github",
+    "run": 302,
+    "answers": [
+        "A",
+        "A",
+        "A",
+        "B",
+        "A",
+        "A",
+        "B",
+        "A",
+        "A",
+        "A",
+        "A",
+        "A",
+        "B",
+        "B",
+        "A",
+        "B"
+    ],
+    "type": "PTCN",
+    "dimensions": [
+        3,
+        3,
+        4,
+        1
+    ]
+}

--- a/data/reliability/codestral-2501-run-303.json
+++ b/data/reliability/codestral-2501-run-303.json
@@ -1,0 +1,30 @@
+{
+    "model": "Codestral-2501",
+    "provider": "github",
+    "run": 303,
+    "answers": [
+        "B",
+        "A",
+        "A",
+        "B",
+        "B",
+        "A",
+        "A",
+        "B",
+        "B",
+        "A",
+        "B",
+        "B",
+        "B",
+        "B",
+        "A",
+        "A"
+    ],
+    "type": "PTDF",
+    "dimensions": [
+        2,
+        2,
+        1,
+        2
+    ]
+}

--- a/data/reliability/gpt-4.1-mini-run-301.json
+++ b/data/reliability/gpt-4.1-mini-run-301.json
@@ -1,0 +1,30 @@
+{
+    "model": "openai/gpt-4.1-mini",
+    "provider": "github",
+    "run": 301,
+    "answers": [
+        "B",
+        "B",
+        "A",
+        "B",
+        "B",
+        "A",
+        "B",
+        "A",
+        "B",
+        "A",
+        "B",
+        "B",
+        "A",
+        "B",
+        "B",
+        "A"
+    ],
+    "type": "RTDF",
+    "dimensions": [
+        1,
+        2,
+        1,
+        2
+    ]
+}

--- a/data/reliability/gpt-4.1-mini-run-302.json
+++ b/data/reliability/gpt-4.1-mini-run-302.json
@@ -1,0 +1,30 @@
+{
+    "model": "openai/gpt-4.1-mini",
+    "provider": "github",
+    "run": 302,
+    "answers": [
+        "A",
+        "A",
+        "B",
+        "A",
+        "B",
+        "B",
+        "A",
+        "B",
+        "B",
+        "B",
+        "B",
+        "A",
+        "A",
+        "B",
+        "A",
+        "A"
+    ],
+    "type": "PEDF",
+    "dimensions": [
+        3,
+        1,
+        1,
+        3
+    ]
+}


### PR DESCRIPTION
## Summary

Adds post-Q11+Q13-redesign reliability runs:

### Codestral-2501 (3 runs, complete set)
| Run | Type | Dimensions |
|-----|------|-----------|
| 301 | PTDF | [2,2,1,3] |
| 302 | PTCN | [3,3,4,1] |
| 303 | PTDF | [2,2,1,2] |

### GPT-4.1-mini (2 of 3 runs)
| Run | Type | Dimensions |
|-----|------|-----------|
| 301 | RTDF | [1,2,1,2] |
| 302 | PEDF | [3,1,1,3] |

Run 303 for GPT-4.1-mini pending (rate limited).

All runs via GitHub Models provider.

Part of #738 batch.