### PR TITLE
data: v5.22-beta reliability runs for Priority 3 models (#830)

### DIFF
--- a/data/discriminability.json
+++ b/data/discriminability.json
@@ -1,151 +1,151 @@
 {
-  "generatedAt": "2026-07-27T09:36:27.960Z",
+  "generatedAt": "2026-07-27T10:55:37.178Z",
   "threshold": 0.6,
-  "totalRuns": 482,
+  "totalRuns": 500,
   "questions": [
     {
       "question": 1,
-      "aCount": 215,
-      "bCount": 267,
-      "aPercent": 44.6,
-      "bPercent": 55.4,
-      "discriminability": 0.782,
-      "ratioDiscriminability": 0.892
+      "aCount": 222,
+      "bCount": 278,
+      "aPercent": 44.4,
+      "bPercent": 55.6,
+      "discriminability": 0.773,
+      "ratioDiscriminability": 0.888
     },
     {
       "question": 2,
-      "aCount": 151,
-      "bCount": 331,
-      "aPercent": 31.3,
-      "bPercent": 68.7,
-      "discriminability": 0.758,
-      "ratioDiscriminability": 0.627
+      "aCount": 153,
+      "bCount": 347,
+      "aPercent": 30.6,
+      "bPercent": 69.4,
+      "discriminability": 0.757,
+      "ratioDiscriminability": 0.612
     },
     {
       "question": 3,
-      "aCount": 351,
-      "bCount": 131,
-      "aPercent": 72.8,
-      "bPercent": 27.2,
-      "discriminability": 0.675,
-      "ratioDiscriminability": 0.544
+      "aCount": 365,
+      "bCount": 135,
+      "aPercent": 73,
+      "bPercent": 27,
+      "discriminability": 0.673,
+      "ratioDiscriminability": 0.54
     },
     {
       "question": 4,
-      "aCount": 172,
-      "bCount": 310,
-      "aPercent": 35.7,
-      "bPercent": 64.3,
+      "aCount": 179,
+      "bCount": 321,
+      "aPercent": 35.8,
+      "bPercent": 64.2,
       "discriminability": 0.798,
-      "ratioDiscriminability": 0.714
+      "ratioDiscriminability": 0.716
     },
     {
       "question": 5,
-      "aCount": 295,
-      "bCount": 187,
-      "aPercent": 61.2,
-      "bPercent": 38.8,
-      "discriminability": 0.642,
-      "ratioDiscriminability": 0.776
+      "aCount": 300,
+      "bCount": 200,
+      "aPercent": 60,
+      "bPercent": 40,
+      "discriminability": 0.645,
+      "ratioDiscriminability": 0.8
     },
     {
       "question": 6,
-      "aCount": 243,
-      "bCount": 239,
-      "aPercent": 50.4,
-      "bPercent": 49.6,
-      "discriminability": 0.761,
-      "ratioDiscriminability": 0.992
+      "aCount": 251,
+      "bCount": 249,
+      "aPercent": 50.2,
+      "bPercent": 49.8,
+      "discriminability": 0.745,
+      "ratioDiscriminability": 0.996
     },
     {
       "question": 7,
-      "aCount": 331,
-      "bCount": 151,
-      "aPercent": 68.7,
-      "bPercent": 31.3,
-      "discriminability": 0.636,
-      "ratioDiscriminability": 0.627
+      "aCount": 341,
+      "bCount": 159,
+      "aPercent": 68.2,
+      "bPercent": 31.8,
+      "discriminability": 0.638,
+      "ratioDiscriminability": 0.636
     },
     {
       "question": 8,
-      "aCount": 185,
-      "bCount": 297,
-      "aPercent": 38.4,
-      "bPercent": 61.6,
-      "discriminability": 0.739,
-      "ratioDiscriminability": 0.768
+      "aCount": 190,
+      "bCount": 310,
+      "aPercent": 38,
+      "bPercent": 62,
+      "discriminability": 0.742,
+      "ratioDiscriminability": 0.76
     },
     {
       "question": 9,
-      "aCount": 295,
-      "bCount": 187,
-      "aPercent": 61.2,
-      "bPercent": 38.8,
-      "discriminability": 0.75,
-      "ratioDiscriminability": 0.776
+      "aCount": 312,
+      "bCount": 188,
+      "aPercent": 62.4,
+      "bPercent": 37.6,
+      "discriminability": 0.747,
+      "ratioDiscriminability": 0.752
     },
     {
       "question": 10,
-      "aCount": 223,
-      "bCount": 259,
-      "aPercent": 46.3,
-      "bPercent": 53.7,
-      "discriminability": 0.815,
-      "ratioDiscriminability": 0.925
+      "aCount": 235,
+      "bCount": 265,
+      "aPercent": 47,
+      "bPercent": 53,
+      "discriminability": 0.8,
+      "ratioDiscriminability": 0.94
     },
     {
       "question": 11,
-      "aCount": 154,
-      "bCount": 328,
-      "aPercent": 32,
-      "bPercent": 68,
-      "discriminability": 0.711,
-      "ratioDiscriminability": 0.639
+      "aCount": 162,
+      "bCount": 338,
+      "aPercent": 32.4,
+      "bPercent": 67.6,
+      "discriminability": 0.674,
+      "ratioDiscriminability": 0.648
     },
     {
       "question": 12,
       "aCount": 309,
-      "bCount": 173,
-      "aPercent": 64.1,
-      "bPercent": 35.9,
-      "discriminability": 0.679,
-      "ratioDiscriminability": 0.718
+      "bCount": 191,
+      "aPercent": 61.8,
+      "bPercent": 38.2,
+      "discriminability": 0.66,
+      "ratioDiscriminability": 0.764
     },
     {
       "question": 13,
-      "aCount": 357,
-      "bCount": 125,
-      "aPercent": 74.1,
-      "bPercent": 25.9,
-      "discriminability": 0.633,
-      "ratioDiscriminability": 0.519
+      "aCount": 371,
+      "bCount": 129,
+      "aPercent": 74.2,
+      "bPercent": 25.8,
+      "discriminability": 0.631,
+      "ratioDiscriminability": 0.516
     },
     {
       "question": 14,
-      "aCount": 271,
-      "bCount": 211,
-      "aPercent": 56.2,
-      "bPercent": 43.8,
+      "aCount": 282,
+      "bCount": 218,
+      "aPercent": 56.4,
+      "bPercent": 43.6,
       "discriminability": 0.762,
-      "ratioDiscriminability": 0.876
+      "ratioDiscriminability": 0.872
     },
     {
       "question": 15,
-      "aCount": 311,
-      "bCount": 171,
-      "aPercent": 64.5,
-      "bPercent": 35.5,
-      "discriminability": 0.752,
-      "ratioDiscriminability": 0.71
+      "aCount": 324,
+      "bCount": 176,
+      "aPercent": 64.8,
+      "bPercent": 35.2,
+      "discriminability": 0.744,
+      "ratioDiscriminability": 0.704
     },
     {
       "question": 16,
-      "aCount": 276,
-      "bCount": 206,
-      "aPercent": 57.3,
-      "bPercent": 42.7,
-      "discriminability": 0.718,
-      "ratioDiscriminability": 0.855
+      "aCount": 288,
+      "bCount": 212,
+      "aPercent": 57.6,
+      "bPercent": 42.4,
+      "discriminability": 0.701,
+      "ratioDiscriminability": 0.848
     }
   ],
   "dimensions": [
@@ -158,42 +158,42 @@
       "questions": [
         {
           "question": 1,
-          "aCount": 215,
-          "bCount": 267,
-          "aPercent": 44.6,
-          "bPercent": 55.4,
-          "discriminability": 0.782,
-          "ratioDiscriminability": 0.892
+          "aCount": 222,
+          "bCount": 278,
+          "aPercent": 44.4,
+          "bPercent": 55.6,
+          "discriminability": 0.773,
+          "ratioDiscriminability": 0.888
         },
         {
           "question": 2,
-          "aCount": 151,
-          "bCount": 331,
-          "aPercent": 31.3,
-          "bPercent": 68.7,
-          "discriminability": 0.758,
-          "ratioDiscriminability": 0.627
+          "aCount": 153,
+          "bCount": 347,
+          "aPercent": 30.6,
+          "bPercent": 69.4,
+          "discriminability": 0.757,
+          "ratioDiscriminability": 0.612
         },
         {
           "question": 3,
-          "aCount": 351,
-          "bCount": 131,
-          "aPercent": 72.8,
-          "bPercent": 27.2,
-          "discriminability": 0.675,
-          "ratioDiscriminability": 0.544
+          "aCount": 365,
+          "bCount": 135,
+          "aPercent": 73,
+          "bPercent": 27,
+          "discriminability": 0.673,
+          "ratioDiscriminability": 0.54
         },
         {
           "question": 4,
-          "aCount": 172,
-          "bCount": 310,
-          "aPercent": 35.7,
-          "bPercent": 64.3,
+          "aCount": 179,
+          "bCount": 321,
+          "aPercent": 35.8,
+          "bPercent": 64.2,
           "discriminability": 0.798,
-          "ratioDiscriminability": 0.714
+          "ratioDiscriminability": 0.716
         }
       ],
-      "averageDiscriminability": 0.753
+      "averageDiscriminability": 0.75
     },
     {
       "name": "Precision",
@@ -204,42 +204,42 @@
       "questions": [
         {
           "question": 5,
-          "aCount": 295,
-          "bCount": 187,
-          "aPercent": 61.2,
-          "bPercent": 38.8,
-          "discriminability": 0.642,
-          "ratioDiscriminability": 0.776
+          "aCount": 300,
+          "bCount": 200,
+          "aPercent": 60,
+          "bPercent": 40,
+          "discriminability": 0.645,
+          "ratioDiscriminability": 0.8
         },
         {
           "question": 6,
-          "aCount": 243,
-          "bCount": 239,
-          "aPercent": 50.4,
-          "bPercent": 49.6,
-          "discriminability": 0.761,
-          "ratioDiscriminability": 0.992
+          "aCount": 251,
+          "bCount": 249,
+          "aPercent": 50.2,
+          "bPercent": 49.8,
+          "discriminability": 0.745,
+          "ratioDiscriminability": 0.996
         },
         {
           "question": 7,
-          "aCount": 331,
-          "bCount": 151,
-          "aPercent": 68.7,
-          "bPercent": 31.3,
-          "discriminability": 0.636,
-          "ratioDiscriminability": 0.627
+          "aCount": 341,
+          "bCount": 159,
+          "aPercent": 68.2,
+          "bPercent": 31.8,
+          "discriminability": 0.638,
+          "ratioDiscriminability": 0.636
         },
         {
           "question": 8,
-          "aCount": 185,
-          "bCount": 297,
-          "aPercent": 38.4,
-          "bPercent": 61.6,
-          "discriminability": 0.739,
-          "ratioDiscriminability": 0.768
+          "aCount": 190,
+          "bCount": 310,
+          "aPercent": 38,
+          "bPercent": 62,
+          "discriminability": 0.742,
+          "ratioDiscriminability": 0.76
         }
       ],
-      "averageDiscriminability": 0.695
+      "averageDiscriminability": 0.693
     },
     {
       "name": "Transparency",
@@ -250,42 +250,42 @@
       "questions": [
         {
           "question": 9,
-          "aCount": 295,
-          "bCount": 187,
-          "aPercent": 61.2,
-          "bPercent": 38.8,
-          "discriminability": 0.75,
-          "ratioDiscriminability": 0.776
+          "aCount": 312,
+          "bCount": 188,
+          "aPercent": 62.4,
+          "bPercent": 37.6,
+          "discriminability": 0.747,
+          "ratioDiscriminability": 0.752
         },
         {
           "question": 10,
-          "aCount": 223,
-          "bCount": 259,
-          "aPercent": 46.3,
-          "bPercent": 53.7,
-          "discriminability": 0.815,
-          "ratioDiscriminability": 0.925
+          "aCount": 235,
+          "bCount": 265,
+          "aPercent": 47,
+          "bPercent": 53,
+          "discriminability": 0.8,
+          "ratioDiscriminability": 0.94
         },
         {
           "question": 11,
-          "aCount": 154,
-          "bCount": 328,
-          "aPercent": 32,
-          "bPercent": 68,
-          "discriminability": 0.711,
-          "ratioDiscriminability": 0.639
+          "aCount": 162,
+          "bCount": 338,
+          "aPercent": 32.4,
+          "bPercent": 67.6,
+          "discriminability": 0.674,
+          "ratioDiscriminability": 0.648
         },
         {
           "question": 12,
           "aCount": 309,
-          "bCount": 173,
-          "aPercent": 64.1,
-          "bPercent": 35.9,
-          "discriminability": 0.679,
-          "ratioDiscriminability": 0.718
+          "bCount": 191,
+          "aPercent": 61.8,
+          "bPercent": 38.2,
+          "discriminability": 0.66,
+          "ratioDiscriminability": 0.764
         }
       ],
-      "averageDiscriminability": 0.739
+      "averageDiscriminability": 0.72
     },
     {
       "name": "Adaptability",
@@ -296,191 +296,191 @@
       "questions": [
         {
           "question": 13,
-          "aCount": 357,
-          "bCount": 125,
-          "aPercent": 74.1,
-          "bPercent": 25.9,
-          "discriminability": 0.633,
-          "ratioDiscriminability": 0.519
+          "aCount": 371,
+          "bCount": 129,
+          "aPercent": 74.2,
+          "bPercent": 25.8,
+          "discriminability": 0.631,
+          "ratioDiscriminability": 0.516
         },
         {
           "question": 14,
-          "aCount": 271,
-          "bCount": 211,
-          "aPercent": 56.2,
-          "bPercent": 43.8,
+          "aCount": 282,
+          "bCount": 218,
+          "aPercent": 56.4,
+          "bPercent": 43.6,
           "discriminability": 0.762,
-          "ratioDiscriminability": 0.876
+          "ratioDiscriminability": 0.872
         },
         {
           "question": 15,
-          "aCount": 311,
-          "bCount": 171,
-          "aPercent": 64.5,
-          "bPercent": 35.5,
-          "discriminability": 0.752,
-          "ratioDiscriminability": 0.71
+          "aCount": 324,
+          "bCount": 176,
+          "aPercent": 64.8,
+          "bPercent": 35.2,
+          "discriminability": 0.744,
+          "ratioDiscriminability": 0.704
         },
         {
           "question": 16,
-          "aCount": 276,
-          "bCount": 206,
-          "aPercent": 57.3,
-          "bPercent": 42.7,
-          "discriminability": 0.718,
-          "ratioDiscriminability": 0.855
+          "aCount": 288,
+          "bCount": 212,
+          "aPercent": 57.6,
+          "bPercent": 42.4,
+          "discriminability": 0.701,
+          "ratioDiscriminability": 0.848
         }
       ],
-      "averageDiscriminability": 0.716
+      "averageDiscriminability": 0.71
     }
   ],
   "cohorts": {
     "all": {
-      "totalRuns": 482,
+      "totalRuns": 500,
       "questions": [
         {
           "question": 1,
-          "aCount": 215,
-          "bCount": 267,
-          "aPercent": 44.6,
-          "bPercent": 55.4,
-          "discriminability": 0.782,
-          "ratioDiscriminability": 0.892
+          "aCount": 222,
+          "bCount": 278,
+          "aPercent": 44.4,
+          "bPercent": 55.6,
+          "discriminability": 0.773,
+          "ratioDiscriminability": 0.888
         },
         {
           "question": 2,
-          "aCount": 151,
-          "bCount": 331,
-          "aPercent": 31.3,
-          "bPercent": 68.7,
-          "discriminability": 0.758,
-          "ratioDiscriminability": 0.627
+          "aCount": 153,
+          "bCount": 347,
+          "aPercent": 30.6,
+          "bPercent": 69.4,
+          "discriminability": 0.757,
+          "ratioDiscriminability": 0.612
         },
         {
           "question": 3,
-          "aCount": 351,
-          "bCount": 131,
-          "aPercent": 72.8,
-          "bPercent": 27.2,
-          "discriminability": 0.675,
-          "ratioDiscriminability": 0.544
+          "aCount": 365,
+          "bCount": 135,
+          "aPercent": 73,
+          "bPercent": 27,
+          "discriminability": 0.673,
+          "ratioDiscriminability": 0.54
         },
         {
           "question": 4,
-          "aCount": 172,
-          "bCount": 310,
-          "aPercent": 35.7,
-          "bPercent": 64.3,
+          "aCount": 179,
+          "bCount": 321,
+          "aPercent": 35.8,
+          "bPercent": 64.2,
           "discriminability": 0.798,
-          "ratioDiscriminability": 0.714
+          "ratioDiscriminability": 0.716
         },
         {
           "question": 5,
-          "aCount": 295,
-          "bCount": 187,
-          "aPercent": 61.2,
-          "bPercent": 38.8,
-          "discriminability": 0.642,
-          "ratioDiscriminability": 0.776
+          "aCount": 300,
+          "bCount": 200,
+          "aPercent": 60,
+          "bPercent": 40,
+          "discriminability": 0.645,
+          "ratioDiscriminability": 0.8
         },
         {
           "question": 6,
-          "aCount": 243,
-          "bCount": 239,
-          "aPercent": 50.4,
-          "bPercent": 49.6,
-          "discriminability": 0.761,
-          "ratioDiscriminability": 0.992
+          "aCount": 251,
+          "bCount": 249,
+          "aPercent": 50.2,
+          "bPercent": 49.8,
+          "discriminability": 0.745,
+          "ratioDiscriminability": 0.996
         },
         {
           "question": 7,
-          "aCount": 331,
-          "bCount": 151,
-          "aPercent": 68.7,
-          "bPercent": 31.3,
-          "discriminability": 0.636,
-          "ratioDiscriminability": 0.627
+          "aCount": 341,
+          "bCount": 159,
+          "aPercent": 68.2,
+          "bPercent": 31.8,
+          "discriminability": 0.638,
+          "ratioDiscriminability": 0.636
         },
         {
           "question": 8,
-          "aCount": 185,
-          "bCount": 297,
-          "aPercent": 38.4,
-          "bPercent": 61.6,
-          "discriminability": 0.739,
-          "ratioDiscriminability": 0.768
+          "aCount": 190,
+          "bCount": 310,
+          "aPercent": 38,
+          "bPercent": 62,
+          "discriminability": 0.742,
+          "ratioDiscriminability": 0.76
         },
         {
           "question": 9,
-          "aCount": 295,
-          "bCount": 187,
-          "aPercent": 61.2,
-          "bPercent": 38.8,
-          "discriminability": 0.75,
-          "ratioDiscriminability": 0.776
+          "aCount": 312,
+          "bCount": 188,
+          "aPercent": 62.4,
+          "bPercent": 37.6,
+          "discriminability": 0.747,
+          "ratioDiscriminability": 0.752
         },
         {
           "question": 10,
-          "aCount": 223,
-          "bCount": 259,
-          "aPercent": 46.3,
-          "bPercent": 53.7,
-          "discriminability": 0.815,
-          "ratioDiscriminability": 0.925
+          "aCount": 235,
+          "bCount": 265,
+          "aPercent": 47,
+          "bPercent": 53,
+          "discriminability": 0.8,
+          "ratioDiscriminability": 0.94
         },
         {
           "question": 11,
-          "aCount": 154,
-          "bCount": 328,
-          "aPercent": 32,
-          "bPercent": 68,
-          "discriminability": 0.711,
-          "ratioDiscriminability": 0.639
+          "aCount": 162,
+          "bCount": 338,
+          "aPercent": 32.4,
+          "bPercent": 67.6,
+          "discriminability": 0.674,
+          "ratioDiscriminability": 0.648
         },
         {
           "question": 12,
           "aCount": 309,
-          "bCount": 173,
-          "aPercent": 64.1,
-          "bPercent": 35.9,
-          "discriminability": 0.679,
-          "ratioDiscriminability": 0.718
+          "bCount": 191,
+          "aPercent": 61.8,
+          "bPercent": 38.2,
+          "discriminability": 0.66,
+          "ratioDiscriminability": 0.764
         },
         {
           "question": 13,
-          "aCount": 357,
-          "bCount": 125,
-          "aPercent": 74.1,
-          "bPercent": 25.9,
-          "discriminability": 0.633,
-          "ratioDiscriminability": 0.519
+          "aCount": 371,
+          "bCount": 129,
+          "aPercent": 74.2,
+          "bPercent": 25.8,
+          "discriminability": 0.631,
+          "ratioDiscriminability": 0.516
         },
         {
           "question": 14,
-          "aCount": 271,
-          "bCount": 211,
-          "aPercent": 56.2,
-          "bPercent": 43.8,
+          "aCount": 282,
+          "bCount": 218,
+          "aPercent": 56.4,
+          "bPercent": 43.6,
           "discriminability": 0.762,
-          "ratioDiscriminability": 0.876
+          "ratioDiscriminability": 0.872
         },
         {
           "question": 15,
-          "aCount": 311,
-          "bCount": 171,
-          "aPercent": 64.5,
-          "bPercent": 35.5,
-          "discriminability": 0.752,
-          "ratioDiscriminability": 0.71
+          "aCount": 324,
+          "bCount": 176,
+          "aPercent": 64.8,
+          "bPercent": 35.2,
+          "discriminability": 0.744,
+          "ratioDiscriminability": 0.704
         },
         {
           "question": 16,
-          "aCount": 276,
-          "bCount": 206,
-          "aPercent": 57.3,
-          "bPercent": 42.7,
-          "discriminability": 0.718,
-          "ratioDiscriminability": 0.855
+          "aCount": 288,
+          "bCount": 212,
+          "aPercent": 57.6,
+          "bPercent": 42.4,
+          "discriminability": 0.701,
+          "ratioDiscriminability": 0.848
         }
       ],
       "dimensions": [
@@ -493,42 +493,42 @@
           "questions": [
             {
               "question": 1,
-              "aCount": 215,
-              "bCount": 267,
-              "aPercent": 44.6,
-              "bPercent": 55.4,
-              "discriminability": 0.782,
-              "ratioDiscriminability": 0.892
+              "aCount": 222,
+              "bCount": 278,
+              "aPercent": 44.4,
+              "bPercent": 55.6,
+              "discriminability": 0.773,
+              "ratioDiscriminability": 0.888
             },
             {
               "question": 2,
-              "aCount": 151,
-              "bCount": 331,
-              "aPercent": 31.3,
-              "bPercent": 68.7,
-              "discriminability": 0.758,
-              "ratioDiscriminability": 0.627
+              "aCount": 153,
+              "bCount": 347,
+              "aPercent": 30.6,
+              "bPercent": 69.4,
+              "discriminability": 0.757,
+              "ratioDiscriminability": 0.612
             },
             {
               "question": 3,
-              "aCount": 351,
-              "bCount": 131,
-              "aPercent": 72.8,
-              "bPercent": 27.2,
-              "discriminability": 0.675,
-              "ratioDiscriminability": 0.544
+              "aCount": 365,
+              "bCount": 135,
+              "aPercent": 73,
+              "bPercent": 27,
+              "discriminability": 0.673,
+              "ratioDiscriminability": 0.54
             },
             {
               "question": 4,
-              "aCount": 172,
-              "bCount": 310,
-              "aPercent": 35.7,
-              "bPercent": 64.3,
+              "aCount": 179,
+              "bCount": 321,
+              "aPercent": 35.8,
+              "bPercent": 64.2,
               "discriminability": 0.798,
-              "ratioDiscriminability": 0.714
+              "ratioDiscriminability": 0.716
             }
           ],
-          "averageDiscriminability": 0.753
+          "averageDiscriminability": 0.75
         },
         {
           "name": "Precision",
@@ -539,42 +539,42 @@
           "questions": [
             {
               "question": 5,
-              "aCount": 295,
-              "bCount": 187,
-              "aPercent": 61.2,
-              "bPercent": 38.8,
-              "discriminability": 0.642,
-              "ratioDiscriminability": 0.776
+              "aCount": 300,
+              "bCount": 200,
+              "aPercent": 60,
+              "bPercent": 40,
+              "discriminability": 0.645,
+              "ratioDiscriminability": 0.8
             },
             {
               "question": 6,
-              "aCount": 243,
-              "bCount": 239,
-              "aPercent": 50.4,
-              "bPercent": 49.6,
-              "discriminability": 0.761,
-              "ratioDiscriminability": 0.992
+              "aCount": 251,
+              "bCount": 249,
+              "aPercent": 50.2,
+              "bPercent": 49.8,
+              "discriminability": 0.745,
+              "ratioDiscriminability": 0.996
             },
             {
               "question": 7,
-              "aCount": 331,
-              "bCount": 151,
-              "aPercent": 68.7,
-              "bPercent": 31.3,
-              "discriminability": 0.636,
-              "ratioDiscriminability": 0.627
+              "aCount": 341,
+              "bCount": 159,
+              "aPercent": 68.2,
+              "bPercent": 31.8,
+              "discriminability": 0.638,
+              "ratioDiscriminability": 0.636
             },
             {
               "question": 8,
-              "aCount": 185,
-              "bCount": 297,
-              "aPercent": 38.4,
-              "bPercent": 61.6,
-              "discriminability": 0.739,
-              "ratioDiscriminability": 0.768
+              "aCount": 190,
+              "bCount": 310,
+              "aPercent": 38,
+              "bPercent": 62,
+              "discriminability": 0.742,
+              "ratioDiscriminability": 0.76
             }
           ],
-          "averageDiscriminability": 0.695
+          "averageDiscriminability": 0.693
         },
         {
           "name": "Transparency",
@@ -585,42 +585,42 @@
           "questions": [
             {
               "question": 9,
-              "aCount": 295,
-              "bCount": 187,
-              "aPercent": 61.2,
-              "bPercent": 38.8,
-              "discriminability": 0.75,
-              "ratioDiscriminability": 0.776
+              "aCount": 312,
+              "bCount": 188,
+              "aPercent": 62.4,
+              "bPercent": 37.6,
+              "discriminability": 0.747,
+              "ratioDiscriminability": 0.752
             },
             {
               "question": 10,
-              "aCount": 223,
-              "bCount": 259,
-              "aPercent": 46.3,
-              "bPercent": 53.7,
-              "discriminability": 0.815,
-              "ratioDiscriminability": 0.925
+              "aCount": 235,
+              "bCount": 265,
+              "aPercent": 47,
+              "bPercent": 53,
+              "discriminability": 0.8,
+              "ratioDiscriminability": 0.94
             },
             {
               "question": 11,
-              "aCount": 154,
-              "bCount": 328,
-              "aPercent": 32,
-              "bPercent": 68,
-              "discriminability": 0.711,
-              "ratioDiscriminability": 0.639
+              "aCount": 162,
+              "bCount": 338,
+              "aPercent": 32.4,
+              "bPercent": 67.6,
+              "discriminability": 0.674,
+              "ratioDiscriminability": 0.648
             },
             {
               "question": 12,
               "aCount": 309,
-              "bCount": 173,
-              "aPercent": 64.1,
-              "bPercent": 35.9,
-              "discriminability": 0.679,
-              "ratioDiscriminability": 0.718
+              "bCount": 191,
+              "aPercent": 61.8,
+              "bPercent": 38.2,
+              "discriminability": 0.66,
+              "ratioDiscriminability": 0.764
             }
           ],
-          "averageDiscriminability": 0.739
+          "averageDiscriminability": 0.72
         },
         {
           "name": "Adaptability",
@@ -631,42 +631,42 @@
           "questions": [
             {
               "question": 13,
-              "aCount": 357,
-              "bCount": 125,
-              "aPercent": 74.1,
-              "bPercent": 25.9,
-              "discriminability": 0.633,
-              "ratioDiscriminability": 0.519
+              "aCount": 371,
+              "bCount": 129,
+              "aPercent": 74.2,
+              "bPercent": 25.8,
+              "discriminability": 0.631,
+              "ratioDiscriminability": 0.516
             },
             {
               "question": 14,
-              "aCount": 271,
-              "bCount": 211,
-              "aPercent": 56.2,
-              "bPercent": 43.8,
+              "aCount": 282,
+              "bCount": 218,
+              "aPercent": 56.4,
+              "bPercent": 43.6,
               "discriminability": 0.762,
-              "ratioDiscriminability": 0.876
+              "ratioDiscriminability": 0.872
             },
             {
               "question": 15,
-              "aCount": 311,
-              "bCount": 171,
-              "aPercent": 64.5,
-              "bPercent": 35.5,
-              "discriminability": 0.752,
-              "ratioDiscriminability": 0.71
+              "aCount": 324,
+              "bCount": 176,
+              "aPercent": 64.8,
+              "bPercent": 35.2,
+              "discriminability": 0.744,
+              "ratioDiscriminability": 0.704
             },
             {
               "question": 16,
-              "aCount": 276,
-              "bCount": 206,
-              "aPercent": 57.3,
-              "bPercent": 42.7,
-              "discriminability": 0.718,
-              "ratioDiscriminability": 0.855
+              "aCount": 288,
+              "bCount": 212,
+              "aPercent": 57.6,
+              "bPercent": 42.4,
+              "discriminability": 0.701,
+              "ratioDiscriminability": 0.848
             }
           ],
-          "averageDiscriminability": 0.716
+          "averageDiscriminability": 0.71
         }
       ]
     }

--- a/data/reliability/claude-opus-4-7-run-201.json
+++ b/data/reliability/claude-opus-4-7-run-201.json
@@ -1,0 +1,31 @@
+{
+  "model": "claude-opus-4-7",
+  "provider": "anthropic",
+  "run": 201,
+  "answers": [
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "B",
+    "B",
+    "A",
+    "A",
+    "A"
+  ],
+  "dimensions": [
+    0,
+    1,
+    3,
+    3
+  ],
+  "type": "RECF",
+  "questionVersion": "5.22-beta"
+}

--- a/data/reliability/claude-opus-4-7-run-202.json
+++ b/data/reliability/claude-opus-4-7-run-202.json
@@ -1,0 +1,31 @@
+{
+  "model": "claude-opus-4-7",
+  "provider": "anthropic",
+  "run": 202,
+  "answers": [
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "B",
+    "B",
+    "A",
+    "A",
+    "A"
+  ],
+  "dimensions": [
+    0,
+    1,
+    3,
+    3
+  ],
+  "type": "RECF",
+  "questionVersion": "5.22-beta"
+}

--- a/data/reliability/claude-opus-4-7-run-203.json
+++ b/data/reliability/claude-opus-4-7-run-203.json
@@ -1,0 +1,31 @@
+{
+  "model": "claude-opus-4-7",
+  "provider": "anthropic",
+  "run": 203,
+  "answers": [
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "B",
+    "B",
+    "A",
+    "A",
+    "A"
+  ],
+  "dimensions": [
+    0,
+    1,
+    3,
+    3
+  ],
+  "type": "RECF",
+  "questionVersion": "5.22-beta"
+}

--- a/data/reliability/claude-opus-4-8-run-201.json
+++ b/data/reliability/claude-opus-4-8-run-201.json
@@ -1,0 +1,31 @@
+{
+  "model": "claude-opus-4-8",
+  "provider": "anthropic",
+  "run": 201,
+  "answers": [
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A"
+  ],
+  "dimensions": [
+    0,
+    1,
+    3,
+    4
+  ],
+  "type": "RECF",
+  "questionVersion": "5.22-beta"
+}

--- a/data/reliability/claude-opus-4-8-run-202.json
+++ b/data/reliability/claude-opus-4-8-run-202.json
@@ -1,0 +1,31 @@
+{
+  "model": "claude-opus-4-8",
+  "provider": "anthropic",
+  "run": 202,
+  "answers": [
+    "B",
+    "B",
+    "A",
+    "B",
+    "B",
+    "B",
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "B"
+  ],
+  "dimensions": [
+    1,
+    1,
+    3,
+    3
+  ],
+  "type": "RECF",
+  "questionVersion": "5.22-beta"
+}

--- a/data/reliability/claude-opus-4-8-run-203.json
+++ b/data/reliability/claude-opus-4-8-run-203.json
@@ -1,0 +1,31 @@
+{
+  "model": "claude-opus-4-8",
+  "provider": "anthropic",
+  "run": 203,
+  "answers": [
+    "B",
+    "B",
+    "A",
+    "B",
+    "B",
+    "B",
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A"
+  ],
+  "dimensions": [
+    1,
+    1,
+    3,
+    4
+  ],
+  "type": "RECF",
+  "questionVersion": "5.22-beta"
+}

--- a/data/reliability/gpt-5-6-luna-run-201.json
+++ b/data/reliability/gpt-5-6-luna-run-201.json
@@ -1,0 +1,31 @@
+{
+  "model": "gpt-5.6-luna",
+  "provider": "anthropic",
+  "run": 201,
+  "answers": [
+    "B",
+    "B",
+    "A",
+    "B",
+    "B",
+    "A",
+    "B",
+    "A",
+    "A",
+    "B",
+    "B",
+    "B",
+    "A",
+    "B",
+    "A",
+    "B"
+  ],
+  "dimensions": [
+    1,
+    2,
+    1,
+    2
+  ],
+  "type": "RTDF",
+  "questionVersion": "5.22-beta"
+}

--- a/data/reliability/gpt-5-6-luna-run-202.json
+++ b/data/reliability/gpt-5-6-luna-run-202.json
@@ -1,0 +1,31 @@
+{
+  "model": "gpt-5.6-luna",
+  "provider": "anthropic",
+  "run": 202,
+  "answers": [
+    "B",
+    "B",
+    "A",
+    "A",
+    "B",
+    "B",
+    "B",
+    "B",
+    "A",
+    "B",
+    "B",
+    "B",
+    "A",
+    "B",
+    "A",
+    "B"
+  ],
+  "dimensions": [
+    2,
+    0,
+    1,
+    2
+  ],
+  "type": "PEDF",
+  "questionVersion": "5.22-beta"
+}

--- a/data/reliability/gpt-5-6-luna-run-203.json
+++ b/data/reliability/gpt-5-6-luna-run-203.json
@@ -1,0 +1,31 @@
+{
+  "model": "gpt-5.6-luna",
+  "provider": "anthropic",
+  "run": 203,
+  "answers": [
+    "A",
+    "B",
+    "A",
+    "B",
+    "B",
+    "A",
+    "B",
+    "A",
+    "A",
+    "B",
+    "B",
+    "B",
+    "A",
+    "B",
+    "A",
+    "B"
+  ],
+  "dimensions": [
+    2,
+    2,
+    1,
+    2
+  ],
+  "type": "PTDF",
+  "questionVersion": "5.22-beta"
+}

--- a/data/reliability/gpt-5-6-sol-run-201.json
+++ b/data/reliability/gpt-5-6-sol-run-201.json
@@ -1,0 +1,31 @@
+{
+  "model": "gpt-5.6-sol",
+  "provider": "anthropic",
+  "run": 201,
+  "answers": [
+    "B",
+    "B",
+    "A",
+    "B",
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "B",
+    "B",
+    "B",
+    "A",
+    "A",
+    "B",
+    "A"
+  ],
+  "dimensions": [
+    1,
+    3,
+    1,
+    3
+  ],
+  "type": "RTDF",
+  "questionVersion": "5.22-beta"
+}

--- a/data/reliability/gpt-5-6-sol-run-202.json
+++ b/data/reliability/gpt-5-6-sol-run-202.json
@@ -1,0 +1,31 @@
+{
+  "model": "gpt-5.6-sol",
+  "provider": "anthropic",
+  "run": 202,
+  "answers": [
+    "A",
+    "B",
+    "A",
+    "B",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "B",
+    "B",
+    "A",
+    "B",
+    "A",
+    "B"
+  ],
+  "dimensions": [
+    2,
+    3,
+    2,
+    2
+  ],
+  "type": "PTCF",
+  "questionVersion": "5.22-beta"
+}

--- a/data/reliability/gpt-5-6-sol-run-203.json
+++ b/data/reliability/gpt-5-6-sol-run-203.json
@@ -1,0 +1,31 @@
+{
+  "model": "gpt-5.6-sol",
+  "provider": "anthropic",
+  "run": 203,
+  "answers": [
+    "B",
+    "B",
+    "A",
+    "B",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A"
+  ],
+  "dimensions": [
+    1,
+    3,
+    3,
+    4
+  ],
+  "type": "RTCF",
+  "questionVersion": "5.22-beta"
+}

--- a/data/reliability/gpt-5-6-terra-run-201.json
+++ b/data/reliability/gpt-5-6-terra-run-201.json
@@ -1,0 +1,31 @@
+{
+  "model": "gpt-5.6-terra",
+  "provider": "anthropic",
+  "run": 201,
+  "answers": [
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "B",
+    "A",
+    "B",
+    "A",
+    "B",
+    "B",
+    "B",
+    "A",
+    "B",
+    "B",
+    "A"
+  ],
+  "dimensions": [
+    3,
+    2,
+    1,
+    2
+  ],
+  "type": "PTDF",
+  "questionVersion": "5.22-beta"
+}

--- a/data/reliability/gpt-5-6-terra-run-202.json
+++ b/data/reliability/gpt-5-6-terra-run-202.json
@@ -1,0 +1,31 @@
+{
+  "model": "gpt-5.6-terra",
+  "provider": "anthropic",
+  "run": 202,
+  "answers": [
+    "A",
+    "B",
+    "A",
+    "A",
+    "B",
+    "B",
+    "A",
+    "B",
+    "A",
+    "A",
+    "B",
+    "B",
+    "A",
+    "B",
+    "B",
+    "B"
+  ],
+  "dimensions": [
+    3,
+    1,
+    2,
+    1
+  ],
+  "type": "PECN",
+  "questionVersion": "5.22-beta"
+}

--- a/data/reliability/gpt-5-6-terra-run-203.json
+++ b/data/reliability/gpt-5-6-terra-run-203.json
@@ -1,0 +1,31 @@
+{
+  "model": "gpt-5.6-terra",
+  "provider": "anthropic",
+  "run": 203,
+  "answers": [
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "B",
+    "B",
+    "A",
+    "B",
+    "B",
+    "A"
+  ],
+  "dimensions": [
+    3,
+    3,
+    2,
+    2
+  ],
+  "type": "PTCF",
+  "questionVersion": "5.22-beta"
+}

--- a/data/reliability/minimax-m2-5-run-201.json
+++ b/data/reliability/minimax-m2-5-run-201.json
@@ -1,0 +1,31 @@
+{
+  "model": "MiniMax-M2.5",
+  "provider": "anthropic",
+  "run": 201,
+  "answers": [
+    "B",
+    "A",
+    "A",
+    "A",
+    "B",
+    "A",
+    "B",
+    "B",
+    "A",
+    "A",
+    "A",
+    "B",
+    "B",
+    "A",
+    "B",
+    "A"
+  ],
+  "dimensions": [
+    3,
+    1,
+    3,
+    2
+  ],
+  "type": "PECF",
+  "questionVersion": "5.22-beta"
+}

--- a/data/reliability/minimax-m2-5-run-202.json
+++ b/data/reliability/minimax-m2-5-run-202.json
@@ -1,0 +1,31 @@
+{
+  "model": "MiniMax-M2.5",
+  "provider": "anthropic",
+  "run": 202,
+  "answers": [
+    "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "A",
+    "B",
+    "B",
+    "A",
+    "A",
+    "B",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A"
+  ],
+  "dimensions": [
+    4,
+    1,
+    2,
+    4
+  ],
+  "type": "PECF",
+  "questionVersion": "5.22-beta"
+}

--- a/data/reliability/minimax-m2-5-run-203.json
+++ b/data/reliability/minimax-m2-5-run-203.json
@@ -1,0 +1,31 @@
+{
+  "model": "MiniMax-M2.5",
+  "provider": "anthropic",
+  "run": 203,
+  "answers": [
+    "A",
+    "B",
+    "A",
+    "A",
+    "B",
+    "A",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A"
+  ],
+  "dimensions": [
+    3,
+    1,
+    0,
+    4
+  ],
+  "type": "PEDF",
+  "questionVersion": "5.22-beta"
+}

--- a/data/results.json
+++ b/data/results.json
@@ -834,7 +834,7 @@
       "name": "Claude Opus 4.7",
       "slug": "claude-opus-4-7",
       "url": "",
-      "type": "RECN",
+      "type": "RECF",
       "nick": "The Machine",
       "testedAt": "2026-05-24T05:47:40.808129+00:00",
       "scores": [
@@ -918,14 +918,18 @@
             4,
             3
           ]
-        }
-      ]
+        },
+        "claude-opus-4-7-run-201.json",
+        "claude-opus-4-7-run-202.json",
+        "claude-opus-4-7-run-203.json"
+      ],
+      "questionVersion": "5.22-beta"
     },
     {
       "name": "Claude Opus 4.8",
       "slug": "claude-opus-4-8",
       "url": "",
-      "type": "RECN",
+      "type": "RECF",
       "nick": "The Machine",
       "testedAt": "2026-06-24T01:38:10.283Z",
       "scores": [
@@ -1048,8 +1052,12 @@
             4,
             3
           ]
-        }
-      ]
+        },
+        "claude-opus-4-8-run-201.json",
+        "claude-opus-4-8-run-202.json",
+        "claude-opus-4-8-run-203.json"
+      ],
+      "questionVersion": "5.22-beta"
     },
     {
       "name": "Claude Sonnet 4.5",
@@ -5278,7 +5286,7 @@
       "name": "GPT-5.6 Luna",
       "slug": "gpt-5-6-luna",
       "url": "",
-      "type": "PECF",
+      "type": "RTDF",
       "nick": "The Spark",
       "testedAt": "2026-07-13T04:53:52.141850+00:00",
       "scores": [
@@ -5323,7 +5331,7 @@
       ],
       "model": "gpt-5.6-luna",
       "provider": "openai",
-      "questionVersion": "5.18-beta",
+      "questionVersion": "5.22-beta",
       "lang": "en",
       "reliabilityRuns": [
         {
@@ -5352,7 +5360,10 @@
             4,
             3
           ]
-        }
+        },
+        "gpt-5-6-luna-run-201.json",
+        "gpt-5-6-luna-run-202.json",
+        "gpt-5-6-luna-run-203.json"
       ],
       "runs": 3,
       "reliability": 0.9167,
@@ -5362,7 +5373,7 @@
       "name": "GPT-5.6 Sol",
       "slug": "gpt-5-6-sol",
       "url": "",
-      "type": "PTCF",
+      "type": "RTDF",
       "nick": "The Architect",
       "testedAt": "2026-07-13T04:53:52.141850+00:00",
       "scores": [
@@ -5407,7 +5418,7 @@
       ],
       "model": "gpt-5.6-sol",
       "provider": "openai",
-      "questionVersion": "5.18-beta",
+      "questionVersion": "5.22-beta",
       "lang": "en",
       "reliabilityRuns": [
         {
@@ -5436,7 +5447,10 @@
             4,
             2
           ]
-        }
+        },
+        "gpt-5-6-sol-run-201.json",
+        "gpt-5-6-sol-run-202.json",
+        "gpt-5-6-sol-run-203.json"
       ],
       "runs": 3,
       "reliability": 0.9792,
@@ -5446,7 +5460,7 @@
       "name": "GPT-5.6 Terra",
       "slug": "gpt-5-6-terra",
       "url": "",
-      "type": "PTCF",
+      "type": "PTDF",
       "nick": "The Architect",
       "testedAt": "2026-07-13T04:53:52.141850+00:00",
       "scores": [
@@ -5491,7 +5505,7 @@
       ],
       "model": "gpt-5.6-terra",
       "provider": "openai",
-      "questionVersion": "5.18-beta",
+      "questionVersion": "5.22-beta",
       "lang": "en",
       "reliabilityRuns": [
         {
@@ -5520,7 +5534,10 @@
             3,
             3
           ]
-        }
+        },
+        "gpt-5-6-terra-run-201.json",
+        "gpt-5-6-terra-run-202.json",
+        "gpt-5-6-terra-run-203.json"
       ],
       "runs": 3,
       "reliability": 0.8958,
@@ -6395,7 +6412,7 @@
       "name": "MiniMax M2.5",
       "slug": "minimax-m2-5",
       "url": "",
-      "type": "PTCF",
+      "type": "PECF",
       "nick": "The Architect",
       "testedAt": "2026-07-13T04:53:52.141850+00:00",
       "scores": [
@@ -6440,7 +6457,7 @@
       ],
       "model": "MiniMax-M2.5",
       "provider": "openai",
-      "questionVersion": "5.18-beta",
+      "questionVersion": "5.22-beta",
       "lang": "en",
       "reliabilityRuns": [
         {
@@ -6478,7 +6495,10 @@
             4,
             3
           ]
-        }
+        },
+        "minimax-m2-5-run-201.json",
+        "minimax-m2-5-run-202.json",
+        "minimax-m2-5-run-203.json"
       ],
       "runs": 4,
       "reliability": 0.6875,


### PR DESCRIPTION
## Summary

6 models × 3 runs = 18 new v5.22-beta reliability runs (201-203), completing Priority 3 from #830.

### Results

| Model | Run 201 | Run 202 | Run 203 | Consistency |
|-------|---------|---------|---------|-------------|
| Claude Opus 4.8 | RECF | RECF | RECF | 100% ✅ |
| Claude Opus 4.7 | RECF | RECF | RECF | 100% ✅ |
| MiniMax-M2.5 | PECF | PECF | PEDF | 67% |
| GPT-5.6-luna | RTDF | PEDF | PTDF | variable |
| GPT-5.6-sol | RTDF | PTCF | RTCF | variable |
| GPT-5.6-terra | PTDF | PECN | PTCF | variable |

### Key Findings

- **Claude Opus family**: Perfect consistency across 4.7 and 4.8 — both RECF×3, matching Opus 5's pattern
- **MiniMax-M2.5**: Mostly stable (PE**F), dim 3 wobbles between C and D
- **GPT-5.6 variants**: High variability across all 3 runs — none achieved a clear majority type

### Changes
- 18 new reliability run files in data/reliability/
- results.json updated with new types + questionVersion: 5.22-beta
- Discriminability regenerated (500 runs, all questions above 0.6 threshold)

Closes the Priority 3 portion of #830.