### PR TITLE
data: Cohere Command A q16v7 reliability runs 301-303

### DIFF
--- a/data/reliability/q16v7-cohere-command-a-run-301.json
+++ b/data/reliability/q16v7-cohere-command-a-run-301.json
@@ -1,0 +1,30 @@
+{
+    "model": "cohere-command-a",
+    "provider": "github",
+    "run": 301,
+    "answers": [
+        "A",
+        "B",
+        "B",
+        "A",
+        "B",
+        "B",
+        "A",
+        "B",
+        "A",
+        "B",
+        "B",
+        "A",
+        "A",
+        "B",
+        "A",
+        "B"
+    ],
+    "type": "PECF",
+    "dimensions": [
+        2,
+        1,
+        2,
+        2
+    ]
+}

--- a/data/reliability/q16v7-cohere-command-a-run-302.json
+++ b/data/reliability/q16v7-cohere-command-a-run-302.json
@@ -1,0 +1,30 @@
+{
+    "model": "cohere-command-a",
+    "provider": "github",
+    "run": 302,
+    "answers": [
+        "A",
+        "A",
+        "B",
+        "B",
+        "B",
+        "B",
+        "A",
+        "A",
+        "A",
+        "B",
+        "B",
+        "A",
+        "A",
+        "B",
+        "A",
+        "B"
+    ],
+    "type": "PTCF",
+    "dimensions": [
+        2,
+        2,
+        2,
+        2
+    ]
+}

--- a/data/reliability/q16v7-cohere-command-a-run-303.json
+++ b/data/reliability/q16v7-cohere-command-a-run-303.json
@@ -1,0 +1,30 @@
+{
+    "model": "cohere-command-a",
+    "provider": "github",
+    "run": 303,
+    "answers": [
+        "B",
+        "B",
+        "B",
+        "A",
+        "A",
+        "B",
+        "A",
+        "A",
+        "A",
+        "A",
+        "B",
+        "A",
+        "A",
+        "B",
+        "A",
+        "B"
+    ],
+    "type": "RTCF",
+    "dimensions": [
+        1,
+        3,
+        3,
+        2
+    ]
+}


### PR DESCRIPTION
## What
- 3 q16v7 reliability runs for Cohere Command A via GitHub Models
- Run 301: PECF [2,1,2,2]
- Run 302: PTCF [2,2,2,2]
- Run 303: RTCF [1,3,3,2]

## Context
Parallel work while waiting for DeepSeek-V3 rate limit reset (#738).
Cohere Command A had old-format reliability runs but no q16v7 data.