### PR TITLE
data: GPT-5.4 Mini reliability runs 1 & 3 (completing 3/3)

### DIFF
--- a/data/reliability/gpt-5-4-mini-run-1.json
+++ b/data/reliability/gpt-5-4-mini-run-1.json
@@ -1,0 +1,31 @@
+{
+  "model": "gpt-5.4-mini",
+  "provider": "anthropic",
+  "run": 1,
+  "answers": [
+    "A",
+    "B",
+    "A",
+    "B",
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "B",
+    "B",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A"
+  ],
+  "dimensions": [
+    2,
+    3,
+    2,
+    3
+  ],
+  "type": "PTCF",
+  "questionVersion": "5.18-beta"
+}

--- a/data/reliability/gpt-5-4-mini-run-3.json
+++ b/data/reliability/gpt-5-4-mini-run-3.json
@@ -1,0 +1,31 @@
+{
+  "model": "gpt-5.4-mini",
+  "provider": "anthropic",
+  "run": 3,
+  "answers": [
+    "A",
+    "B",
+    "A",
+    "B",
+    "B",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "B",
+    "B"
+  ],
+  "dimensions": [
+    2,
+    2,
+    3,
+    2
+  ],
+  "type": "PTCF",
+  "questionVersion": "5.18-beta"
+}


### PR DESCRIPTION
Adds the missing reliability runs for GPT-5.4 Mini (run 2 already existed).

All 3 runs: PTCF — very high consistency.

Part of #738 parallel work while DeepSeek-V3 is rate-limited.