### PR TITLE
data: 15 fresh reliability runs (5 models × 3 runs) via Floway SG + rate-limit fix

### DIFF
--- a/data/reliability/claude-haiku-4-5-run-301.json
+++ b/data/reliability/claude-haiku-4-5-run-301.json
@@ -1,0 +1,30 @@
+{
+    "model": "claude-haiku-4-5",
+    "provider": "floway",
+    "run": 301,
+    "answers": [
+        "A",
+        "B",
+        "A",
+        "A",
+        "A",
+        "A",
+        "A",
+        "B",
+        "A",
+        "A",
+        "A",
+        "A",
+        "B",
+        "A",
+        "A",
+        "B"
+    ],
+    "type": "PTCF",
+    "dimensions": [
+        3,
+        3,
+        4,
+        2
+    ]
+}

--- a/data/reliability/claude-haiku-4-5-run-302.json
+++ b/data/reliability/claude-haiku-4-5-run-302.json
@@ -1,0 +1,31 @@
+{
+    "model": "claude-haiku-4-5",
+    "provider": "floway",
+    "run": 302,
+    "answers": [
+        "A",
+        "B",
+        "B",
+        "A",
+        "B",
+        "A",
+        "A",
+        "B",
+        "A",
+        "B",
+        "A",
+        "B",
+        "A",
+        "B",
+        "B",
+        "A",
+        "B"
+    ],
+    "type": "PTCF",
+    "dimensions": [
+        2,
+        2,
+        2,
+        2
+    ]
+}

--- a/data/reliability/claude-haiku-4-5-run-303.json
+++ b/data/reliability/claude-haiku-4-5-run-303.json
@@ -1,0 +1,31 @@
+{
+    "model": "claude-haiku-4-5",
+    "provider": "floway",
+    "run": 303,
+    "answers": [
+        "A",
+        "B",
+        "B",
+        "A",
+        "B",
+        "A",
+        "A",
+        "A",
+        "B",
+        "A",
+        "A",
+        "B",
+        "A",
+        "B",
+        "A",
+        "A",
+        "B"
+    ],
+    "type": "PTCF",
+    "dimensions": [
+        2,
+        3,
+        2,
+        3
+    ]
+}

--- a/data/reliability/gemini-3.5-flash-run-301.json
+++ b/data/reliability/gemini-3.5-flash-run-301.json
@@ -1,0 +1,30 @@
+{
+    "model": "gemini-3.5-flash",
+    "provider": "floway",
+    "run": 301,
+    "answers": [
+        "B",
+        "B",
+        "B",
+        "B",
+        "B",
+        "A",
+        "A",
+        "B",
+        "B",
+        "B",
+        "B",
+        "A",
+        "A",
+        "B",
+        "A",
+        "A"
+    ],
+    "type": "RTDF",
+    "dimensions": [
+        0,
+        2,
+        1,
+        3
+    ]
+}

--- a/data/reliability/gemini-3.5-flash-run-302.json
+++ b/data/reliability/gemini-3.5-flash-run-302.json
@@ -1,0 +1,30 @@
+{
+    "model": "gemini-3.5-flash",
+    "provider": "floway",
+    "run": 302,
+    "answers": [
+        "A",
+        "A",
+        "B",
+        "B",
+        "A",
+        "A",
+        "A",
+        "B",
+        "B",
+        "B",
+        "B",
+        "A",
+        "A",
+        "B",
+        "A",
+        "A"
+    ],
+    "type": "PTDF",
+    "dimensions": [
+        2,
+        3,
+        1,
+        3
+    ]
+}

--- a/data/reliability/gemini-3.5-flash-run-303.json
+++ b/data/reliability/gemini-3.5-flash-run-303.json
@@ -1,0 +1,30 @@
+{
+    "model": "gemini-3.5-flash",
+    "provider": "floway",
+    "run": 303,
+    "answers": [
+        "A",
+        "B",
+        "A",
+        "B",
+        "B",
+        "B",
+        "A",
+        "B",
+        "A",
+        "A",
+        "B",
+        "A",
+        "A",
+        "B",
+        "A",
+        "A"
+    ],
+    "type": "PECF",
+    "dimensions": [
+        2,
+        1,
+        3,
+        3
+    ]
+}

--- a/data/reliability/gemini-3.6-flash-run-301.json
+++ b/data/reliability/gemini-3.6-flash-run-301.json
@@ -1,0 +1,30 @@
+{
+    "model": "gemini-3.6-flash",
+    "provider": "floway",
+    "run": 301,
+    "answers": [
+        "A",
+        "B",
+        "A",
+        "B",
+        "A",
+        "A",
+        "A",
+        "B",
+        "B",
+        "A",
+        "B",
+        "A",
+        "A",
+        "A",
+        "A",
+        "A"
+    ],
+    "type": "PTCF",
+    "dimensions": [
+        2,
+        3,
+        2,
+        4
+    ]
+}

--- a/data/reliability/gemini-3.6-flash-run-302.json
+++ b/data/reliability/gemini-3.6-flash-run-302.json
@@ -1,0 +1,30 @@
+{
+    "model": "gemini-3.6-flash",
+    "provider": "floway",
+    "run": 302,
+    "answers": [
+        "B",
+        "B",
+        "A",
+        "B",
+        "A",
+        "A",
+        "A",
+        "B",
+        "B",
+        "A",
+        "B",
+        "A",
+        "A",
+        "B",
+        "A",
+        "A"
+    ],
+    "type": "RTCF",
+    "dimensions": [
+        1,
+        3,
+        2,
+        3
+    ]
+}

--- a/data/reliability/gemini-3.6-flash-run-303.json
+++ b/data/reliability/gemini-3.6-flash-run-303.json
@@ -1,0 +1,30 @@
+{
+    "model": "gemini-3.6-flash",
+    "provider": "floway",
+    "run": 303,
+    "answers": [
+        "A",
+        "B",
+        "A",
+        "B",
+        "A",
+        "B",
+        "A",
+        "B",
+        "A",
+        "B",
+        "B",
+        "A",
+        "A",
+        "A",
+        "A",
+        "A"
+    ],
+    "type": "PTCF",
+    "dimensions": [
+        2,
+        2,
+        2,
+        4
+    ]
+}

--- a/data/reliability/gpt-4o-mini-run-301.json
+++ b/data/reliability/gpt-4o-mini-run-301.json
@@ -1,0 +1,30 @@
+{
+    "model": "gpt-4o-mini",
+    "provider": "floway",
+    "run": 301,
+    "answers": [
+        "B",
+        "A",
+        "A",
+        "A",
+        "A",
+        "B",
+        "A",
+        "A",
+        "B",
+        "B",
+        "B",
+        "A",
+        "A",
+        "A",
+        "A",
+        "B"
+    ],
+    "type": "PTDF",
+    "dimensions": [
+        3,
+        3,
+        1,
+        3
+    ]
+}

--- a/data/reliability/gpt-4o-mini-run-302.json
+++ b/data/reliability/gpt-4o-mini-run-302.json
@@ -1,0 +1,30 @@
+{
+    "model": "gpt-4o-mini",
+    "provider": "floway",
+    "run": 302,
+    "answers": [
+        "A",
+        "A",
+        "A",
+        "A",
+        "A",
+        "A",
+        "A",
+        "A",
+        "B",
+        "B",
+        "A",
+        "B",
+        "A",
+        "A",
+        "A",
+        "B"
+    ],
+    "type": "PTDF",
+    "dimensions": [
+        4,
+        4,
+        1,
+        3
+    ]
+}

--- a/data/reliability/gpt-4o-mini-run-303.json
+++ b/data/reliability/gpt-4o-mini-run-303.json
@@ -1,0 +1,30 @@
+{
+    "model": "gpt-4o-mini",
+    "provider": "floway",
+    "run": 303,
+    "answers": [
+        "B",
+        "A",
+        "A",
+        "A",
+        "B",
+        "A",
+        "A",
+        "B",
+        "B",
+        "B",
+        "B",
+        "B",
+        "A",
+        "A",
+        "A",
+        "B"
+    ],
+    "type": "PTDF",
+    "dimensions": [
+        3,
+        2,
+        0,
+        3
+    ]
+}

--- a/data/reliability/gpt-5.4-mini-run-301.json
+++ b/data/reliability/gpt-5.4-mini-run-301.json
@@ -1,0 +1,30 @@
+{
+    "model": "gpt-5.4-mini",
+    "provider": "floway",
+    "run": 301,
+    "answers": [
+        "A",
+        "A",
+        "A",
+        "A",
+        "A",
+        "A",
+        "A",
+        "B",
+        "B",
+        "A",
+        "B",
+        "A",
+        "A",
+        "B",
+        "B",
+        "B"
+    ],
+    "type": "PTCN",
+    "dimensions": [
+        4,
+        3,
+        2,
+        1
+    ]
+}

--- a/data/reliability/gpt-5.4-mini-run-302.json
+++ b/data/reliability/gpt-5.4-mini-run-302.json
@@ -1,0 +1,30 @@
+{
+    "model": "gpt-5.4-mini",
+    "provider": "floway",
+    "run": 302,
+    "answers": [
+        "A",
+        "B",
+        "A",
+        "A",
+        "A",
+        "A",
+        "A",
+        "B",
+        "B",
+        "B",
+        "B",
+        "B",
+        "A",
+        "A",
+        "B",
+        "A"
+    ],
+    "type": "PTDF",
+    "dimensions": [
+        3,
+        3,
+        0,
+        3
+    ]
+}

--- a/data/reliability/gpt-5.4-mini-run-303.json
+++ b/data/reliability/gpt-5.4-mini-run-303.json
@@ -1,0 +1,30 @@
+{
+    "model": "gpt-5.4-mini",
+    "provider": "floway",
+    "run": 303,
+    "answers": [
+        "A",
+        "A",
+        "A",
+        "B",
+        "A",
+        "A",
+        "A",
+        "B",
+        "B",
+        "A",
+        "B",
+        "B",
+        "A",
+        "A",
+        "B",
+        "A"
+    ],
+    "type": "PTDF",
+    "dimensions": [
+        3,
+        3,
+        1,
+        3
+    ]
+}

--- a/resume-reliability.sh
+++ b/resume-reliability.sh
@@ -522,10 +522,15 @@ with open('$STATE_FILE', 'w') as f:
 "
     echo "  State saved (${QNUM}/16 done)"
 
-    # Wait between questions (skip after last)
+    # Wait between questions (skip after last; skip for floway which has no rate limit)
     if [ "$QNUM" -lt 16 ]; then
-      echo "  Waiting 65s for rate limit..."
-      sleep 65
+      if [ "$PROVIDER" = "floway" ]; then
+        echo "  Floway: no rate limit wait needed"
+        sleep 2
+      else
+        echo "  Waiting 65s for rate limit..."
+        sleep 65
+      fi
     fi
   done
 fi


### PR DESCRIPTION
## Summary

15 fresh reliability runs (5 models × 3 runs each) via Floway SG provider.

## Models tested

| Model | Run 301 | Run 302 | Run 303 | Consistency |
|-------|---------|---------|---------|-------------|
| claude-haiku-4-5 | PTCF [3,3,4,2] | PTCF [2,2,2,2] | PTCF [2,3,2,3] | ✅ Perfect (3/3 PTCF) |
| gpt-4o-mini | PTDF [3,3,1,3] | PTDF [4,4,1,3] | PTDF [3,2,0,3] | ✅ Perfect (3/3 PTDF) |
| gemini-3.5-flash | RTDF [0,2,1,3] | PTDF [2,3,1,3] | PECF [2,1,3,3] | ⚠️ Variable |
| gemini-3.6-flash | PTCF [2,3,2,4] | RTCF [1,3,2,3] | PTCF [2,2,2,4] | Good (2/3 PTCF) |
| gpt-5.4-mini | PTCN [4,3,2,1] | PTDF [3,3,0,3] | PTDF [3,3,1,3] | Good (2/3 PTDF) |

## Script fix
- Skip 65s rate-limit wait for Floway provider (Floway has no per-request rate limiting, was unnecessarily slow)

## Important finding: script-API question sync issue
During this work, discovered that `resume-reliability.sh` has **hardcoded questions that don't match** `api/v1/abti.json`. The script's Q13 is the code ownership question, while the API's Q13 is the sprint/Kanban question (just redesigned in #795). Filed #797 to track the sync.

These runs are valid reliability data for the script's question set (questionVersion 5.0-beta).

Refs #796