### PR TITLE
data: reliability runs for Gemini 3 Flash Preview, Claude Sonnet 4-6, Claude Opus 4-8

### DIFF
--- a/data/reliability/claude-opus-4-8-run-1.json
+++ b/data/reliability/claude-opus-4-8-run-1.json
@@ -1,0 +1,31 @@
+{
+  "model": "claude-opus-4-8",
+  "provider": "anthropic",
+  "run": 1,
+  "answers": [
+    "B",
+    "B",
+    "A",
+    "B",
+    "A",
+    "B",
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B"
+  ],
+  "dimensions": [
+    1,
+    2,
+    4,
+    3
+  ],
+  "type": "RTCF",
+  "questionVersion": "5.18-beta"
+}

--- a/data/reliability/claude-opus-4-8-run-3.json
+++ b/data/reliability/claude-opus-4-8-run-3.json
@@ -1,0 +1,31 @@
+{
+  "model": "claude-opus-4-8",
+  "provider": "anthropic",
+  "run": 3,
+  "answers": [
+    "B",
+    "B",
+    "A",
+    "B",
+    "B",
+    "B",
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B"
+  ],
+  "dimensions": [
+    1,
+    1,
+    4,
+    3
+  ],
+  "type": "RECF",
+  "questionVersion": "5.18-beta"
+}

--- a/data/reliability/claude-sonnet-4-6-run-1.json
+++ b/data/reliability/claude-sonnet-4-6-run-1.json
@@ -1,0 +1,31 @@
+{
+  "model": "claude-sonnet-4-6",
+  "provider": "anthropic",
+  "run": 1,
+  "answers": [
+    "B",
+    "B",
+    "B",
+    "B",
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "A",
+    "B",
+    "A",
+    "A",
+    "B"
+  ],
+  "dimensions": [
+    0,
+    3,
+    3,
+    2
+  ],
+  "type": "RTCF",
+  "questionVersion": "5.18-beta"
+}

--- a/data/reliability/claude-sonnet-4-6-run-3.json
+++ b/data/reliability/claude-sonnet-4-6-run-3.json
@@ -1,0 +1,31 @@
+{
+  "model": "claude-sonnet-4-6",
+  "provider": "anthropic",
+  "run": 3,
+  "answers": [
+    "B",
+    "B",
+    "B",
+    "B",
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B"
+  ],
+  "dimensions": [
+    0,
+    3,
+    4,
+    3
+  ],
+  "type": "RTCF",
+  "questionVersion": "5.18-beta"
+}

--- a/data/reliability/gemini-3-flash-preview-run-301.json
+++ b/data/reliability/gemini-3-flash-preview-run-301.json
@@ -1,0 +1,31 @@
+{
+  "model": "gemini-3-flash-preview",
+  "provider": "anthropic",
+  "run": 301,
+  "answers": [
+    "A",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "B",
+    "A",
+    "B"
+  ],
+  "dimensions": [
+    3,
+    4,
+    3,
+    2
+  ],
+  "type": "PTCF",
+  "questionVersion": "5.18-beta"
+}

--- a/data/reliability/gemini-3-flash-preview-run-302.json
+++ b/data/reliability/gemini-3-flash-preview-run-302.json
@@ -1,0 +1,31 @@
+{
+  "model": "gemini-3-flash-preview",
+  "provider": "anthropic",
+  "run": 302,
+  "answers": [
+    "B",
+    "B",
+    "B",
+    "B",
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "B",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B"
+  ],
+  "dimensions": [
+    0,
+    3,
+    2,
+    3
+  ],
+  "type": "RTCF",
+  "questionVersion": "5.18-beta"
+}

--- a/data/reliability/gemini-3-flash-preview-run-303.json
+++ b/data/reliability/gemini-3-flash-preview-run-303.json
@@ -1,0 +1,31 @@
+{
+  "model": "gemini-3-flash-preview",
+  "provider": "anthropic",
+  "run": 303,
+  "answers": [
+    "A",
+    "A",
+    "A",
+    "B",
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "B",
+    "B",
+    "B"
+  ],
+  "dimensions": [
+    3,
+    3,
+    3,
+    1
+  ],
+  "type": "PTCN",
+  "questionVersion": "5.18-beta"
+}


### PR DESCRIPTION
## Summary

Reliability data for 3 models, completing minimum 3-run coverage:

### New model (first time tested)
- **Gemini 3 Flash Preview**: 3 runs (301-303) — PTCF, RTCF, PTCN

### Completing existing models (was 1/3, now 3/3)
- **Claude Sonnet 4-6**: runs 1 & 3 — RTCF, RTCF, RTCF (perfect consistency across all 3 runs)
- **Claude Opus 4-8**: runs 1 & 3 — RTCF, RTCF, RECF

## Notes
- All runs via Floway (JP endpoint)
- Parallel work while waiting for DeepSeek-V3 rate limit reset (#738)
- Question version: 5.18-beta (16 questions)