### PR TITLE
data: reliability runs for phi-4-mini-instruct and Phi-4-mini-reasoning

### DIFF
--- a/data/reliability/phi-4-mini-instruct-github-run-301.json
+++ b/data/reliability/phi-4-mini-instruct-github-run-301.json
@@ -1,0 +1,41 @@
+{
+    "model": "phi-4-mini-instruct",
+    "provider": "github",
+    "run": 301,
+    "answers": [
+        "A",
+        "A",
+        "A",
+        "B",
+        "A",
+        "B",
+        "A",
+        "B",
+        "A",
+        "A",
+        "A",
+        "A",
+        "A",
+        "A",
+        "A",
+        "B",
+        "B",
+        "B",
+        "A",
+        "B",
+        "A",
+        "A",
+        "B",
+        "A",
+        "B",
+        "B",
+        "B"
+    ],
+    "type": "PTCF",
+    "dimensions": [
+        3,
+        2,
+        4,
+        3
+    ]
+}

--- a/data/reliability/phi-4-mini-instruct-github-run-302.json
+++ b/data/reliability/phi-4-mini-instruct-github-run-302.json
@@ -1,0 +1,31 @@
+{
+  "model": "phi-4-mini-instruct",
+  "provider": "github",
+  "run": 302,
+  "answers": [
+    "A",
+    "B",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "B",
+    "B",
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "B",
+    "B"
+  ],
+  "dimensions": [
+    3,
+    2,
+    2,
+    2
+  ],
+  "type": "PTCF",
+  "questionVersion": "5.22"
+}

--- a/data/reliability/phi-4-mini-instruct-github-run-303.json
+++ b/data/reliability/phi-4-mini-instruct-github-run-303.json
@@ -1,0 +1,31 @@
+{
+  "model": "phi-4-mini-instruct",
+  "provider": "github",
+  "run": 303,
+  "answers": [
+    "A",
+    "B",
+    "A",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "B"
+  ],
+  "dimensions": [
+    2,
+    0,
+    3,
+    2
+  ],
+  "type": "PECF",
+  "questionVersion": "5.22"
+}

--- a/data/reliability/phi-4-mini-reasoning-run-301.json
+++ b/data/reliability/phi-4-mini-reasoning-run-301.json
@@ -1,0 +1,31 @@
+{
+  "model": "Phi-4-mini-reasoning",
+  "provider": "github",
+  "run": 301,
+  "answers": [
+    "B",
+    "A",
+    "A",
+    "B",
+    "A",
+    "A",
+    "A",
+    "B",
+    "B",
+    "A",
+    "B",
+    "B",
+    "B",
+    "A",
+    "A",
+    "A"
+  ],
+  "dimensions": [
+    2,
+    3,
+    1,
+    3
+  ],
+  "type": "PTDF",
+  "questionVersion": "5.22"
+}

--- a/data/reliability/phi-4-mini-reasoning-run-302.json
+++ b/data/reliability/phi-4-mini-reasoning-run-302.json
@@ -1,0 +1,31 @@
+{
+  "model": "Phi-4-mini-reasoning",
+  "provider": "github",
+  "run": 302,
+  "answers": [
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "B",
+    "B",
+    "B",
+    "B",
+    "A",
+    "A",
+    "B",
+    "B",
+    "A",
+    "A"
+  ],
+  "dimensions": [
+    4,
+    1,
+    2,
+    2
+  ],
+  "type": "PECF",
+  "questionVersion": "5.22"
+}

--- a/data/reliability/phi-4-mini-reasoning-run-303.json
+++ b/data/reliability/phi-4-mini-reasoning-run-303.json
@@ -1,0 +1,31 @@
+{
+  "model": "Phi-4-mini-reasoning",
+  "provider": "github",
+  "run": 303,
+  "answers": [
+    "A",
+    "A",
+    "A",
+    "A",
+    "A",
+    "B",
+    "B",
+    "A",
+    "B",
+    "B",
+    "A",
+    "B",
+    "A",
+    "B",
+    "A",
+    "B"
+  ],
+  "dimensions": [
+    4,
+    2,
+    1,
+    2
+  ],
+  "type": "PTDF",
+  "questionVersion": "5.22"
+}

--- a/data/results.json
+++ b/data/results.json
@@ -4289,10 +4289,123 @@
         true,
         false
       ],
-      "reliability": 0.9167,
-      "reliabilityRuns": 0,
-      "runs": 1,
-      "consistency": 92
+      "reliability": 0.8519,
+      "reliabilityRuns": [
+        {
+          "type": "PTCF",
+          "scores": [
+            3,
+            2,
+            4,
+            3
+          ]
+        },
+        {
+          "type": "PTCF",
+          "scores": [
+            3,
+            2,
+            2,
+            2
+          ]
+        },
+        {
+          "type": "PECF",
+          "scores": [
+            2,
+            0,
+            3,
+            2
+          ]
+        }
+      ],
+      "runs": 3,
+      "consistency": 85,
+      "questionVersion": "5.22"
+    },
+    {
+      "name": "Phi-4 Mini Reasoning",
+      "slug": "phi-4-mini-reasoning",
+      "url": "",
+      "type": "PTDF",
+      "nick": "The Strategist",
+      "testedAt": "2026-05-08T04:01:00.822Z",
+      "scores": [
+        2,
+        2,
+        1,
+        2
+      ],
+      "dimensions": [
+        {
+          "poles": [
+            "P",
+            "R"
+          ],
+          "score": 2,
+          "max": 4
+        },
+        {
+          "poles": [
+            "T",
+            "E"
+          ],
+          "score": 2,
+          "max": 4
+        },
+        {
+          "poles": [
+            "C",
+            "D"
+          ],
+          "score": 1,
+          "max": 4
+        },
+        {
+          "poles": [
+            "F",
+            "N"
+          ],
+          "score": 2,
+          "max": 4
+        }
+      ],
+      "model": "Phi-4-mini-reasoning",
+      "provider": "github",
+      "reliability": 0.7708,
+      "reliabilityRuns": [
+        {
+          "type": "PTDF",
+          "scores": [
+            2,
+            3,
+            1,
+            3
+          ]
+        },
+        {
+          "type": "PECF",
+          "scores": [
+            4,
+            1,
+            2,
+            2
+          ]
+        },
+        {
+          "type": "PTDF",
+          "scores": [
+            4,
+            2,
+            1,
+            2
+          ]
+        }
+      ],
+      "badge": "https://abti.kagura-agent.com/badge/PTDF",
+      "runs": 3,
+      "consistency": 77,
+      "questionVersion": "5.22"
     },
     {
       "model": "phi-4-reasoning",


### PR DESCRIPTION
## Summary

Add 3 reliability runs each for phi-4-mini-instruct (GitHub Models) and Phi-4-mini-reasoning (GitHub Models).

### phi-4-mini-instruct-github
- Runs 301-303
- Reliability: 85%, Consistency: 85%
- Question version: 5.22

### phi-4-mini-reasoning
- Runs 301-303
- Question version: 5.22
- Type results: PTDF (run 1 & 3), PECF (run 2) — shows some variation

### Process
- Used `run-reliability-github.js` with extended timeout (120s) for reasoning model
- Synced via `scripts/sync-reliability.js`
- All reliability data files and updated `results.json` included

Closes #847