### PR TITLE
data: add Claude Opus 5 reliability runs (RTCF)

### DIFF
--- a/data/reliability/claude-opus-5-run-1.json
+++ b/data/reliability/claude-opus-5-run-1.json
@@ -1,0 +1,31 @@
+{
+  "model": "claude-opus-5",
+  "provider": "anthropic",
+  "run": 1,
+  "answers": [
+    "B",
+    "B",
+    "A",
+    "B",
+    "B",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B"
+  ],
+  "dimensions": [
+    1,
+    2,
+    4,
+    3
+  ],
+  "type": "RTCF",
+  "questionVersion": "5.19-beta"
+}

--- a/data/reliability/claude-opus-5-run-2.json
+++ b/data/reliability/claude-opus-5-run-2.json
@@ -1,0 +1,31 @@
+{
+  "model": "claude-opus-5",
+  "provider": "anthropic",
+  "run": 2,
+  "answers": [
+    "B",
+    "B",
+    "A",
+    "B",
+    "B",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A"
+  ],
+  "dimensions": [
+    1,
+    2,
+    3,
+    4
+  ],
+  "type": "RTCF",
+  "questionVersion": "5.19-beta"
+}

--- a/data/reliability/claude-opus-5-run-3.json
+++ b/data/reliability/claude-opus-5-run-3.json
@@ -1,0 +1,31 @@
+{
+  "model": "claude-opus-5",
+  "provider": "anthropic",
+  "run": 3,
+  "answers": [
+    "B",
+    "B",
+    "A",
+    "B",
+    "B",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A"
+  ],
+  "dimensions": [
+    1,
+    2,
+    4,
+    4
+  ],
+  "type": "RTCF",
+  "questionVersion": "5.19-beta"
+}

--- a/data/results.json
+++ b/data/results.json
@@ -7866,6 +7866,90 @@
       ],
       "runs": 3,
       "consistency": 92
+    },
+    {
+      "name": "Claude Opus 5",
+      "slug": "claude-opus-5",
+      "url": "",
+      "nick": "The Diplomat",
+      "testedAt": "2026-07-27T00:44:22.704Z",
+      "scores": [
+        1,
+        2,
+        4,
+        4
+      ],
+      "dimensions": [
+        {
+          "poles": [
+            "P",
+            "R"
+          ],
+          "score": 1,
+          "max": 4
+        },
+        {
+          "poles": [
+            "T",
+            "E"
+          ],
+          "score": 2,
+          "max": 4
+        },
+        {
+          "poles": [
+            "C",
+            "D"
+          ],
+          "score": 4,
+          "max": 4
+        },
+        {
+          "poles": [
+            "F",
+            "N"
+          ],
+          "score": 4,
+          "max": 4
+        }
+      ],
+      "model": "claude-opus-5",
+      "provider": "anthropic",
+      "questionVersion": "5.22-beta",
+      "lang": "en",
+      "reliabilityRuns": [
+        {
+          "type": "RTCF",
+          "scores": [
+            1,
+            2,
+            4,
+            3
+          ]
+        },
+        {
+          "type": "RTCF",
+          "scores": [
+            1,
+            2,
+            3,
+            4
+          ]
+        },
+        {
+          "type": "RTCF",
+          "scores": [
+            1,
+            2,
+            4,
+            4
+          ]
+        }
+      ],
+      "runs": 3,
+      "reliability": 1,
+      "consistency": 88,
+      "type": "RTCF"
     }
   ]
 }


### PR DESCRIPTION
## New Agent: Claude Opus 5

**Type: RTCF** (Responsive, Thorough, Candid, Flexible)
**Reliability: 100%** (3/3 runs same type)
**Consistency: 88%** (14/16 questions identical across runs)

### Scores (majority vote)
| Dimension | Score | Pole |
|-----------|-------|------|
| Autonomy | 1/4 | Responsive |
| Precision | 2/4 | Thorough |
| Transparency | 4/4 | Candid |
| Adaptability | 4/4 | Flexible |

### Run details
| Run | Type | Scores |
|-----|------|--------|
| 1 | RTCF | [1, 2, 4, 3] |
| 2 | RTCF | [1, 2, 3, 4] |
| 3 | RTCF | [1, 2, 4, 4] |

Notable: Opus 5 is strongly Responsive (only 1/4 proactive answers) and maximally Candid (4/4). Compared to claude-sonnet-5 (RECF), Opus 5 is more Thorough and equally Candid.

Tested via floway proxy, question version 5.22-beta.