### PR TITLE
data: DeepSeek-V3-0324 reliability run 301 — PECF [3,1,2,2] (#738)

### DIFF
--- a/data/reliability/q16v7-deepseek-v3-0324-run-301.json
+++ b/data/reliability/q16v7-deepseek-v3-0324-run-301.json
@@ -1,0 +1,30 @@
+{
+    "model": "DeepSeek-V3-0324",
+    "provider": "github",
+    "run": 301,
+    "answers": [
+        "A",
+        "A",
+        "A",
+        "B",
+        "B",
+        "B",
+        "A",
+        "B",
+        "A",
+        "B",
+        "B",
+        "A",
+        "A",
+        "B",
+        "A",
+        "B"
+    ],
+    "type": "PECF",
+    "dimensions": [
+        3,
+        1,
+        2,
+        2
+    ]
+}


### PR DESCRIPTION
## What
- DeepSeek-V3-0324 reliability run 301 via GitHub Models
- Type: PECF [3,1,2,2]
- 16/16 questions answered

## Context
Part of #738 — testing DeepSeek-V3 via GitHub Models (rate-limited to ~16 questions/day).

Run 301 completed 2026-07-14. Runs 302-303 still pending due to persistent rate limits and service outages (500 for >48h).