### PR TITLE
data: DeepSeek-R1 reliability runs 301-303 (3/3 complete)

### DIFF
--- a/data/reliability/DeepSeek-R1-run-301.json
+++ b/data/reliability/DeepSeek-R1-run-301.json
@@ -1,0 +1,30 @@
+{
+    "model": "DeepSeek-R1",
+    "provider": "github",
+    "run": 301,
+    "answers": [
+        "B",
+        "B",
+        "A",
+        "B",
+        "B",
+        "A",
+        "A",
+        "B",
+        "B",
+        "B",
+        "B",
+        "B",
+        "B",
+        "B",
+        "B",
+        "A"
+    ],
+    "type": "RTDN",
+    "dimensions": [
+        1,
+        2,
+        0,
+        1
+    ]
+}

--- a/data/reliability/DeepSeek-R1-run-302.json
+++ b/data/reliability/DeepSeek-R1-run-302.json
@@ -1,0 +1,30 @@
+{
+    "model": "DeepSeek-R1",
+    "provider": "github",
+    "run": 302,
+    "answers": [
+        "B",
+        "B",
+        "A",
+        "B",
+        "A",
+        "B",
+        "B",
+        "A",
+        "B",
+        "A",
+        "A",
+        "B",
+        "B",
+        "B",
+        "B",
+        "A"
+    ],
+    "type": "RTCN",
+    "dimensions": [
+        1,
+        2,
+        2,
+        1
+    ]
+}

--- a/data/reliability/DeepSeek-R1-run-303.json
+++ b/data/reliability/DeepSeek-R1-run-303.json
@@ -1,0 +1,30 @@
+{
+    "model": "DeepSeek-R1",
+    "provider": "github",
+    "run": 303,
+    "answers": [
+        "B",
+        "B",
+        "A",
+        "B",
+        "B",
+        "A",
+        "A",
+        "A",
+        "A",
+        "B",
+        "B",
+        "A",
+        "A",
+        "B",
+        "B",
+        "A"
+    ],
+    "type": "RTCF",
+    "dimensions": [
+        1,
+        3,
+        2,
+        2
+    ]
+}

--- a/resume-reliability.sh
+++ b/resume-reliability.sh
@@ -316,7 +316,7 @@ payload = {
         {'role': 'system', 'content': '''$SYSTEM_PROMPT'''},
         {'role': 'user', 'content': '''$USER_MSG'''}
     ],
-    'max_tokens': 2048,
+    'max_tokens': 16384,
 }
 if '$NO_TEMP' != 'true':
     payload['temperature'] = 0


### PR DESCRIPTION
## Summary

Completes 3/3 reliability runs for **DeepSeek-R1** (reasoning model) via GitHub Models.

### Results:
| Run | Type | Scores |
|-----|------|--------|
| 301 | RTDN | [1,2,0,1] |
| 302 | RTCN | [1,2,2,1] |
| 303 | RTCF | [1,3,2,2] |

### Notes:
- DeepSeek-R1 is a reasoning model with long `<think>` blocks
- Required max_tokens increase from 2048 → 16384 to handle chain-of-thought output
- Aggressive daily rate limits on GitHub Models required multi-day collection

Fixes part of #738