### PR TITLE
docs: mark GitHub Models provider as retired (July 2026)

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Test any AI agent from the command line:
 npx @kagura-agent/abti test --provider openai --model gpt-4o --api-key sk-...
 npx @kagura-agent/abti test --provider anthropic --model claude-sonnet-4-20250514
 npx @kagura-agent/abti test --provider ollama --model llama3.1
-npx @kagura-agent/abti test --provider github --model gpt-4o
+npx @kagura-agent/abti test --provider github --model gpt-4o  # retired July 2026, use openrouter instead
 npx @kagura-agent/abti test --provider groq --model llama-3.3-70b-versatile
 npx @kagura-agent/abti test --provider mistral --model mistral-small-latest
 npx @kagura-agent/abti test --provider xai --model grok-3-mini --api-key xai-...

--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,7 @@ inputs:
     description: 'Path to file containing the agent system prompt (e.g. AGENTS.md)'
     required: false
   provider:
-    description: 'LLM provider: openai, anthropic, gemini, deepseek, github, groq, openrouter, mistral, xai, or cohere'
+    description: 'LLM provider: openai, anthropic, gemini, deepseek, github (retired), groq, openrouter, mistral, xai, or cohere'
     required: true
   model:
     description: 'Model name (e.g. gpt-4o, claude-sonnet-4-20250514)'

--- a/action/action.yml
+++ b/action/action.yml
@@ -10,7 +10,7 @@ inputs:
     description: 'Path to file containing the agent system prompt (e.g. AGENTS.md)'
     required: false
   provider:
-    description: 'LLM provider: openai|anthropic|gemini|deepseek|github|groq|openrouter|mistral|xai|cohere'
+    description: 'LLM provider: openai|anthropic|gemini|deepseek|github (retired)|groq|openrouter|mistral|xai|cohere'
     required: true
   model:
     description: 'Model name (e.g. gpt-4o, claude-sonnet-4-20250514)'


### PR DESCRIPTION
Closes #856

GitHub Models officially retired today (July 30, 2026). This PR updates documentation to reflect the retirement:

## Changes
- **action.yml** + **action/action.yml**: Added '(retired)' note to provider description
- **action/README.md**: Strikethrough section header, retirement notice with alternative suggestion, commented-out code example
- **README.md**: Inline comment on CLI example noting retirement and suggesting openrouter

## Notes
- The `github` provider code is **kept functional** (for anyone with cached tokens or private deployments using the same API shape)
- Only documentation is updated to prevent new users from hitting a dead service
- Recommends `openrouter` as the free-tier alternative