### PR TITLE
data: Phi-4 reliability run 3 — PTDF [4,3,1,3]

### DIFF
--- a/data/reliability/phi-4-run-3.json
+++ b/data/reliability/phi-4-run-3.json
@@ -1,0 +1,30 @@
+{
+    "model": "Phi-4",
+    "provider": "github",
+    "run": 3,
+    "answers": [
+        "A",
+        "A",
+        "A",
+        "A",
+        "A",
+        "A",
+        "A",
+        "B",
+        "B",
+        "B",
+        "B",
+        "A",
+        "A",
+        "A",
+        "A",
+        "B"
+    ],
+    "type": "PTDF",
+    "dimensions": [
+        4,
+        3,
+        1,
+        3
+    ]
+}


### PR DESCRIPTION
Completes 3/3 reliability runs for Phi-4 on GitHub Models.

| Run | Type | Dimensions |
|-----|------|-----------|
| 1 | PTCF | [3,3,4,2] |
| 2 | RTDF | [1,4,1,2] (PR #764) |
| 3 | PTDF | [4,3,1,3] |

Phi-4 now meets the 3-run minimum for reliability assessment.

Part of #738 parallel work while DeepSeek-V3 is rate-limited.