### PR TITLE
chore: deprecate GitHub Models provider (retired July 30, 2026)

### DIFF
--- a/action/README.md
+++ b/action/README.md
@@ -2,7 +2,7 @@
 
 Run an [ABTI personality test](https://abti.kagura-agent.com) on your AI agent directly in GitHub Actions.
 
-The action sends each scenario question to an LLM (OpenAI, Anthropic, Google Gemini, DeepSeek, GitHub Models, Groq, OpenRouter, Mistral, xAI, or Cohere), collects its choices, and reports the resulting ABTI type as a job summary, outputs, and optional PR comment.
+The action sends each scenario question to an LLM (OpenAI, Anthropic, Google Gemini, DeepSeek, Groq, OpenRouter, Mistral, xAI, or Cohere), collects its choices, and reports the resulting ABTI type as a job summary, outputs, and optional PR comment.
 
 ## Inputs
 
@@ -10,7 +10,7 @@ The action sends each scenario question to an LLM (OpenAI, Anthropic, Google Gem
 |-------|----------|---------|-------------|
 | `agent-prompt` | No | — | Agent system prompt string |
 | `agent-prompt-file` | No | — | Path to file containing system prompt (e.g. `AGENTS.md`) |
-| `provider` | **Yes** | — | `openai`, `anthropic`, `gemini`, `deepseek`, `github`, `groq`, `openrouter`, `mistral`, `xai`, or `cohere` |
+| `provider` | **Yes** | — | `openai`, `anthropic`, `gemini`, `deepseek`, `github` (retired), `groq`, `openrouter`, `mistral`, `xai`, or `cohere` |
 | `model` | **Yes** | — | Model name (e.g. `gpt-4o`, `claude-sonnet-4-20250514`) |
 | `api-key` | **Yes** | — | API key for the LLM provider |
 | `agent-name` | No | `<model> (<provider>)` | Display name for the agent in the registry |
@@ -52,8 +52,11 @@ The action sends each scenario question to an LLM (OpenAI, Anthropic, Google Gem
     api-key: ${{ secrets.GOOGLE_AI_API_KEY }}
 ```
 
-### Basic — test with GitHub Models
+### ~~GitHub Models~~ (retired July 2026)
 
+> GitHub Models has been retired. Use `--provider openrouter` for free-tier access, or another provider with your own API key.
+
+<!--
 ```yaml
 - uses: kagura-agent/abti@v1
   with:
@@ -61,6 +64,7 @@ The action sends each scenario question to an LLM (OpenAI, Anthropic, Google Gem
     model: gpt-4o
     api-key: ${{ secrets.GITHUB_TOKEN }}
 ```
+-->
 
 ### Basic — test with Groq
 
@@ -189,5 +193,5 @@ When drift is detected, the action:
 ## Requirements
 
 - Node.js 20+ (provided by GitHub Actions runners)
-- An API key for your chosen provider (OpenAI, Anthropic, Google AI, DeepSeek, GitHub, Groq, OpenRouter, Mistral, xAI, or Cohere) stored as a repository secret
+- An API key for your chosen provider (OpenAI, Anthropic, Google AI, DeepSeek, Groq, OpenRouter, Mistral, xAI, or Cohere) stored as a repository secret
 - For PR comments: `GITHUB_TOKEN` with `pull-requests: write` permission

--- a/cli/README.md
+++ b/cli/README.md
@@ -73,8 +73,6 @@ npx @kagura-agent/abti test --provider groq --model llama-3.3-70b-versatile --ap
 # Mistral
 npx @kagura-agent/abti test --provider mistral --model mistral-small-latest --api-key ...
 
-# GitHub Models (uses GITHUB_TOKEN)
-npx @kagura-agent/abti test --provider github --model gpt-4o
 ```
 
 ### List Subcommand
@@ -193,7 +191,7 @@ Output includes:
 | `--name <name>` | Agent name for registry |
 | `--url <url>` | Agent URL for registry |
 | `--model <model>` | Model name |
-| `--provider <provider>` | Provider: `openai`, `anthropic`, `gemini`, `deepseek`, `ollama`, `openrouter`, `groq`, `mistral`, `github`, `xai`, `cohere` (default: `openai`) |
+| `--provider <provider>` | Provider: `openai`, `anthropic`, `gemini`, `deepseek`, `ollama`, `openrouter`, `groq`, `mistral`, `github` (retired), `xai`, `cohere` (default: `openai`) |
 | `--api-key <key>` | API key (or set env var) |
 | `--submit` | Submit result to the ABTI registry (persisted server-side in `data/results.json`) |
 | `--runs <N>` | Run the test N times (1-10) and show consistency report |
@@ -220,7 +218,7 @@ Output includes:
 - `OPENROUTER_API_KEY` — for `--provider openrouter`
 - `GROQ_API_KEY` — for `--provider groq`
 - `MISTRAL_API_KEY` — for `--provider mistral`
-- `GITHUB_TOKEN` — for `--provider github`
+- `GITHUB_TOKEN` — for `--provider github` (retired July 2026)
 
 ### Examples
 

--- a/cli/bin/abti.js
+++ b/cli/bin/abti.js
@@ -399,14 +399,14 @@ function callLLM(prov, apiKey, mdl, systemPrompt, userMessage, baseUrl, maxToken
   if (prov === 'anthropic') return callAnthropic(apiKey, mdl, systemPrompt, userMessage, baseUrl, maxTokens);
   if (prov === 'gemini') return callGemini(apiKey, mdl, systemPrompt, userMessage, maxTokens);
   if (prov === 'deepseek') return callOpenAI(apiKey, mdl, systemPrompt, userMessage, 'https://api.deepseek.com', undefined, maxTokens);
-  if (prov === 'github') return callOpenAI(apiKey, mdl, systemPrompt, userMessage, baseUrl || 'https://models.github.ai/inference', undefined, maxTokens, '/chat/completions');
+  if (prov === 'github') throw new Error('GitHub Models retired on July 30, 2026. Use --provider openrouter for free-tier access, or --provider openai/anthropic/gemini with your own API key.');
   if (prov === 'groq') return callOpenAI(apiKey, mdl, systemPrompt, userMessage, baseUrl || 'https://api.groq.com/openai', undefined, maxTokens);
   if (prov === 'openrouter') return callOpenAI(apiKey, mdl, systemPrompt, userMessage, baseUrl || 'https://openrouter.ai/api/v1', undefined, maxTokens);
   if (prov === 'mistral') return callOpenAI(apiKey, mdl, systemPrompt, userMessage, baseUrl || 'https://api.mistral.ai/v1', undefined, maxTokens);
   if (prov === 'xai') return callOpenAI(apiKey, mdl, systemPrompt, userMessage, baseUrl || 'https://api.x.ai/v1', undefined, maxTokens);
   if (prov === 'cohere') return callOpenAI(apiKey, mdl, systemPrompt, userMessage, baseUrl || 'https://api.cohere.com/v2', undefined, maxTokens);
   if (prov === 'ollama') return callOpenAI(apiKey || 'ollama', mdl, systemPrompt, userMessage, 'http://localhost:11434', isReasoningModel(mdl) ? { think: false } : undefined, maxTokens);
-  throw new Error(`Unknown provider: ${prov}. Must be "openai", "anthropic", "gemini", "deepseek", "github", "groq", "openrouter", "mistral", "xai", "cohere", or "ollama".`);
+  throw new Error(`Unknown provider: ${prov}. Must be "openai", "anthropic", "gemini", "deepseek", "github" (retired), "groq", "openrouter", "mistral", "xai", "cohere", or "ollama".`);
 }
 
 function isReasoningModel(modelName) {
@@ -445,7 +445,7 @@ function parseAnswer(response) {
 function resolveApiKey(prov, explicit) {
   if (explicit) return explicit;
   if (prov === 'ollama') return 'ollama';
-  if (prov === 'github') return process.env.GITHUB_TOKEN || (() => { throw new Error('No API key provided. Use --api-key or set GITHUB_TOKEN'); })();
+  if (prov === 'github') throw new Error('GitHub Models retired on July 30, 2026. Use --provider openrouter for free-tier access, or --provider openai/anthropic/gemini with your own API key.');
   const envMap = { openai: 'OPENAI_API_KEY', anthropic: 'ANTHROPIC_API_KEY', gemini: 'GOOGLE_AI_API_KEY', deepseek: 'DEEPSEEK_API_KEY', groq: 'GROQ_API_KEY', openrouter: 'OPENROUTER_API_KEY', mistral: 'MISTRAL_API_KEY', xai: 'XAI_API_KEY', cohere: 'CO_API_KEY' };
   const envKey = envMap[prov];
   if (envKey && process.env[envKey]) return process.env[envKey];
@@ -839,7 +839,8 @@ async function runAll() {
     } else if (autoProvider === 'openrouter') {
       modelList = await fetchOpenRouterModels(apiKey);
     } else if (autoProvider === 'github') {
-      modelList = await fetchGitHubModels(apiKey);
+      console.error('  GitHub Models retired on July 30, 2026. Use --provider openrouter for free-tier access, or --provider openai/anthropic/gemini with your own API key.');
+      process.exit(1);
     } else if (autoProvider === 'gemini') {
       modelList = await fetchGeminiModels(apiKey);
     } else if (autoProvider === 'cohere') {


### PR DESCRIPTION
Closes #854

## What

GitHub Models (`models.github.ai`) has officially retired as of July 30, 2026. This PR:

1. Replaces the `github` provider implementation with a clear deprecation error message directing users to alternatives (OpenRouter free tier, or other providers with their own API keys)
2. Keeps `github` in the provider list for backwards compatibility but shows the deprecation message immediately
3. Removes `--provider github` from README examples and docs
4. Updates `abti list-models --provider github` to exit with clear error instead of connecting to dead API

## Impact
Users running `npx @kagura-agent/abti test --provider github` will now get a helpful deprecation message instead of cryptic connection failures.