### PR TITLE
data: add MAI-Code-1-Flash test results (PECF) with 3 reliability runs

### DIFF
--- a/cli/bin/abti.js
+++ b/cli/bin/abti.js
@@ -412,7 +412,7 @@ function callLLM(prov, apiKey, mdl, systemPrompt, userMessage, baseUrl, maxToken
 function isReasoningModel(modelName) {
   if (!modelName) return false;
   const lower = modelName.toLowerCase();
-  return /\b(r1|o1|o3|o4|qwq|qwen3|deepseek-r|gemini-3|gpt-5\.\d|gpt-5-mini)\b/.test(lower) || lower.includes('reasoner') || lower.includes('reasoning');
+  return /\b(r1|o1|o3|o4|qwq|qwen3|deepseek-r|gemini-3|gpt-5\.\d|gpt-5-mini|mai-code)\b/.test(lower) || lower.includes('reasoner') || lower.includes('reasoning');
 }
 
 function parseAnswer(response) {

--- a/data/reliability/mai-code-1-flash-picker-run-301.json
+++ b/data/reliability/mai-code-1-flash-picker-run-301.json
@@ -1,0 +1,31 @@
+{
+  "model": "mai-code-1-flash-picker",
+  "provider": "anthropic",
+  "run": 301,
+  "answers": [
+    "A",
+    "B",
+    "A",
+    "A",
+    "B",
+    "B",
+    "A",
+    "B",
+    "A",
+    "B",
+    "B",
+    "A",
+    "A",
+    "A",
+    "B",
+    "B"
+  ],
+  "dimensions": [
+    3,
+    1,
+    2,
+    2
+  ],
+  "type": "PECF",
+  "questionVersion": "5.18-beta"
+}

--- a/data/reliability/mai-code-1-flash-picker-run-302.json
+++ b/data/reliability/mai-code-1-flash-picker-run-302.json
@@ -1,0 +1,31 @@
+{
+  "model": "mai-code-1-flash-picker",
+  "provider": "anthropic",
+  "run": 302,
+  "answers": [
+    "A",
+    "B",
+    "A",
+    "A",
+    "B",
+    "B",
+    "A",
+    "B",
+    "A",
+    "B",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A"
+  ],
+  "dimensions": [
+    3,
+    1,
+    2,
+    4
+  ],
+  "type": "PECF",
+  "questionVersion": "5.18-beta"
+}

--- a/data/reliability/mai-code-1-flash-picker-run-303.json
+++ b/data/reliability/mai-code-1-flash-picker-run-303.json
@@ -1,0 +1,31 @@
+{
+  "model": "mai-code-1-flash-picker",
+  "provider": "anthropic",
+  "run": 303,
+  "answers": [
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "A",
+    "B",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A"
+  ],
+  "dimensions": [
+    3,
+    3,
+    2,
+    4
+  ],
+  "type": "PTCF",
+  "questionVersion": "5.18-beta"
+}

--- a/data/results.json
+++ b/data/results.json
@@ -7323,6 +7323,88 @@
       ],
       "runs": 3,
       "consistency": 88
+    },
+    {
+      "name": "MAI-Code-1-Flash",
+      "slug": "mai-code-1-flash-picker",
+      "url": "",
+      "type": "PECF",
+      "nick": "The Spark",
+      "testedAt": "2026-07-23T03:30:00.000Z",
+      "scores": [
+        3,
+        1,
+        2,
+        2
+      ],
+      "dimensions": [
+        {
+          "poles": [
+            "P",
+            "R"
+          ],
+          "score": 3,
+          "max": 4
+        },
+        {
+          "poles": [
+            "T",
+            "E"
+          ],
+          "score": 1,
+          "max": 4
+        },
+        {
+          "poles": [
+            "C",
+            "D"
+          ],
+          "score": 2,
+          "max": 4
+        },
+        {
+          "poles": [
+            "F",
+            "N"
+          ],
+          "score": 2,
+          "max": 4
+        }
+      ],
+      "model": "mai-code-1-flash-picker",
+      "provider": "openai",
+      "reliability": 0.9167,
+      "reliabilityRuns": [
+        {
+          "type": "PECF",
+          "scores": [
+            3,
+            1,
+            2,
+            2
+          ]
+        },
+        {
+          "type": "PECF",
+          "scores": [
+            3,
+            1,
+            2,
+            4
+          ]
+        },
+        {
+          "type": "PTCF",
+          "scores": [
+            3,
+            3,
+            2,
+            4
+          ]
+        }
+      ],
+      "runs": 3,
+      "consistency": 92
     }
   ]
 }


### PR DESCRIPTION
## Summary

Tested `mai-code-1-flash-picker` (Microsoft AI coding model) via Floway.

**Type: PECF** (The Spark) — Proactive, Efficient, Candid, Flexible

### Reliability
| Run | Type | Scores (P/R, T/E, C/D, F/N) |
|-----|------|------------------------------|
| 301 | PECF | 3, 1, 2, 2 |
| 302 | PECF | 3, 1, 2, 4 |
| 303 | PTCF | 3, 3, 2, 4 |

- Consistency: 92%
- Reliability: 0.9167

### Notes
- `mai-code-1-flash-picker` doesn't support the `temperature` parameter, similar to reasoning models. Added `mai-code` to the `isReasoningModel` regex to handle this.
- This is the first Microsoft MAI-family model in ABTI. Interesting to compare against Phi-4 family (also Microsoft).

Closes #787