### PR TITLE
data: gpt-4.1-mini v4 reliability runs 1-3

### DIFF
--- a/data/reliability/v4/gpt-4.1-mini-run-1.json
+++ b/data/reliability/v4/gpt-4.1-mini-run-1.json
@@ -1,0 +1,30 @@
+{
+    "model": "gpt-4.1-mini",
+    "provider": "github",
+    "run": 1,
+    "answers": [
+        "A",
+        "A",
+        "B",
+        "A",
+        "B",
+        "B",
+        "A",
+        "A",
+        "A",
+        "B",
+        "B",
+        "A",
+        "A",
+        "B",
+        "A",
+        "A"
+    ],
+    "type": "PTCF",
+    "dimensions": [
+        3,
+        2,
+        2,
+        3
+    ]
+}

--- a/data/reliability/v4/gpt-4.1-mini-run-2.json
+++ b/data/reliability/v4/gpt-4.1-mini-run-2.json
@@ -1,0 +1,30 @@
+{
+    "model": "gpt-4.1-mini",
+    "provider": "github",
+    "run": 2,
+    "answers": [
+        "B",
+        "A",
+        "B",
+        "A",
+        "B",
+        "B",
+        "A",
+        "B",
+        "A",
+        "B",
+        "B",
+        "A",
+        "A",
+        "A",
+        "A",
+        "A"
+    ],
+    "type": "PECF",
+    "dimensions": [
+        2,
+        1,
+        2,
+        4
+    ]
+}

--- a/data/reliability/v4/gpt-4.1-mini-run-3.json
+++ b/data/reliability/v4/gpt-4.1-mini-run-3.json
@@ -1,0 +1,30 @@
+{
+    "model": "gpt-4.1-mini",
+    "provider": "github",
+    "run": 3,
+    "answers": [
+        "A",
+        "A",
+        "B",
+        "B",
+        "A",
+        "B",
+        "A",
+        "B",
+        "A",
+        "B",
+        "B",
+        "A",
+        "A",
+        "B",
+        "A",
+        "A"
+    ],
+    "type": "PTCF",
+    "dimensions": [
+        2,
+        2,
+        2,
+        3
+    ]
+}


### PR DESCRIPTION
## GPT-4.1-mini v4 Reliability Data

3 fresh reliability runs for **gpt-4.1-mini** via GitHub Models API.

### Results

| Run | Type | Dimensions (S/V/E/F) |
|-----|------|---------------------|
| 1 | PTCF | [3, 2, 2, 3] |
| 2 | PECF | [2, 1, 2, 4] |
| 3 | PTCF | [2, 2, 2, 3] |

### Observations

- Dominant type: **PTCF** (2/3 runs)
- Moderate variability on dimension 1 (sycophantic) and dimension 4 (feature-flag/trunk)
- Dimension 3 (E) is perfectly consistent across all 3 runs (score=2)
- gpt-4.1-mini leans pragmatic (P) and cautious/fence-sitting (T/C) with moderate feature-flag preference (F)

Provider: GitHub Models | Question version: v5.0-beta