### PR TITLE
ops: add deploy drift check script and CI deploy workflow

### DIFF
--- a/.github/workflows/deploy-vm1.yml
+++ b/.github/workflows/deploy-vm1.yml
@@ -1,0 +1,22 @@
+# VM1 deployment — requires secrets VM1_HOST and VM1_SSH_KEY
+# See issue #128 for secrets configuration
+name: Deploy to VM1
+
+on:
+  push:
+    branches: [master]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy via SSH
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.VM1_HOST }}
+          username: azureuser
+          key: ${{ secrets.VM1_SSH_KEY }}
+          script: |
+            cd /home/azureuser/abti
+            git pull origin master
+            sudo systemctl restart abti-api

--- a/scripts/deploy-check.sh
+++ b/scripts/deploy-check.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SSH_USER="azureuser"
+SSH_HOST="74.226.216.75"
+SSH_KEY="${VM1_SSH_KEY:-$HOME/.ssh/vm1.pem}"
+REMOTE_DIR="/home/azureuser/abti"
+REPO="git@github.com:kagura-agent/abti.git"
+
+ssh_cmd() {
+  ssh -i "$SSH_KEY" -o StrictHostKeyChecking=accept-new -o ConnectTimeout=10 "${SSH_USER}@${SSH_HOST}" "$@"
+}
+
+echo "Fetching deployed commit from VM1..."
+deployed=$(ssh_cmd "cd ${REMOTE_DIR} && git rev-parse HEAD") || {
+  echo "ERROR: SSH to VM1 failed"
+  exit 1
+}
+echo "Deployed: ${deployed:0:12}"
+
+echo "Fetching latest origin/master..."
+latest=$(git ls-remote "$REPO" refs/heads/master | cut -f1)
+echo "Latest:   ${latest:0:12}"
+
+if [ "$deployed" = "$latest" ]; then
+  echo "Production is in sync."
+  exit 0
+fi
+
+echo "Production is behind — deploying..."
+ssh_cmd "cd ${REMOTE_DIR} && git pull origin master && sudo systemctl restart abti-api" || {
+  echo "ERROR: deploy failed"
+  exit 1
+}
+
+echo "Deployed ${latest:0:12} successfully."


### PR DESCRIPTION
## What

Adds two deployment automation tools:

1. **`scripts/deploy-check.sh`** — Local drift detection script (interim workaround)
   - SSHes to VM1 and compares deployed commit with latest `origin/master`
   - Auto-deploys (git pull + systemctl restart) if production is behind
   - Clear status output: in sync / deploying / deployed
   - Exit 0 on success/in-sync, exit 1 on SSH failure

2. **`.github/workflows/deploy-vm1.yml`** — GitHub Actions auto-deploy on master push
   - Uses `appleboy/ssh-action@v1`
   - Requires `VM1_HOST` and `VM1_SSH_KEY` secrets (see #128)
   - Ready to activate once secrets are configured

## Why

Production was 2.5 weeks behind master (#804). Users were getting stale questions.
The local script provides immediate protection; the CI workflow provides the long-term solution.

## Testing

- Ran `scripts/deploy-check.sh` — confirmed production is in sync (833fcdc)
- Script correctly detects in-sync state and exits 0

Closes #804