### PR TITLE
data: gpt-4-o-preview 3 reliability runs (#781)

### DIFF
--- a/data/reliability/gpt-4-o-preview-run-301.json
+++ b/data/reliability/gpt-4-o-preview-run-301.json
@@ -1,0 +1,31 @@
+{
+  "model": "gpt-4-o-preview",
+  "provider": "anthropic",
+  "run": 301,
+  "answers": [
+    "B",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A"
+  ],
+  "dimensions": [
+    2,
+    4,
+    2,
+    4
+  ],
+  "type": "PTCF",
+  "questionVersion": "5.18-beta"
+}

--- a/data/reliability/gpt-4-o-preview-run-302.json
+++ b/data/reliability/gpt-4-o-preview-run-302.json
@@ -1,0 +1,31 @@
+{
+  "model": "gpt-4-o-preview",
+  "provider": "anthropic",
+  "run": 302,
+  "answers": [
+    "B",
+    "B",
+    "A",
+    "B",
+    "B",
+    "A",
+    "A",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A"
+  ],
+  "dimensions": [
+    1,
+    2,
+    0,
+    4
+  ],
+  "type": "RTDF",
+  "questionVersion": "5.18-beta"
+}

--- a/data/reliability/gpt-4-o-preview-run-303.json
+++ b/data/reliability/gpt-4-o-preview-run-303.json
@@ -1,0 +1,31 @@
+{
+  "model": "gpt-4-o-preview",
+  "provider": "anthropic",
+  "run": 303,
+  "answers": [
+    "B",
+    "B",
+    "A",
+    "B",
+    "B",
+    "A",
+    "A",
+    "B",
+    "B",
+    "B",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A"
+  ],
+  "dimensions": [
+    1,
+    2,
+    1,
+    4
+  ],
+  "type": "RTDF",
+  "questionVersion": "5.18-beta"
+}


### PR DESCRIPTION
## Summary

3 reliability runs for **GPT-4o Preview** (via Floway), a previously untested model.

### Results:
- Run 301: **PTCF**
- Run 302: **RTDF**
- Run 303: **RTDF**

### Notes:
- `gpt-41-copilot` does not support `/chat/completions` endpoint (400 error) — cannot be tested with current methodology
- `mai-code-1-flash-picker` does not support `temperature` parameter — would need script modification

Closes #781 (partially — remaining models cannot be tested without script changes)