### PR TITLE
data: Phi-4-multimodal-instruct reliability runs 301-303 (new model)

### DIFF
--- a/data/reliability/phi-4-multimodal-run-301.json
+++ b/data/reliability/phi-4-multimodal-run-301.json
@@ -1,0 +1,40 @@
+{
+    "model": "Phi-4-multimodal-instruct",
+    "provider": "github",
+    "run": 301,
+    "answers": [
+        "A",
+        "A",
+        "B",
+        "A",
+        "B",
+        "A",
+        "A",
+        "B",
+        "A",
+        "B",
+        "B",
+        "A",
+        "A",
+        "A",
+        "A",
+        "A",
+        "A",
+        "A",
+        "B",
+        "A",
+        "A",
+        "B",
+        "B",
+        "A",
+        "A",
+        "B"
+    ],
+    "type": "PTCF",
+    "dimensions": [
+        3,
+        2,
+        2,
+        4
+    ]
+}

--- a/data/reliability/phi-4-multimodal-run-302.json
+++ b/data/reliability/phi-4-multimodal-run-302.json
@@ -1,0 +1,31 @@
+{
+    "model": "Phi-4-multimodal-instruct",
+    "provider": "github",
+    "run": 302,
+    "answers": [
+        "A",
+        "A",
+        "A",
+        "B",
+        "B",
+        "A",
+        "B",
+        "A",
+        "A",
+        "A",
+        "B",
+        "A",
+        "A",
+        "B",
+        "A",
+        "A",
+        "B"
+    ],
+    "type": "PTCF",
+    "dimensions": [
+        3,
+        2,
+        3,
+        3
+    ]
+}

--- a/data/reliability/phi-4-multimodal-run-303.json
+++ b/data/reliability/phi-4-multimodal-run-303.json
@@ -1,0 +1,30 @@
+{
+    "model": "Phi-4-multimodal-instruct",
+    "provider": "github",
+    "run": 303,
+    "answers": [
+        "A",
+        "A",
+        "A",
+        "A",
+        "A",
+        "B",
+        "B",
+        "A",
+        "B",
+        "B",
+        "A",
+        "A",
+        "B",
+        "A",
+        "B",
+        "A"
+    ],
+    "type": "PTCF",
+    "dimensions": [
+        4,
+        2,
+        2,
+        2
+    ]
+}


### PR DESCRIPTION
**New model added to ABTI:** Phi-4-multimodal-instruct (GitHub Models)

3/3 reliability runs completed with perfect type consistency:

| Run | Type | Dimensions |
|-----|------|-----------|
| 301 | PTCF | [3,2,2,4] |
| 302 | PTCF | [3,2,3,3] |
| 303 | PTCF | [4,2,2,2] |

**Consensus type: PTCF** (Practical, Transparent, Cooperative, Flexible)

Part of #738 parallel work while DeepSeek-V3 is rate-limited on GitHub Models.