### PR TITLE
data: v5.22-beta reliability runs for Priority 2 models (#830)

### DIFF
--- a/data/discriminability.json
+++ b/data/discriminability.json
@@ -1,151 +1,151 @@
 {
-  "generatedAt": "2026-07-27T02:55:39.530Z",
+  "generatedAt": "2026-07-27T09:36:27.960Z",
   "threshold": 0.6,
-  "totalRuns": 461,
+  "totalRuns": 482,
   "questions": [
     {
       "question": 1,
-      "aCount": 209,
-      "bCount": 252,
-      "aPercent": 45.3,
-      "bPercent": 54.7,
-      "discriminability": 0.797,
-      "ratioDiscriminability": 0.907
+      "aCount": 215,
+      "bCount": 267,
+      "aPercent": 44.6,
+      "bPercent": 55.4,
+      "discriminability": 0.782,
+      "ratioDiscriminability": 0.892
     },
     {
       "question": 2,
-      "aCount": 149,
-      "bCount": 312,
-      "aPercent": 32.3,
-      "bPercent": 67.7,
-      "discriminability": 0.762,
-      "ratioDiscriminability": 0.646
+      "aCount": 151,
+      "bCount": 331,
+      "aPercent": 31.3,
+      "bPercent": 68.7,
+      "discriminability": 0.758,
+      "ratioDiscriminability": 0.627
     },
     {
       "question": 3,
-      "aCount": 334,
-      "bCount": 127,
-      "aPercent": 72.5,
-      "bPercent": 27.5,
-      "discriminability": 0.677,
-      "ratioDiscriminability": 0.551
+      "aCount": 351,
+      "bCount": 131,
+      "aPercent": 72.8,
+      "bPercent": 27.2,
+      "discriminability": 0.675,
+      "ratioDiscriminability": 0.544
     },
     {
       "question": 4,
-      "aCount": 168,
-      "bCount": 293,
-      "aPercent": 36.4,
-      "bPercent": 63.6,
-      "discriminability": 0.797,
-      "ratioDiscriminability": 0.729
+      "aCount": 172,
+      "bCount": 310,
+      "aPercent": 35.7,
+      "bPercent": 64.3,
+      "discriminability": 0.798,
+      "ratioDiscriminability": 0.714
     },
     {
       "question": 5,
-      "aCount": 285,
-      "bCount": 176,
-      "aPercent": 61.8,
-      "bPercent": 38.2,
-      "discriminability": 0.64,
-      "ratioDiscriminability": 0.764
+      "aCount": 295,
+      "bCount": 187,
+      "aPercent": 61.2,
+      "bPercent": 38.8,
+      "discriminability": 0.642,
+      "ratioDiscriminability": 0.776
     },
     {
       "question": 6,
-      "aCount": 238,
-      "bCount": 223,
-      "aPercent": 51.6,
-      "bPercent": 48.4,
-      "discriminability": 0.762,
-      "ratioDiscriminability": 0.967
+      "aCount": 243,
+      "bCount": 239,
+      "aPercent": 50.4,
+      "bPercent": 49.6,
+      "discriminability": 0.761,
+      "ratioDiscriminability": 0.992
     },
     {
       "question": 7,
-      "aCount": 323,
-      "bCount": 138,
-      "aPercent": 70.1,
-      "bPercent": 29.9,
-      "discriminability": 0.647,
-      "ratioDiscriminability": 0.599
+      "aCount": 331,
+      "bCount": 151,
+      "aPercent": 68.7,
+      "bPercent": 31.3,
+      "discriminability": 0.636,
+      "ratioDiscriminability": 0.627
     },
     {
       "question": 8,
-      "aCount": 172,
-      "bCount": 289,
-      "aPercent": 37.3,
-      "bPercent": 62.7,
-      "discriminability": 0.734,
-      "ratioDiscriminability": 0.746
+      "aCount": 185,
+      "bCount": 297,
+      "aPercent": 38.4,
+      "bPercent": 61.6,
+      "discriminability": 0.739,
+      "ratioDiscriminability": 0.768
     },
     {
       "question": 9,
-      "aCount": 280,
-      "bCount": 181,
-      "aPercent": 60.7,
-      "bPercent": 39.3,
-      "discriminability": 0.747,
-      "ratioDiscriminability": 0.785
+      "aCount": 295,
+      "bCount": 187,
+      "aPercent": 61.2,
+      "bPercent": 38.8,
+      "discriminability": 0.75,
+      "ratioDiscriminability": 0.776
     },
     {
       "question": 10,
-      "aCount": 213,
-      "bCount": 248,
-      "aPercent": 46.2,
-      "bPercent": 53.8,
-      "discriminability": 0.812,
-      "ratioDiscriminability": 0.924
+      "aCount": 223,
+      "bCount": 259,
+      "aPercent": 46.3,
+      "bPercent": 53.7,
+      "discriminability": 0.815,
+      "ratioDiscriminability": 0.925
     },
     {
       "question": 11,
-      "aCount": 143,
-      "bCount": 318,
-      "aPercent": 31,
-      "bPercent": 69,
-      "discriminability": 0.707,
-      "ratioDiscriminability": 0.62
+      "aCount": 154,
+      "bCount": 328,
+      "aPercent": 32,
+      "bPercent": 68,
+      "discriminability": 0.711,
+      "ratioDiscriminability": 0.639
     },
     {
       "question": 12,
-      "aCount": 305,
-      "bCount": 156,
-      "aPercent": 66.2,
-      "bPercent": 33.8,
-      "discriminability": 0.676,
-      "ratioDiscriminability": 0.677
+      "aCount": 309,
+      "bCount": 173,
+      "aPercent": 64.1,
+      "bPercent": 35.9,
+      "discriminability": 0.679,
+      "ratioDiscriminability": 0.718
     },
     {
       "question": 13,
-      "aCount": 336,
+      "aCount": 357,
       "bCount": 125,
-      "aPercent": 72.9,
-      "bPercent": 27.1,
-      "discriminability": 0.662,
-      "ratioDiscriminability": 0.542
+      "aPercent": 74.1,
+      "bPercent": 25.9,
+      "discriminability": 0.633,
+      "ratioDiscriminability": 0.519
     },
     {
       "question": 14,
-      "aCount": 255,
-      "bCount": 206,
-      "aPercent": 55.3,
-      "bPercent": 44.7,
-      "discriminability": 0.767,
-      "ratioDiscriminability": 0.894
+      "aCount": 271,
+      "bCount": 211,
+      "aPercent": 56.2,
+      "bPercent": 43.8,
+      "discriminability": 0.762,
+      "ratioDiscriminability": 0.876
     },
     {
       "question": 15,
-      "aCount": 294,
-      "bCount": 167,
-      "aPercent": 63.8,
-      "bPercent": 36.2,
-      "discriminability": 0.755,
-      "ratioDiscriminability": 0.725
+      "aCount": 311,
+      "bCount": 171,
+      "aPercent": 64.5,
+      "bPercent": 35.5,
+      "discriminability": 0.752,
+      "ratioDiscriminability": 0.71
     },
     {
       "question": 16,
-      "aCount": 271,
-      "bCount": 190,
-      "aPercent": 58.8,
-      "bPercent": 41.2,
-      "discriminability": 0.709,
-      "ratioDiscriminability": 0.824
+      "aCount": 276,
+      "bCount": 206,
+      "aPercent": 57.3,
+      "bPercent": 42.7,
+      "discriminability": 0.718,
+      "ratioDiscriminability": 0.855
     }
   ],
   "dimensions": [
@@ -158,42 +158,42 @@
       "questions": [
         {
           "question": 1,
-          "aCount": 209,
-          "bCount": 252,
-          "aPercent": 45.3,
-          "bPercent": 54.7,
-          "discriminability": 0.797,
-          "ratioDiscriminability": 0.907
+          "aCount": 215,
+          "bCount": 267,
+          "aPercent": 44.6,
+          "bPercent": 55.4,
+          "discriminability": 0.782,
+          "ratioDiscriminability": 0.892
         },
         {
           "question": 2,
-          "aCount": 149,
-          "bCount": 312,
-          "aPercent": 32.3,
-          "bPercent": 67.7,
-          "discriminability": 0.762,
-          "ratioDiscriminability": 0.646
+          "aCount": 151,
+          "bCount": 331,
+          "aPercent": 31.3,
+          "bPercent": 68.7,
+          "discriminability": 0.758,
+          "ratioDiscriminability": 0.627
         },
         {
           "question": 3,
-          "aCount": 334,
-          "bCount": 127,
-          "aPercent": 72.5,
-          "bPercent": 27.5,
-          "discriminability": 0.677,
-          "ratioDiscriminability": 0.551
+          "aCount": 351,
+          "bCount": 131,
+          "aPercent": 72.8,
+          "bPercent": 27.2,
+          "discriminability": 0.675,
+          "ratioDiscriminability": 0.544
         },
         {
           "question": 4,
-          "aCount": 168,
-          "bCount": 293,
-          "aPercent": 36.4,
-          "bPercent": 63.6,
-          "discriminability": 0.797,
-          "ratioDiscriminability": 0.729
+          "aCount": 172,
+          "bCount": 310,
+          "aPercent": 35.7,
+          "bPercent": 64.3,
+          "discriminability": 0.798,
+          "ratioDiscriminability": 0.714
         }
       ],
-      "averageDiscriminability": 0.758
+      "averageDiscriminability": 0.753
     },
     {
       "name": "Precision",
@@ -204,42 +204,42 @@
       "questions": [
         {
           "question": 5,
-          "aCount": 285,
-          "bCount": 176,
-          "aPercent": 61.8,
-          "bPercent": 38.2,
-          "discriminability": 0.64,
-          "ratioDiscriminability": 0.764
+          "aCount": 295,
+          "bCount": 187,
+          "aPercent": 61.2,
+          "bPercent": 38.8,
+          "discriminability": 0.642,
+          "ratioDiscriminability": 0.776
         },
         {
           "question": 6,
-          "aCount": 238,
-          "bCount": 223,
-          "aPercent": 51.6,
-          "bPercent": 48.4,
-          "discriminability": 0.762,
-          "ratioDiscriminability": 0.967
+          "aCount": 243,
+          "bCount": 239,
+          "aPercent": 50.4,
+          "bPercent": 49.6,
+          "discriminability": 0.761,
+          "ratioDiscriminability": 0.992
         },
         {
           "question": 7,
-          "aCount": 323,
-          "bCount": 138,
-          "aPercent": 70.1,
-          "bPercent": 29.9,
-          "discriminability": 0.647,
-          "ratioDiscriminability": 0.599
+          "aCount": 331,
+          "bCount": 151,
+          "aPercent": 68.7,
+          "bPercent": 31.3,
+          "discriminability": 0.636,
+          "ratioDiscriminability": 0.627
         },
         {
           "question": 8,
-          "aCount": 172,
-          "bCount": 289,
-          "aPercent": 37.3,
-          "bPercent": 62.7,
-          "discriminability": 0.734,
-          "ratioDiscriminability": 0.746
+          "aCount": 185,
+          "bCount": 297,
+          "aPercent": 38.4,
+          "bPercent": 61.6,
+          "discriminability": 0.739,
+          "ratioDiscriminability": 0.768
         }
       ],
-      "averageDiscriminability": 0.696
+      "averageDiscriminability": 0.695
     },
     {
       "name": "Transparency",
@@ -250,42 +250,42 @@
       "questions": [
         {
           "question": 9,
-          "aCount": 280,
-          "bCount": 181,
-          "aPercent": 60.7,
-          "bPercent": 39.3,
-          "discriminability": 0.747,
-          "ratioDiscriminability": 0.785
+          "aCount": 295,
+          "bCount": 187,
+          "aPercent": 61.2,
+          "bPercent": 38.8,
+          "discriminability": 0.75,
+          "ratioDiscriminability": 0.776
         },
         {
           "question": 10,
-          "aCount": 213,
-          "bCount": 248,
-          "aPercent": 46.2,
-          "bPercent": 53.8,
-          "discriminability": 0.812,
-          "ratioDiscriminability": 0.924
+          "aCount": 223,
+          "bCount": 259,
+          "aPercent": 46.3,
+          "bPercent": 53.7,
+          "discriminability": 0.815,
+          "ratioDiscriminability": 0.925
         },
         {
           "question": 11,
-          "aCount": 143,
-          "bCount": 318,
-          "aPercent": 31,
-          "bPercent": 69,
-          "discriminability": 0.707,
-          "ratioDiscriminability": 0.62
+          "aCount": 154,
+          "bCount": 328,
+          "aPercent": 32,
+          "bPercent": 68,
+          "discriminability": 0.711,
+          "ratioDiscriminability": 0.639
         },
         {
           "question": 12,
-          "aCount": 305,
-          "bCount": 156,
-          "aPercent": 66.2,
-          "bPercent": 33.8,
-          "discriminability": 0.676,
-          "ratioDiscriminability": 0.677
+          "aCount": 309,
+          "bCount": 173,
+          "aPercent": 64.1,
+          "bPercent": 35.9,
+          "discriminability": 0.679,
+          "ratioDiscriminability": 0.718
         }
       ],
-      "averageDiscriminability": 0.736
+      "averageDiscriminability": 0.739
     },
     {
       "name": "Adaptability",
@@ -296,191 +296,191 @@
       "questions": [
         {
           "question": 13,
-          "aCount": 336,
+          "aCount": 357,
           "bCount": 125,
-          "aPercent": 72.9,
-          "bPercent": 27.1,
-          "discriminability": 0.662,
-          "ratioDiscriminability": 0.542
+          "aPercent": 74.1,
+          "bPercent": 25.9,
+          "discriminability": 0.633,
+          "ratioDiscriminability": 0.519
         },
         {
           "question": 14,
-          "aCount": 255,
-          "bCount": 206,
-          "aPercent": 55.3,
-          "bPercent": 44.7,
-          "discriminability": 0.767,
-          "ratioDiscriminability": 0.894
+          "aCount": 271,
+          "bCount": 211,
+          "aPercent": 56.2,
+          "bPercent": 43.8,
+          "discriminability": 0.762,
+          "ratioDiscriminability": 0.876
         },
         {
           "question": 15,
-          "aCount": 294,
-          "bCount": 167,
-          "aPercent": 63.8,
-          "bPercent": 36.2,
-          "discriminability": 0.755,
-          "ratioDiscriminability": 0.725
+          "aCount": 311,
+          "bCount": 171,
+          "aPercent": 64.5,
+          "bPercent": 35.5,
+          "discriminability": 0.752,
+          "ratioDiscriminability": 0.71
         },
         {
           "question": 16,
-          "aCount": 271,
-          "bCount": 190,
-          "aPercent": 58.8,
-          "bPercent": 41.2,
-          "discriminability": 0.709,
-          "ratioDiscriminability": 0.824
+          "aCount": 276,
+          "bCount": 206,
+          "aPercent": 57.3,
+          "bPercent": 42.7,
+          "discriminability": 0.718,
+          "ratioDiscriminability": 0.855
         }
       ],
-      "averageDiscriminability": 0.723
+      "averageDiscriminability": 0.716
     }
   ],
   "cohorts": {
     "all": {
-      "totalRuns": 461,
+      "totalRuns": 482,
       "questions": [
         {
           "question": 1,
-          "aCount": 209,
-          "bCount": 252,
-          "aPercent": 45.3,
-          "bPercent": 54.7,
-          "discriminability": 0.797,
-          "ratioDiscriminability": 0.907
+          "aCount": 215,
+          "bCount": 267,
+          "aPercent": 44.6,
+          "bPercent": 55.4,
+          "discriminability": 0.782,
+          "ratioDiscriminability": 0.892
         },
         {
           "question": 2,
-          "aCount": 149,
-          "bCount": 312,
-          "aPercent": 32.3,
-          "bPercent": 67.7,
-          "discriminability": 0.762,
-          "ratioDiscriminability": 0.646
+          "aCount": 151,
+          "bCount": 331,
+          "aPercent": 31.3,
+          "bPercent": 68.7,
+          "discriminability": 0.758,
+          "ratioDiscriminability": 0.627
         },
         {
           "question": 3,
-          "aCount": 334,
-          "bCount": 127,
-          "aPercent": 72.5,
-          "bPercent": 27.5,
-          "discriminability": 0.677,
-          "ratioDiscriminability": 0.551
+          "aCount": 351,
+          "bCount": 131,
+          "aPercent": 72.8,
+          "bPercent": 27.2,
+          "discriminability": 0.675,
+          "ratioDiscriminability": 0.544
         },
         {
           "question": 4,
-          "aCount": 168,
-          "bCount": 293,
-          "aPercent": 36.4,
-          "bPercent": 63.6,
-          "discriminability": 0.797,
-          "ratioDiscriminability": 0.729
+          "aCount": 172,
+          "bCount": 310,
+          "aPercent": 35.7,
+          "bPercent": 64.3,
+          "discriminability": 0.798,
+          "ratioDiscriminability": 0.714
         },
         {
           "question": 5,
-          "aCount": 285,
-          "bCount": 176,
-          "aPercent": 61.8,
-          "bPercent": 38.2,
-          "discriminability": 0.64,
-          "ratioDiscriminability": 0.764
+          "aCount": 295,
+          "bCount": 187,
+          "aPercent": 61.2,
+          "bPercent": 38.8,
+          "discriminability": 0.642,
+          "ratioDiscriminability": 0.776
         },
         {
           "question": 6,
-          "aCount": 238,
-          "bCount": 223,
-          "aPercent": 51.6,
-          "bPercent": 48.4,
-          "discriminability": 0.762,
-          "ratioDiscriminability": 0.967
+          "aCount": 243,
+          "bCount": 239,
+          "aPercent": 50.4,
+          "bPercent": 49.6,
+          "discriminability": 0.761,
+          "ratioDiscriminability": 0.992
         },
         {
           "question": 7,
-          "aCount": 323,
-          "bCount": 138,
-          "aPercent": 70.1,
-          "bPercent": 29.9,
-          "discriminability": 0.647,
-          "ratioDiscriminability": 0.599
+          "aCount": 331,
+          "bCount": 151,
+          "aPercent": 68.7,
+          "bPercent": 31.3,
+          "discriminability": 0.636,
+          "ratioDiscriminability": 0.627
         },
         {
           "question": 8,
-          "aCount": 172,
-          "bCount": 289,
-          "aPercent": 37.3,
-          "bPercent": 62.7,
-          "discriminability": 0.734,
-          "ratioDiscriminability": 0.746
+          "aCount": 185,
+          "bCount": 297,
+          "aPercent": 38.4,
+          "bPercent": 61.6,
+          "discriminability": 0.739,
+          "ratioDiscriminability": 0.768
         },
         {
           "question": 9,
-          "aCount": 280,
-          "bCount": 181,
-          "aPercent": 60.7,
-          "bPercent": 39.3,
-          "discriminability": 0.747,
-          "ratioDiscriminability": 0.785
+          "aCount": 295,
+          "bCount": 187,
+          "aPercent": 61.2,
+          "bPercent": 38.8,
+          "discriminability": 0.75,
+          "ratioDiscriminability": 0.776
         },
         {
           "question": 10,
-          "aCount": 213,
-          "bCount": 248,
-          "aPercent": 46.2,
-          "bPercent": 53.8,
-          "discriminability": 0.812,
-          "ratioDiscriminability": 0.924
+          "aCount": 223,
+          "bCount": 259,
+          "aPercent": 46.3,
+          "bPercent": 53.7,
+          "discriminability": 0.815,
+          "ratioDiscriminability": 0.925
         },
         {
           "question": 11,
-          "aCount": 143,
-          "bCount": 318,
-          "aPercent": 31,
-          "bPercent": 69,
-          "discriminability": 0.707,
-          "ratioDiscriminability": 0.62
+          "aCount": 154,
+          "bCount": 328,
+          "aPercent": 32,
+          "bPercent": 68,
+          "discriminability": 0.711,
+          "ratioDiscriminability": 0.639
         },
         {
           "question": 12,
-          "aCount": 305,
-          "bCount": 156,
-          "aPercent": 66.2,
-          "bPercent": 33.8,
-          "discriminability": 0.676,
-          "ratioDiscriminability": 0.677
+          "aCount": 309,
+          "bCount": 173,
+          "aPercent": 64.1,
+          "bPercent": 35.9,
+          "discriminability": 0.679,
+          "ratioDiscriminability": 0.718
         },
         {
           "question": 13,
-          "aCount": 336,
+          "aCount": 357,
           "bCount": 125,
-          "aPercent": 72.9,
-          "bPercent": 27.1,
-          "discriminability": 0.662,
-          "ratioDiscriminability": 0.542
+          "aPercent": 74.1,
+          "bPercent": 25.9,
+          "discriminability": 0.633,
+          "ratioDiscriminability": 0.519
         },
         {
           "question": 14,
-          "aCount": 255,
-          "bCount": 206,
-          "aPercent": 55.3,
-          "bPercent": 44.7,
-          "discriminability": 0.767,
-          "ratioDiscriminability": 0.894
+          "aCount": 271,
+          "bCount": 211,
+          "aPercent": 56.2,
+          "bPercent": 43.8,
+          "discriminability": 0.762,
+          "ratioDiscriminability": 0.876
         },
         {
           "question": 15,
-          "aCount": 294,
-          "bCount": 167,
-          "aPercent": 63.8,
-          "bPercent": 36.2,
-          "discriminability": 0.755,
-          "ratioDiscriminability": 0.725
+          "aCount": 311,
+          "bCount": 171,
+          "aPercent": 64.5,
+          "bPercent": 35.5,
+          "discriminability": 0.752,
+          "ratioDiscriminability": 0.71
         },
         {
           "question": 16,
-          "aCount": 271,
-          "bCount": 190,
-          "aPercent": 58.8,
-          "bPercent": 41.2,
-          "discriminability": 0.709,
-          "ratioDiscriminability": 0.824
+          "aCount": 276,
+          "bCount": 206,
+          "aPercent": 57.3,
+          "bPercent": 42.7,
+          "discriminability": 0.718,
+          "ratioDiscriminability": 0.855
         }
       ],
       "dimensions": [
@@ -493,42 +493,42 @@
           "questions": [
             {
               "question": 1,
-              "aCount": 209,
-              "bCount": 252,
-              "aPercent": 45.3,
-              "bPercent": 54.7,
-              "discriminability": 0.797,
-              "ratioDiscriminability": 0.907
+              "aCount": 215,
+              "bCount": 267,
+              "aPercent": 44.6,
+              "bPercent": 55.4,
+              "discriminability": 0.782,
+              "ratioDiscriminability": 0.892
             },
             {
               "question": 2,
-              "aCount": 149,
-              "bCount": 312,
-              "aPercent": 32.3,
-              "bPercent": 67.7,
-              "discriminability": 0.762,
-              "ratioDiscriminability": 0.646
+              "aCount": 151,
+              "bCount": 331,
+              "aPercent": 31.3,
+              "bPercent": 68.7,
+              "discriminability": 0.758,
+              "ratioDiscriminability": 0.627
             },
             {
               "question": 3,
-              "aCount": 334,
-              "bCount": 127,
-              "aPercent": 72.5,
-              "bPercent": 27.5,
-              "discriminability": 0.677,
-              "ratioDiscriminability": 0.551
+              "aCount": 351,
+              "bCount": 131,
+              "aPercent": 72.8,
+              "bPercent": 27.2,
+              "discriminability": 0.675,
+              "ratioDiscriminability": 0.544
             },
             {
               "question": 4,
-              "aCount": 168,
-              "bCount": 293,
-              "aPercent": 36.4,
-              "bPercent": 63.6,
-              "discriminability": 0.797,
-              "ratioDiscriminability": 0.729
+              "aCount": 172,
+              "bCount": 310,
+              "aPercent": 35.7,
+              "bPercent": 64.3,
+              "discriminability": 0.798,
+              "ratioDiscriminability": 0.714
             }
           ],
-          "averageDiscriminability": 0.758
+          "averageDiscriminability": 0.753
         },
         {
           "name": "Precision",
@@ -539,42 +539,42 @@
           "questions": [
             {
               "question": 5,
-              "aCount": 285,
-              "bCount": 176,
-              "aPercent": 61.8,
-              "bPercent": 38.2,
-              "discriminability": 0.64,
-              "ratioDiscriminability": 0.764
+              "aCount": 295,
+              "bCount": 187,
+              "aPercent": 61.2,
+              "bPercent": 38.8,
+              "discriminability": 0.642,
+              "ratioDiscriminability": 0.776
             },
             {
               "question": 6,
-              "aCount": 238,
-              "bCount": 223,
-              "aPercent": 51.6,
-              "bPercent": 48.4,
-              "discriminability": 0.762,
-              "ratioDiscriminability": 0.967
+              "aCount": 243,
+              "bCount": 239,
+              "aPercent": 50.4,
+              "bPercent": 49.6,
+              "discriminability": 0.761,
+              "ratioDiscriminability": 0.992
             },
             {
               "question": 7,
-              "aCount": 323,
-              "bCount": 138,
-              "aPercent": 70.1,
-              "bPercent": 29.9,
-              "discriminability": 0.647,
-              "ratioDiscriminability": 0.599
+              "aCount": 331,
+              "bCount": 151,
+              "aPercent": 68.7,
+              "bPercent": 31.3,
+              "discriminability": 0.636,
+              "ratioDiscriminability": 0.627
             },
             {
               "question": 8,
-              "aCount": 172,
-              "bCount": 289,
-              "aPercent": 37.3,
-              "bPercent": 62.7,
-              "discriminability": 0.734,
-              "ratioDiscriminability": 0.746
+              "aCount": 185,
+              "bCount": 297,
+              "aPercent": 38.4,
+              "bPercent": 61.6,
+              "discriminability": 0.739,
+              "ratioDiscriminability": 0.768
             }
           ],
-          "averageDiscriminability": 0.696
+          "averageDiscriminability": 0.695
         },
         {
           "name": "Transparency",
@@ -585,42 +585,42 @@
           "questions": [
             {
               "question": 9,
-              "aCount": 280,
-              "bCount": 181,
-              "aPercent": 60.7,
-              "bPercent": 39.3,
-              "discriminability": 0.747,
-              "ratioDiscriminability": 0.785
+              "aCount": 295,
+              "bCount": 187,
+              "aPercent": 61.2,
+              "bPercent": 38.8,
+              "discriminability": 0.75,
+              "ratioDiscriminability": 0.776
             },
             {
               "question": 10,
-              "aCount": 213,
-              "bCount": 248,
-              "aPercent": 46.2,
-              "bPercent": 53.8,
-              "discriminability": 0.812,
-              "ratioDiscriminability": 0.924
+              "aCount": 223,
+              "bCount": 259,
+              "aPercent": 46.3,
+              "bPercent": 53.7,
+              "discriminability": 0.815,
+              "ratioDiscriminability": 0.925
             },
             {
               "question": 11,
-              "aCount": 143,
-              "bCount": 318,
-              "aPercent": 31,
-              "bPercent": 69,
-              "discriminability": 0.707,
-              "ratioDiscriminability": 0.62
+              "aCount": 154,
+              "bCount": 328,
+              "aPercent": 32,
+              "bPercent": 68,
+              "discriminability": 0.711,
+              "ratioDiscriminability": 0.639
             },
             {
               "question": 12,
-              "aCount": 305,
-              "bCount": 156,
-              "aPercent": 66.2,
-              "bPercent": 33.8,
-              "discriminability": 0.676,
-              "ratioDiscriminability": 0.677
+              "aCount": 309,
+              "bCount": 173,
+              "aPercent": 64.1,
+              "bPercent": 35.9,
+              "discriminability": 0.679,
+              "ratioDiscriminability": 0.718
             }
           ],
-          "averageDiscriminability": 0.736
+          "averageDiscriminability": 0.739
         },
         {
           "name": "Adaptability",
@@ -631,42 +631,42 @@
           "questions": [
             {
               "question": 13,
-              "aCount": 336,
+              "aCount": 357,
               "bCount": 125,
-              "aPercent": 72.9,
-              "bPercent": 27.1,
-              "discriminability": 0.662,
-              "ratioDiscriminability": 0.542
+              "aPercent": 74.1,
+              "bPercent": 25.9,
+              "discriminability": 0.633,
+              "ratioDiscriminability": 0.519
             },
             {
               "question": 14,
-              "aCount": 255,
-              "bCount": 206,
-              "aPercent": 55.3,
-              "bPercent": 44.7,
-              "discriminability": 0.767,
-              "ratioDiscriminability": 0.894
+              "aCount": 271,
+              "bCount": 211,
+              "aPercent": 56.2,
+              "bPercent": 43.8,
+              "discriminability": 0.762,
+              "ratioDiscriminability": 0.876
             },
             {
               "question": 15,
-              "aCount": 294,
-              "bCount": 167,
-              "aPercent": 63.8,
-              "bPercent": 36.2,
-              "discriminability": 0.755,
-              "ratioDiscriminability": 0.725
+              "aCount": 311,
+              "bCount": 171,
+              "aPercent": 64.5,
+              "bPercent": 35.5,
+              "discriminability": 0.752,
+              "ratioDiscriminability": 0.71
             },
             {
               "question": 16,
-              "aCount": 271,
-              "bCount": 190,
-              "aPercent": 58.8,
-              "bPercent": 41.2,
-              "discriminability": 0.709,
-              "ratioDiscriminability": 0.824
+              "aCount": 276,
+              "bCount": 206,
+              "aPercent": 57.3,
+              "bPercent": 42.7,
+              "discriminability": 0.718,
+              "ratioDiscriminability": 0.855
             }
           ],
-          "averageDiscriminability": 0.723
+          "averageDiscriminability": 0.716
         }
       ]
     }

--- a/data/reliability/gemini-3-6-flash-run-201.json
+++ b/data/reliability/gemini-3-6-flash-run-201.json
@@ -1,0 +1,31 @@
+{
+  "model": "gemini-3.6-flash",
+  "provider": "anthropic",
+  "run": 201,
+  "answers": [
+    "B",
+    "B",
+    "B",
+    "B",
+    "A",
+    "B",
+    "B",
+    "A",
+    "B",
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B"
+  ],
+  "dimensions": [
+    0,
+    2,
+    2,
+    3
+  ],
+  "type": "RTCF",
+  "questionVersion": "5.22-beta"
+}

--- a/data/reliability/gemini-3-6-flash-run-202.json
+++ b/data/reliability/gemini-3-6-flash-run-202.json
@@ -1,0 +1,31 @@
+{
+  "model": "gemini-3.6-flash",
+  "provider": "anthropic",
+  "run": 202,
+  "answers": [
+    "B",
+    "B",
+    "B",
+    "B",
+    "A",
+    "B",
+    "A",
+    "B",
+    "B",
+    "B",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A"
+  ],
+  "dimensions": [
+    0,
+    2,
+    1,
+    4
+  ],
+  "type": "RTDF",
+  "questionVersion": "5.22-beta"
+}

--- a/data/reliability/gemini-3-6-flash-run-203.json
+++ b/data/reliability/gemini-3-6-flash-run-203.json
@@ -1,0 +1,31 @@
+{
+  "model": "gemini-3.6-flash",
+  "provider": "anthropic",
+  "run": 203,
+  "answers": [
+    "B",
+    "B",
+    "A",
+    "B",
+    "A",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "A",
+    "A",
+    "A",
+    "B"
+  ],
+  "dimensions": [
+    1,
+    1,
+    0,
+    3
+  ],
+  "type": "REDF",
+  "questionVersion": "5.22-beta"
+}

--- a/data/reliability/gpt-5-4-run-201.json
+++ b/data/reliability/gpt-5-4-run-201.json
@@ -1,0 +1,31 @@
+{
+  "model": "gpt-5.4",
+  "provider": "anthropic",
+  "run": 201,
+  "answers": [
+    "A",
+    "B",
+    "A",
+    "B",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "B",
+    "B",
+    "B",
+    "A",
+    "B",
+    "A",
+    "B"
+  ],
+  "dimensions": [
+    2,
+    3,
+    1,
+    2
+  ],
+  "type": "PTDF",
+  "questionVersion": "5.22-beta"
+}

--- a/data/reliability/gpt-5-4-run-202.json
+++ b/data/reliability/gpt-5-4-run-202.json
@@ -1,0 +1,31 @@
+{
+  "model": "gpt-5.4",
+  "provider": "anthropic",
+  "run": 202,
+  "answers": [
+    "A",
+    "B",
+    "A",
+    "B",
+    "A",
+    "B",
+    "B",
+    "A",
+    "A",
+    "B",
+    "B",
+    "B",
+    "A",
+    "A",
+    "B",
+    "B"
+  ],
+  "dimensions": [
+    2,
+    2,
+    1,
+    2
+  ],
+  "type": "PTDF",
+  "questionVersion": "5.22-beta"
+}

--- a/data/reliability/gpt-5-4-run-203.json
+++ b/data/reliability/gpt-5-4-run-203.json
@@ -1,0 +1,31 @@
+{
+  "model": "gpt-5.4",
+  "provider": "anthropic",
+  "run": 203,
+  "answers": [
+    "B",
+    "B",
+    "A",
+    "B",
+    "A",
+    "B",
+    "B",
+    "A",
+    "A",
+    "B",
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "B"
+  ],
+  "dimensions": [
+    1,
+    2,
+    2,
+    3
+  ],
+  "type": "RTCF",
+  "questionVersion": "5.22-beta"
+}

--- a/data/reliability/gpt-5-mini-run-201.json
+++ b/data/reliability/gpt-5-mini-run-201.json
@@ -1,0 +1,31 @@
+{
+  "model": "gpt-5-mini",
+  "provider": "anthropic",
+  "run": 201,
+  "answers": [
+    "A",
+    "A",
+    "B",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "B",
+    "A",
+    "A",
+    "B",
+    "A",
+    "B"
+  ],
+  "dimensions": [
+    2,
+    4,
+    2,
+    2
+  ],
+  "type": "PTCF",
+  "questionVersion": "5.22-beta"
+}

--- a/data/reliability/gpt-5-mini-run-202.json
+++ b/data/reliability/gpt-5-mini-run-202.json
@@ -1,0 +1,31 @@
+{
+  "model": "gpt-5-mini",
+  "provider": "anthropic",
+  "run": 202,
+  "answers": [
+    "A",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "B",
+    "B",
+    "B",
+    "A",
+    "A",
+    "B",
+    "B"
+  ],
+  "dimensions": [
+    3,
+    3,
+    1,
+    2
+  ],
+  "type": "PTDF",
+  "questionVersion": "5.22-beta"
+}

--- a/data/reliability/gpt-5-mini-run-203.json
+++ b/data/reliability/gpt-5-mini-run-203.json
@@ -1,0 +1,31 @@
+{
+  "model": "gpt-5-mini",
+  "provider": "anthropic",
+  "run": 203,
+  "answers": [
+    "B",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "B",
+    "B",
+    "A",
+    "A",
+    "B",
+    "B",
+    "B"
+  ],
+  "dimensions": [
+    2,
+    3,
+    2,
+    1
+  ],
+  "type": "PTCN",
+  "questionVersion": "5.22-beta"
+}

--- a/data/results.json
+++ b/data/results.json
@@ -1626,11 +1626,38 @@
             4,
             3
           ]
+        },
+        {
+          "type": "RECF",
+          "scores": [
+            1,
+            1,
+            3,
+            3
+          ]
+        },
+        {
+          "type": "RECF",
+          "scores": [
+            0,
+            1,
+            3,
+            3
+          ]
+        },
+        {
+          "type": "RECF",
+          "scores": [
+            1,
+            1,
+            3,
+            3
+          ]
         }
       ],
-      "runs": 4,
-      "reliability": 0.8594,
-      "consistency": 86
+      "runs": 7,
+      "reliability": 0.875,
+      "consistency": 88
     },
     {
       "name": "Codestral (Mistral)",
@@ -4770,9 +4797,9 @@
       ],
       "model": "gpt-5-mini",
       "provider": "openai",
-      "consistency": 85,
-      "runs": 3,
-      "reliability": 0.8542,
+      "consistency": 82,
+      "runs": 6,
+      "reliability": 0.8229,
       "reliabilityRuns": [
         {
           "type": "PTCF",
@@ -4799,6 +4826,33 @@
             4,
             2,
             2
+          ]
+        },
+        {
+          "type": "PTCF",
+          "scores": [
+            2,
+            4,
+            2,
+            2
+          ]
+        },
+        {
+          "type": "PTDF",
+          "scores": [
+            3,
+            3,
+            1,
+            2
+          ]
+        },
+        {
+          "type": "PTCN",
+          "scores": [
+            2,
+            3,
+            2,
+            1
           ]
         }
       ]
@@ -4906,7 +4960,7 @@
       ],
       "model": "gpt-5.4",
       "provider": "openai",
-      "runs": 4,
+      "runs": 7,
       "reliabilityRuns": [
         {
           "type": "PTDF",
@@ -4943,9 +4997,36 @@
             3,
             2
           ]
+        },
+        {
+          "type": "PTDF",
+          "scores": [
+            2,
+            3,
+            1,
+            2
+          ]
+        },
+        {
+          "type": "PTDF",
+          "scores": [
+            2,
+            2,
+            1,
+            2
+          ]
+        },
+        {
+          "type": "RTCF",
+          "scores": [
+            1,
+            2,
+            2,
+            3
+          ]
         }
       ],
-      "reliability": 0.8438,
+      "reliability": 0.8393,
       "consistency": 84
     },
     {
@@ -5135,6 +5216,33 @@
           ]
         },
         {
+          "type": "PTCF",
+          "scores": [
+            2,
+            2,
+            3,
+            4
+          ]
+        },
+        {
+          "type": "PECF",
+          "scores": [
+            2,
+            1,
+            2,
+            4
+          ]
+        },
+        {
+          "type": "RECF",
+          "scores": [
+            1,
+            1,
+            2,
+            3
+          ]
+        },
+        {
           "type": "RTCN",
           "scores": [
             1,
@@ -5162,8 +5270,8 @@
           ]
         }
       ],
-      "runs": 7,
-      "reliability": 0.7411,
+      "runs": 10,
+      "reliability": 0.7438,
       "consistency": 74
     },
     {
@@ -6425,7 +6533,7 @@
       ],
       "model": "MiniMax-M2.7",
       "provider": "openai",
-      "runs": 3,
+      "runs": 6,
       "reliabilityRuns": [
         {
           "type": "PTCN",
@@ -6453,10 +6561,37 @@
             2,
             0
           ]
+        },
+        {
+          "type": "PEDF",
+          "scores": [
+            2,
+            0,
+            1,
+            3
+          ]
+        },
+        {
+          "type": "PEDF",
+          "scores": [
+            2,
+            1,
+            1,
+            2
+          ]
+        },
+        {
+          "type": "PEDN",
+          "scores": [
+            2,
+            0,
+            1,
+            1
+          ]
         }
       ],
-      "reliability": 0.8333,
-      "consistency": 83
+      "reliability": 0.7188,
+      "consistency": 72
     },
     {
       "name": "Ministral 3B",
@@ -8129,7 +8264,7 @@
       ],
       "model": "gemini-3.6-flash",
       "provider": "github",
-      "reliability": 0.9063,
+      "reliability": 0.8681,
       "reliabilityRuns": [
         {
           "type": "RTDF",
@@ -8154,6 +8289,33 @@
           "scores": [
             0,
             2,
+            0,
+            3
+          ]
+        },
+        {
+          "type": "RTCF",
+          "scores": [
+            0,
+            2,
+            2,
+            3
+          ]
+        },
+        {
+          "type": "RTDF",
+          "scores": [
+            0,
+            2,
+            1,
+            4
+          ]
+        },
+        {
+          "type": "REDF",
+          "scores": [
+            1,
+            1,
             0,
             3
           ]
@@ -8186,8 +8348,8 @@
           ]
         }
       ],
-      "runs": 6,
-      "consistency": 91
+      "runs": 9,
+      "consistency": 87
     },
     {
       "name": "GPT-4o Preview",
@@ -8430,9 +8592,36 @@
             4,
             4
           ]
+        },
+        {
+          "type": "RTCF",
+          "scores": [
+            1,
+            2,
+            3,
+            4
+          ]
+        },
+        {
+          "type": "RTCF",
+          "scores": [
+            1,
+            2,
+            3,
+            4
+          ]
+        },
+        {
+          "type": "RTCF",
+          "scores": [
+            1,
+            2,
+            3,
+            3
+          ]
         }
       ],
-      "runs": 3,
+      "runs": 6,
       "reliability": 0.9583,
       "consistency": 96,
       "type": "RTCF"


### PR DESCRIPTION
## Summary

3 Priority 2 models tested with v5.22-beta questions (runs 201-203):

| Model | Run 201 | Run 202 | Run 203 | Consistency |
|-------|---------|---------|---------|-------------|
| Gemini 3.6 Flash | RTCF [0,2,2,3] | RTDF [0,2,1,4] | REDF [1,1,0,3] | 87% |
| GPT-5.4 | PTDF [2,3,1,2] | PTDF [2,2,1,2] | RTCF [1,2,2,3] | 84% |
| GPT-5-mini | PTCF [2,4,2,2] | PTDF [3,3,1,2] | PTCN [2,3,2,1] | 82% |

## Changes
- 9 new reliability run files in `data/reliability/`
- `results.json` synced via `sync-reliability.js` (7 agents updated)
- Discriminability regenerated (482 runs, 0 questions below threshold)

## Next
Priority 3 models remain: Claude Opus 4.8/4.7, MiniMax-M2.5, GPT-5.6 variants.

Closes part of #830.