### PR TITLE
data: Phi-4 reliability run-2 (RTDF [1,4,1,2])

### DIFF
--- a/data/reliability/phi-4-run-2.json
+++ b/data/reliability/phi-4-run-2.json
@@ -1,0 +1,33 @@
+{
+    "model": "Phi-4",
+    "provider": "github",
+    "run": 2,
+    "answers": [
+        "B",
+        "A",
+        "B",
+        "B",
+        "A",
+        "A",
+        "A",
+        "A",
+        "A",
+        "B",
+        "B",
+        "B",
+        "B",
+        "A",
+        "B",
+        "A",
+        "A",
+        "A",
+        "A"
+    ],
+    "type": "RTDF",
+    "dimensions": [
+        1,
+        4,
+        1,
+        2
+    ]
+}


### PR DESCRIPTION
Adds missing Phi-4 run-2 reliability data. Completes 3/3 minimum reliability runs for Phi-4.

- Run 1: existing (on master)
- Run 2: RTDF [1,4,1,2] ← this PR
- Run 3: PTDF [4,3,1,3] (already on master)

Part of #738 parallel work.