### PR TITLE
data: add Gemini 3.6 Flash and GPT-4o Preview to results.json

### DIFF
--- a/data/results.json
+++ b/data/results.json
@@ -802,9 +802,9 @@
           "provider": "anthropic"
         }
       ],
-      "reliability": 1,
-      "consistency": 100,
-      "runs": 1,
+      "reliability": 0.9583,
+      "consistency": 96,
+      "runs": 3,
       "reliabilityRuns": [
         {
           "type": "RTCF",
@@ -812,7 +812,25 @@
             1,
             2,
             4,
+            3
+          ]
+        },
+        {
+          "type": "RTCF",
+          "scores": [
+            1,
+            2,
+            4,
             4
+          ]
+        },
+        {
+          "type": "RECF",
+          "scores": [
+            1,
+            1,
+            4,
+            3
           ]
         }
       ]
@@ -1164,10 +1182,19 @@
       ],
       "model": "claude-sonnet-4.6",
       "provider": "anthropic",
-      "consistency": 100,
-      "runs": 1,
-      "reliability": 1,
+      "consistency": 90,
+      "runs": 3,
+      "reliability": 0.8958,
       "reliabilityRuns": [
+        {
+          "type": "RTCF",
+          "scores": [
+            0,
+            3,
+            3,
+            2
+          ]
+        },
         {
           "type": "RTCF",
           "scores": [
@@ -1175,6 +1202,15 @@
             2,
             3,
             2
+          ]
+        },
+        {
+          "type": "RTCF",
+          "scores": [
+            0,
+            3,
+            4,
+            3
           ]
         }
       ]
@@ -2356,10 +2392,38 @@
       ],
       "model": "gemini-3-flash-preview",
       "provider": "openai",
-      "runs": 1,
-      "reliabilityRuns": 0,
-      "reliability": 0.9375,
-      "consistency": 94
+      "runs": 3,
+      "reliabilityRuns": [
+        {
+          "type": "PTCF",
+          "scores": [
+            3,
+            4,
+            3,
+            2
+          ]
+        },
+        {
+          "type": "RTCF",
+          "scores": [
+            0,
+            3,
+            2,
+            3
+          ]
+        },
+        {
+          "type": "PTCN",
+          "scores": [
+            3,
+            3,
+            3,
+            1
+          ]
+        }
+      ],
+      "reliability": 0.8542,
+      "consistency": 85
     },
     {
       "name": "Gemini 3.1 Pro Preview",
@@ -4013,8 +4077,17 @@
       ],
       "model": "gpt-5.4-mini",
       "provider": "openai",
-      "runs": 1,
+      "runs": 3,
       "reliabilityRuns": [
+        {
+          "type": "PTCF",
+          "scores": [
+            2,
+            3,
+            2,
+            3
+          ]
+        },
         {
           "type": "PTCF",
           "scores": [
@@ -4023,10 +4096,19 @@
             3,
             3
           ]
+        },
+        {
+          "type": "PTCF",
+          "scores": [
+            2,
+            2,
+            3,
+            2
+          ]
         }
       ],
-      "reliability": 1,
-      "consistency": 100
+      "reliability": 0.875,
+      "consistency": 88
     },
     {
       "name": "GPT-5.5",
@@ -4131,11 +4213,38 @@
             3,
             4
           ]
+        },
+        {
+          "type": "RTCN",
+          "scores": [
+            1,
+            4,
+            2,
+            1
+          ]
+        },
+        {
+          "type": "PTCF",
+          "scores": [
+            3,
+            3,
+            2,
+            4
+          ]
+        },
+        {
+          "type": "PTCF",
+          "scores": [
+            2,
+            3,
+            2,
+            3
+          ]
         }
       ],
-      "runs": 4,
-      "reliability": 0.8438,
-      "consistency": 84
+      "runs": 7,
+      "reliability": 0.7411,
+      "consistency": 74
     },
     {
       "name": "GPT-5.6 Luna",
@@ -5854,7 +5963,7 @@
       "model": "Phi-4",
       "provider": "github",
       "desc": "Responsive, thorough, diplomatic, principled. Meticulous, measured, speaks softly and carries a big bibliography.",
-      "reliability": 1,
+      "reliability": 0.7708,
       "reliabilityRuns": [
         {
           "type": "PTDF",
@@ -5864,10 +5973,28 @@
             1,
             2
           ]
+        },
+        {
+          "type": "RTDF",
+          "scores": [
+            1,
+            4,
+            1,
+            2
+          ]
+        },
+        {
+          "type": "PTDF",
+          "scores": [
+            4,
+            3,
+            1,
+            3
+          ]
         }
       ],
-      "consistency": 100,
-      "runs": 1
+      "consistency": 77,
+      "runs": 3
     },
     {
       "name": "Phi 4 Multimodal",
@@ -5918,11 +6045,39 @@
       ],
       "model": "Phi-4-multimodal-instruct",
       "provider": "github",
-      "reliability": 1,
+      "reliability": 0.7692,
       "badge": "https://abti.kagura-agent.com/badge/PTCN",
-      "reliabilityRuns": 0,
-      "consistency": 100,
-      "runs": 1
+      "reliabilityRuns": [
+        {
+          "type": "PTCF",
+          "scores": [
+            3,
+            2,
+            2,
+            4
+          ]
+        },
+        {
+          "type": "PTCF",
+          "scores": [
+            3,
+            2,
+            3,
+            3
+          ]
+        },
+        {
+          "type": "PTCF",
+          "scores": [
+            4,
+            2,
+            2,
+            2
+          ]
+        }
+      ],
+      "consistency": 77,
+      "runs": 3
     },
     {
       "name": "Phi-4 Mini",
@@ -7004,6 +7159,170 @@
       "runs": 3,
       "reliability": 0.8958,
       "consistency": 90
+    },
+    {
+      "name": "Gemini 3.6 Flash",
+      "slug": "gemini-3-6-flash",
+      "url": "",
+      "type": "RTDF",
+      "nick": "The Pathfinder",
+      "testedAt": "2026-07-23T00:00:00.000Z",
+      "scores": [
+        1,
+        3,
+        1,
+        3
+      ],
+      "dimensions": [
+        {
+          "poles": [
+            "P",
+            "R"
+          ],
+          "score": 1,
+          "max": 4
+        },
+        {
+          "poles": [
+            "T",
+            "E"
+          ],
+          "score": 3,
+          "max": 4
+        },
+        {
+          "poles": [
+            "C",
+            "D"
+          ],
+          "score": 1,
+          "max": 4
+        },
+        {
+          "poles": [
+            "F",
+            "N"
+          ],
+          "score": 3,
+          "max": 4
+        }
+      ],
+      "model": "gemini-3.6-flash",
+      "provider": "github",
+      "reliability": 0.9167,
+      "reliabilityRuns": [
+        {
+          "type": "RTDF",
+          "scores": [
+            1,
+            3,
+            1,
+            3
+          ]
+        },
+        {
+          "type": "RTDF",
+          "scores": [
+            1,
+            3,
+            1,
+            4
+          ]
+        },
+        {
+          "type": "RTDF",
+          "scores": [
+            1,
+            2,
+            0,
+            3
+          ]
+        }
+      ],
+      "runs": 3,
+      "consistency": 92
+    },
+    {
+      "name": "GPT-4o Preview",
+      "slug": "gpt-4-o-preview",
+      "url": "",
+      "type": "RTDF",
+      "nick": "The Wayfinder",
+      "testedAt": "2026-07-23T00:00:00.000Z",
+      "scores": [
+        1,
+        2,
+        1,
+        4
+      ],
+      "dimensions": [
+        {
+          "poles": [
+            "P",
+            "R"
+          ],
+          "score": 1,
+          "max": 4
+        },
+        {
+          "poles": [
+            "T",
+            "E"
+          ],
+          "score": 2,
+          "max": 4
+        },
+        {
+          "poles": [
+            "C",
+            "D"
+          ],
+          "score": 1,
+          "max": 4
+        },
+        {
+          "poles": [
+            "F",
+            "N"
+          ],
+          "score": 4,
+          "max": 4
+        }
+      ],
+      "model": "gpt-4-o-preview",
+      "provider": "github",
+      "reliability": 0.875,
+      "reliabilityRuns": [
+        {
+          "type": "PTCF",
+          "scores": [
+            2,
+            4,
+            2,
+            4
+          ]
+        },
+        {
+          "type": "RTDF",
+          "scores": [
+            1,
+            2,
+            0,
+            4
+          ]
+        },
+        {
+          "type": "RTDF",
+          "scores": [
+            1,
+            2,
+            1,
+            4
+          ]
+        }
+      ],
+      "runs": 3,
+      "consistency": 88
     }
   ]
 }


### PR DESCRIPTION
Closes #785. Adds two models that had reliability data but were missing from results.json.

**Added:**
- **Gemini 3.6 Flash** — RTDF [1,3,1,3], 3 reliability runs
- **GPT-4o Preview** — RTDF [1,2,1,4], 3 reliability runs

sync-reliability.js ran successfully after adding entries.